### PR TITLE
Agent Bridge: multi-endpoint API, auto-approve policy, live console

### DIFF
--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -1,20 +1,30 @@
 //! Agent Bridge — a localhost HTTP endpoint that lets a local AI agent (Claude
-//! Code, Cursor, …) run commands through Faro's already-authenticated SSH
-//! sessions, without installing anything on the remote server or handing the
-//! agent any credentials.
+//! Code, Cursor, …) operate on the user's servers through Faro's already-
+//! authenticated sessions, without installing anything on the remote server or
+//! handing the agent any credentials.
+//!
+//! Capabilities exposed to the agent (REST + MCP):
+//!   * `exec` — run a shell command (SSH only),
+//!   * `list_dir` / `read_file` / `search` — inspect the remote filesystem,
+//!   * `download` / `upload` — move files through Faro's transfer engine,
+//!   * `server_info` / `list_sessions` — context about what's connected.
 //!
 //! Security model:
 //!   * bound to 127.0.0.1 only,
 //!   * guarded by a per-launch bearer token,
 //!   * every session must be explicitly opted in ("Allow agent access"),
-//!   * every `exec` requires interactive approval in the Faro UI — mirroring
-//!     the host-key prompt flow (emit event → await oneshot → resolve command).
+//!   * each side-effecting request is approved interactively in the Faro UI
+//!     (emit event → await oneshot → resolve), UNLESS the user has relaxed the
+//!     approval policy (allow-all, auto-approve read-only ops, or auto-approve
+//!     read-only shell commands). The policy + the per-profile allow-list are
+//!     persisted to `bridge.json` so they survive restarts/reconnects.
 
 use crate::AppState;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
@@ -23,10 +33,43 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{oneshot, Mutex};
 use uuid::Uuid;
 
+use crate::remotefs::FileKind;
+use crate::session::{ExecStream, Session};
+use crate::transfer::OverwritePolicy;
+
 const APPROVAL_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_ACTIVITY: usize = 200;
 const MAX_BODY: usize = 1024 * 1024; // 1 MiB request bodies
 const MAX_HEADERS: usize = 64 * 1024;
+const MAX_READ_FILE: usize = 256 * 1024; // cap faro_read_file output at 256 KiB
+const MAX_EXEC_BYTES: usize = 512 * 1024; // cap exec output at 512 KiB
+const EXEC_TIMEOUT: Duration = Duration::from_secs(60); // kill a hung/streaming command
+const SEARCH_MAX_RESULTS: usize = 200;
+const SEARCH_MAX_DEPTH: usize = 6;
+const SEARCH_MAX_DIRS: usize = 4000; // hard ceiling on directories visited
+
+/// How much approval friction the user has opted to remove. Every field
+/// defaults to `false` — i.e. the original "approve everything" behaviour.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ApprovalPolicy {
+    /// Master switch — approve every agent request on enabled sessions.
+    pub allow_all: bool,
+    /// Auto-approve read-only operations (list_dir, read_file, search). Note:
+    /// download/upload are treated as writes (they touch a local/remote disk).
+    pub auto_read: bool,
+    /// Auto-approve shell commands that look read-only (best-effort heuristic).
+    pub auto_safe_exec: bool,
+}
+
+/// On-disk shape of `bridge.json`. Session ids are per-connect UUIDs, so the
+/// allow-list is keyed by *profile* id and re-applied when a session connects.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct PersistedConfig {
+    enabled_profiles: Vec<String>,
+    policy: ApprovalPolicy,
+}
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -36,6 +79,7 @@ pub struct BridgeStatus {
     pub port: Option<u16>,
     pub token: Option<String>,
     pub enabled_sessions: Vec<String>,
+    pub policy: ApprovalPolicy,
 }
 
 #[derive(Clone, Serialize)]
@@ -43,7 +87,7 @@ pub struct BridgeStatus {
 pub struct ActivityEntry {
     pub id: String,
     pub session_id: String,
-    pub kind: String, // "exec" | "denied" | "error"
+    pub kind: String, // "exec" | "read" | "download" | "upload" | "search" | "denied" | "error"
     pub detail: String,
     pub ok: bool,
     pub at: i64, // unix millis
@@ -55,6 +99,10 @@ pub struct ApprovalRequest {
     pub request_id: String,
     pub session_id: String,
     pub session_name: String,
+    /// Operation kind ("exec", "read", "download", "upload", "search") so the
+    /// UI can phrase the prompt appropriately.
+    pub kind: String,
+    /// Human-readable summary of what the agent wants to do.
     pub command: String,
 }
 
@@ -63,6 +111,14 @@ pub struct ApprovalRequest {
 pub enum ApprovalDecision {
     Approve,
     Deny,
+}
+
+/// Risk class of an operation, used to decide auto-approval.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OpClass {
+    Read,
+    Write,
+    Exec,
 }
 
 struct Running {
@@ -74,9 +130,14 @@ struct Running {
 #[derive(Default)]
 pub struct BridgeState {
     running: Mutex<Option<Running>>,
+    /// Runtime allow-list, keyed by session id (per-connect UUID).
     enabled: Mutex<HashSet<String>>,
+    /// Persistent allow-list, keyed by profile id; re-applied on connect.
+    enabled_profiles: Mutex<HashSet<String>>,
+    policy: Mutex<ApprovalPolicy>,
     approvals: Mutex<HashMap<String, oneshot::Sender<ApprovalDecision>>>,
     activity: Mutex<Vec<ActivityEntry>>,
+    config_path: Option<PathBuf>,
 }
 
 fn now_millis() -> i64 {
@@ -86,14 +147,117 @@ fn now_millis() -> i64 {
         .unwrap_or(0)
 }
 
+fn activity(kind: &str, session_id: &str, detail: String, ok: bool) -> ActivityEntry {
+    ActivityEntry {
+        id: Uuid::new_v4().to_string(),
+        session_id: session_id.to_string(),
+        kind: kind.to_string(),
+        detail,
+        ok,
+        at: now_millis(),
+    }
+}
+
+/// Best-effort classifier: is this shell command read-only? Conservative by
+/// design — anything with shell chaining/redirection, a known command-runner
+/// (which could exec an arbitrary mutating command via args alone), or a binary
+/// not on the curated safe list, is treated as *not* read-only (so it still
+/// needs approval unless allow-all is on). This is a heuristic, never a security
+/// boundary — the binary+args space is too large to fully reason about, so we
+/// only auto-approve commands we're confident neither mutate state nor launch
+/// another program. Anything else falls back to interactive approval.
+fn is_read_only_command(cmd: &str) -> bool {
+    let trimmed = cmd.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Reject anything that could chain/redirect/substitute into a mutating command.
+    const DANGEROUS: &[&str] = &[
+        ";", "&&", "||", "|", ">", "<", "`", "$(", "${", "&", "\n", "\r",
+    ];
+    for d in DANGEROUS {
+        if trimmed.contains(d) {
+            return false;
+        }
+    }
+    let first = trimmed.split_whitespace().next().unwrap_or("");
+    let bin = first.rsplit('/').next().unwrap_or(first);
+    // Binaries that run another program or mutate system/network state using
+    // only flags/args (no shell metacharacters) — e.g. `env CMD`, `ip netns
+    // exec <ns> CMD`, `date -s`, `dmesg -C`. These can never be auto-approved.
+    const NEVER_SAFE: &[&str] = &[
+        "env", "sudo", "doas", "su", "xargs", "watch", "timeout", "nohup",
+        "nice", "ionice", "time", "ssh", "scp", "rsync", "sh", "bash", "zsh",
+        "dash", "ksh", "fish", "perl", "python", "python3", "ruby", "node",
+        "php", "lua", "eval", "exec", "find", "ip", "ifconfig", "iptables",
+        "nft", "date", "hostname", "hostnamectl", "dmesg", "ss", "systemctl",
+        "service", "kill", "pkill", "killall", "mount", "umount", "modprobe",
+        "sysctl", "tee", "dd", "crontab",
+    ];
+    if NEVER_SAFE.contains(&bin) {
+        return false;
+    }
+    // Curated binaries that neither mutate state nor launch other programs with
+    // their normal invocations. Deliberately excludes find/sed/awk/sort/uniq
+    // (write/exec/-i/-o flags) and anything in NEVER_SAFE.
+    const READ_ONLY: &[&str] = &[
+        "ls", "cat", "pwd", "whoami", "id", "uname", "uptime", "df", "du",
+        "free", "ps", "stat", "head", "tail", "wc", "file", "echo", "printenv",
+        "which", "type", "tree", "readlink", "realpath", "dirname", "basename",
+        "lsblk", "lscpu", "netstat", "cut", "grep", "egrep", "fgrep", "md5sum",
+        "sha1sum", "sha256sum", "groups", "getent", "lsof", "nproc", "vmstat",
+        "cal", "arch", "lsusb", "lspci", "uptime",
+    ];
+    READ_ONLY.contains(&bin)
+}
+
 impl BridgeState {
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Load (or initialise) bridge config from the app data dir. Mirrors
+    /// `ProfileStore::load_or_create`. Falls back to defaults on any error.
+    pub fn load_or_create(app: &AppHandle) -> Result<Self> {
+        let dir = app
+            .path()
+            .app_data_dir()
+            .context("resolving app_data_dir")?;
+        std::fs::create_dir_all(&dir).ok();
+        let path = dir.join("bridge.json");
+        let cfg: PersistedConfig = if path.exists() {
+            std::fs::read(&path)
+                .ok()
+                .and_then(|b| serde_json::from_slice(&b).ok())
+                .unwrap_or_default()
+        } else {
+            PersistedConfig::default()
+        };
+        Ok(Self {
+            enabled_profiles: Mutex::new(cfg.enabled_profiles.into_iter().collect()),
+            policy: Mutex::new(cfg.policy),
+            config_path: Some(path),
+            ..Default::default()
+        })
+    }
+
+    async fn persist(&self) {
+        let Some(path) = self.config_path.as_ref() else {
+            return;
+        };
+        let cfg = PersistedConfig {
+            enabled_profiles: self.enabled_profiles.lock().await.iter().cloned().collect(),
+            policy: *self.policy.lock().await,
+        };
+        if let Ok(bytes) = serde_json::to_vec_pretty(&cfg) {
+            let _ = std::fs::write(path, bytes);
+        }
+    }
+
     pub async fn status(&self) -> BridgeStatus {
         let running = self.running.lock().await;
         let enabled_sessions = self.enabled.lock().await.iter().cloned().collect();
+        let policy = *self.policy.lock().await;
         match running.as_ref() {
             Some(r) => BridgeStatus {
                 running: true,
@@ -101,6 +265,7 @@ impl BridgeState {
                 port: Some(r.port),
                 token: Some(r.token.clone()),
                 enabled_sessions,
+                policy,
             },
             None => BridgeStatus {
                 running: false,
@@ -108,6 +273,7 @@ impl BridgeState {
                 port: None,
                 token: None,
                 enabled_sessions,
+                policy,
             },
         }
     }
@@ -144,17 +310,59 @@ impl BridgeState {
         }
     }
 
-    pub async fn set_access(&self, session_id: &str, enabled: bool) {
-        let mut set = self.enabled.lock().await;
-        if enabled {
-            set.insert(session_id.to_string());
-        } else {
-            set.remove(session_id);
+    /// Grant/revoke agent access for a session. Mirrors the grant onto the
+    /// persistent, profile-keyed allow-list so it survives reconnects.
+    pub async fn set_access(&self, app: &AppHandle, session_id: &str, enabled: bool) {
+        {
+            let mut set = self.enabled.lock().await;
+            if enabled {
+                set.insert(session_id.to_string());
+            } else {
+                set.remove(session_id);
+            }
         }
+        if let Some(sess) = app.state::<AppState>().sessions.get(session_id).await {
+            let profile_id = sess.profile().id.clone();
+            let mut profs = self.enabled_profiles.lock().await;
+            if enabled {
+                profs.insert(profile_id);
+            } else {
+                profs.remove(&profile_id);
+            }
+        }
+        self.persist().await;
+    }
+
+    /// Called when a session connects: auto-enable it if its profile was
+    /// previously granted access.
+    pub async fn on_session_connected(&self, session_id: &str, profile_id: &str) {
+        if self.enabled_profiles.lock().await.contains(profile_id) {
+            self.enabled.lock().await.insert(session_id.to_string());
+        }
+    }
+
+    pub async fn set_policy(&self, policy: ApprovalPolicy) {
+        *self.policy.lock().await = policy;
+        self.persist().await;
     }
 
     async fn is_enabled(&self, session_id: &str) -> bool {
         self.enabled.lock().await.contains(session_id)
+    }
+
+    /// Decide whether the current policy auto-approves an operation.
+    async fn auto_approved(&self, class: OpClass, exec_cmd: Option<&str>) -> bool {
+        let p = *self.policy.lock().await;
+        if p.allow_all {
+            return true;
+        }
+        match class {
+            OpClass::Read => p.auto_read,
+            OpClass::Write => false,
+            OpClass::Exec => {
+                p.auto_safe_exec && exec_cmd.map(is_read_only_command).unwrap_or(false)
+            }
+        }
     }
 
     pub async fn resolve_approval(
@@ -180,7 +388,8 @@ impl BridgeState {
         app: &AppHandle,
         session_id: &str,
         session_name: &str,
-        command: &str,
+        kind: &str,
+        summary: &str,
     ) -> bool {
         let request_id = Uuid::new_v4().to_string();
         let (tx, rx) = oneshot::channel();
@@ -191,7 +400,8 @@ impl BridgeState {
                 request_id: request_id.clone(),
                 session_id: session_id.to_string(),
                 session_name: session_name.to_string(),
-                command: command.to_string(),
+                kind: kind.to_string(),
+                command: summary.to_string(),
             },
         );
         let approved = matches!(
@@ -217,6 +427,38 @@ impl BridgeState {
 
     pub async fn recent_activity(&self) -> Vec<ActivityEntry> {
         self.activity.lock().await.clone()
+    }
+}
+
+/// Opt-in check → policy/approval gate. On success the caller proceeds; on
+/// failure it returns the contained `(status, json)` response. Denials are
+/// logged here so callers only log their own success/error paths.
+async fn gate(
+    app: &AppHandle,
+    state: &Arc<BridgeState>,
+    session_id: &str,
+    session_name: &str,
+    class: OpClass,
+    kind: &str,
+    summary: &str,
+    exec_cmd: Option<&str>,
+) -> Result<(), (u16, Value)> {
+    if !state.is_enabled(session_id).await {
+        return Err((403, json!({"error": "session has not granted agent access"})));
+    }
+    if state.auto_approved(class, exec_cmd).await {
+        return Ok(());
+    }
+    if state
+        .request_approval(app, session_id, session_name, kind, summary)
+        .await
+    {
+        Ok(())
+    } else {
+        state
+            .log(app, activity("denied", session_id, summary.to_string(), false))
+            .await;
+        Err((403, json!({"error": "request was denied or timed out"})))
     }
 }
 
@@ -380,6 +622,13 @@ async fn route(app: &AppHandle, state: &Arc<BridgeState>, req: &Request) -> (u16
         ),
         ("GET", "/sessions") => handle_sessions(app, state).await,
         ("POST", "/exec") => handle_exec(app, state, &req.body).await,
+        ("POST", "/list") => handle_list(app, state, &req.body).await,
+        ("POST", "/read") => handle_read(app, state, &req.body).await,
+        ("POST", "/download") => handle_download(app, state, &req.body).await,
+        ("POST", "/upload") => handle_upload(app, state, &req.body).await,
+        ("POST", "/search") => handle_search(app, state, &req.body).await,
+        ("POST", "/info") => handle_info(app, state, &req.body).await,
+        ("POST", "/transfer") => handle_transfer_status(app, &req.body).await,
         _ => (404, json!({"error": "not found"})),
     }
 }
@@ -396,45 +645,148 @@ async fn handle_sessions(app: &AppHandle, state: &Arc<BridgeState>) -> (u16, Val
                 "name": p.name,
                 "host": p.host,
                 "protocol": sess.protocol(),
-                "canExec": matches!(&*sess, crate::session::Session::Ssh(_)),
+                "canExec": matches!(&*sess, Session::Ssh(_)),
             }));
         }
     }
     (200, json!({ "sessions": out }))
 }
 
+fn body_str(v: &Value, key: &str) -> String {
+    v.get(key).and_then(|x| x.as_str()).unwrap_or("").to_string()
+}
+
+fn parse_body(body: &[u8]) -> Result<Value, (u16, Value)> {
+    serde_json::from_slice(body).map_err(|_| (400, json!({"error": "invalid JSON body"})))
+}
+
 async fn handle_exec(app: &AppHandle, state: &Arc<BridgeState>, body: &[u8]) -> (u16, Value) {
-    let parsed: Value = match serde_json::from_slice(body) {
+    let parsed = match parse_body(body) {
         Ok(v) => v,
-        Err(_) => return (400, json!({"error": "invalid JSON body"})),
+        Err(e) => return e,
     };
-    let session_id = parsed
-        .get("sessionId")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let command = parsed
-        .get("command")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
+    let session_id = body_str(&parsed, "sessionId");
+    let command = body_str(&parsed, "command");
     if session_id.is_empty() || command.is_empty() {
         return (400, json!({"error": "sessionId and command are required"}));
     }
     exec_on(app, state, &session_id, &command).await
 }
 
-/// Shared core for both the REST `/exec` route and the MCP `faro_exec` tool:
-/// opt-in check → approval round-trip → run → audit.
+async fn handle_list(app: &AppHandle, state: &Arc<BridgeState>, body: &[u8]) -> (u16, Value) {
+    let parsed = match parse_body(body) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let session_id = body_str(&parsed, "sessionId");
+    if session_id.is_empty() {
+        return (400, json!({"error": "sessionId is required"}));
+    }
+    let path = match body_str(&parsed, "path") {
+        p if p.is_empty() => ".".to_string(),
+        p => p,
+    };
+    op_list_dir(app, state, &session_id, &path).await
+}
+
+async fn handle_read(app: &AppHandle, state: &Arc<BridgeState>, body: &[u8]) -> (u16, Value) {
+    let parsed = match parse_body(body) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let session_id = body_str(&parsed, "sessionId");
+    let path = body_str(&parsed, "path");
+    if session_id.is_empty() || path.is_empty() {
+        return (400, json!({"error": "sessionId and path are required"}));
+    }
+    op_read_file(app, state, &session_id, &path).await
+}
+
+async fn handle_download(app: &AppHandle, state: &Arc<BridgeState>, body: &[u8]) -> (u16, Value) {
+    let parsed = match parse_body(body) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let session_id = body_str(&parsed, "sessionId");
+    let path = body_str(&parsed, "path");
+    if session_id.is_empty() || path.is_empty() {
+        return (400, json!({"error": "sessionId and path are required"}));
+    }
+    let local_dir = parsed
+        .get("localDir")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    op_download(app, state, &session_id, &path, local_dir).await
+}
+
+async fn handle_upload(app: &AppHandle, state: &Arc<BridgeState>, body: &[u8]) -> (u16, Value) {
+    let parsed = match parse_body(body) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let session_id = body_str(&parsed, "sessionId");
+    let local_path = body_str(&parsed, "localPath");
+    let remote_dir = body_str(&parsed, "remoteDir");
+    if session_id.is_empty() || local_path.is_empty() || remote_dir.is_empty() {
+        return (
+            400,
+            json!({"error": "sessionId, localPath and remoteDir are required"}),
+        );
+    }
+    op_upload(app, state, &session_id, &local_path, &remote_dir).await
+}
+
+async fn handle_search(app: &AppHandle, state: &Arc<BridgeState>, body: &[u8]) -> (u16, Value) {
+    let parsed = match parse_body(body) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let session_id = body_str(&parsed, "sessionId");
+    let query = body_str(&parsed, "query");
+    if session_id.is_empty() || query.is_empty() {
+        return (400, json!({"error": "sessionId and query are required"}));
+    }
+    let root = match body_str(&parsed, "path") {
+        p if p.is_empty() => ".".to_string(),
+        p => p,
+    };
+    op_search(app, state, &session_id, &root, &query).await
+}
+
+async fn handle_info(app: &AppHandle, state: &Arc<BridgeState>, body: &[u8]) -> (u16, Value) {
+    let parsed = match parse_body(body) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let session_id = body_str(&parsed, "sessionId");
+    if session_id.is_empty() {
+        return (400, json!({"error": "sessionId is required"}));
+    }
+    op_server_info(app, state, &session_id).await
+}
+
+async fn handle_transfer_status(app: &AppHandle, body: &[u8]) -> (u16, Value) {
+    let parsed = match parse_body(body) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let transfer_id = body_str(&parsed, "transferId");
+    if transfer_id.is_empty() {
+        return (400, json!({"error": "transferId is required"}));
+    }
+    op_transfer_status(app, &transfer_id).await
+}
+
+// ---- Operation cores (shared by REST routes and MCP tools) ----
+
+/// Run a non-interactive shell command (SSH only).
 async fn exec_on(
     app: &AppHandle,
     state: &Arc<BridgeState>,
     session_id: &str,
     command: &str,
 ) -> (u16, Value) {
-    if !state.is_enabled(session_id).await {
-        return (403, json!({"error": "session has not granted agent access"}));
-    }
     let manager = app.state::<AppState>().sessions.clone();
     let Some(ssh) = manager.get_ssh(session_id).await else {
         return (
@@ -444,37 +796,60 @@ async fn exec_on(
     };
     let session_name = ssh.profile.name.clone();
 
-    if !state
-        .request_approval(app, session_id, &session_name, command)
-        .await
+    if let Err(resp) = gate(
+        app,
+        state,
+        session_id,
+        &session_name,
+        OpClass::Exec,
+        "exec",
+        command,
+        Some(command),
+    )
+    .await
     {
-        state
-            .log(
-                app,
-                ActivityEntry {
-                    id: Uuid::new_v4().to_string(),
-                    session_id: session_id.to_string(),
-                    kind: "denied".into(),
-                    detail: command.to_string(),
-                    ok: false,
-                    at: now_millis(),
-                },
-            )
-            .await;
-        return (403, json!({"error": "command was denied or timed out"}));
+        return resp;
     }
 
-    match ssh.exec(command).await {
+    // Tag this run so streamed output + the final audit line correlate in the
+    // live agent console.
+    let op_id = Uuid::new_v4().to_string();
+    let _ = app.emit(
+        "agent://exec-start",
+        json!({
+            "opId": op_id,
+            "sessionId": session_id,
+            "sessionName": session_name,
+            "command": command,
+        }),
+    );
+    let stream = ExecStream {
+        app: app.clone(),
+        op_id: op_id.clone(),
+    };
+
+    match ssh
+        .exec_bounded(command, MAX_EXEC_BYTES, EXEC_TIMEOUT, Some(&stream))
+        .await
+    {
         Ok(out) => {
+            let ok = !out.timed_out && out.exit_code.unwrap_or(0) == 0;
+            let mut detail = command.to_string();
+            if out.truncated {
+                detail.push_str("  [output truncated]");
+            }
+            if out.timed_out {
+                detail.push_str("  [timed out]");
+            }
             state
                 .log(
                     app,
                     ActivityEntry {
-                        id: Uuid::new_v4().to_string(),
+                        id: op_id,
                         session_id: session_id.to_string(),
                         kind: "exec".into(),
-                        detail: command.to_string(),
-                        ok: out.exit_code.unwrap_or(0) == 0,
+                        detail,
+                        ok,
                         at: now_millis(),
                     },
                 )
@@ -485,15 +860,20 @@ async fn exec_on(
                     "stdout": out.stdout,
                     "stderr": out.stderr,
                     "exitCode": out.exit_code,
+                    "truncated": out.truncated,
+                    "timedOut": out.timed_out,
                 }),
             )
         }
         Err(e) => {
+            // Reuse op_id so the live console finalizes the same "running" entry
+            // emitted by agent://exec-start (instead of leaving a stuck spinner
+            // and appending a duplicate row).
             state
                 .log(
                     app,
                     ActivityEntry {
-                        id: Uuid::new_v4().to_string(),
+                        id: op_id,
                         session_id: session_id.to_string(),
                         kind: "error".into(),
                         detail: format!("{command} — {e}"),
@@ -507,12 +887,441 @@ async fn exec_on(
     }
 }
 
+async fn op_list_dir(
+    app: &AppHandle,
+    state: &Arc<BridgeState>,
+    session_id: &str,
+    path: &str,
+) -> (u16, Value) {
+    let manager = app.state::<AppState>().sessions.clone();
+    let Some(sess) = manager.get(session_id).await else {
+        return (400, json!({"error": "session not found"}));
+    };
+    let name = sess.profile().name.clone();
+    if let Err(resp) = gate(
+        app,
+        state,
+        session_id,
+        &name,
+        OpClass::Read,
+        "read",
+        &format!("list {path}"),
+        None,
+    )
+    .await
+    {
+        return resp;
+    }
+    let fs = crate::commands::fs_for_session(&sess);
+    match fs.list_dir(path).await {
+        Ok(entries) => {
+            state
+                .log(
+                    app,
+                    activity(
+                        "read",
+                        session_id,
+                        format!("list {path} ({} items)", entries.len()),
+                        true,
+                    ),
+                )
+                .await;
+            (200, json!({ "entries": entries }))
+        }
+        Err(e) => {
+            state
+                .log(
+                    app,
+                    activity("error", session_id, format!("list {path} — {e}"), false),
+                )
+                .await;
+            (500, json!({"error": e.to_string()}))
+        }
+    }
+}
+
+async fn op_read_file(
+    app: &AppHandle,
+    state: &Arc<BridgeState>,
+    session_id: &str,
+    path: &str,
+) -> (u16, Value) {
+    let manager = app.state::<AppState>().sessions.clone();
+    let Some(ssh) = manager.get_ssh(session_id).await else {
+        return (
+            400,
+            json!({"error": "read_file currently supports SSH/SFTP sessions — use download for other protocols"}),
+        );
+    };
+    let name = ssh.profile.name.clone();
+    if let Err(resp) = gate(
+        app,
+        state,
+        session_id,
+        &name,
+        OpClass::Read,
+        "read",
+        &format!("read {path}"),
+        None,
+    )
+    .await
+    {
+        return resp;
+    }
+
+    let sftp_cell = match ssh.ensure_sftp().await {
+        Ok(c) => c,
+        Err(e) => {
+            state
+                .log(
+                    app,
+                    activity("error", session_id, format!("read {path} — {e}"), false),
+                )
+                .await;
+            return (500, json!({"error": e.to_string()}));
+        }
+    };
+    // Open under the lock, then read without holding it (the file handle is
+    // independent of the SFTP guard — see transfer.rs).
+    let mut file = {
+        let sftp = sftp_cell.lock().await;
+        match sftp.open(path).await {
+            Ok(f) => f,
+            Err(e) => {
+                state
+                    .log(
+                        app,
+                        activity("error", session_id, format!("read {path} — {e}"), false),
+                    )
+                    .await;
+                return (500, json!({"error": format!("open {path}: {e}")}));
+            }
+        }
+    };
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut chunk = vec![0u8; 64 * 1024];
+    let mut truncated = false;
+    loop {
+        let n = match file.read(&mut chunk).await {
+            Ok(n) => n,
+            Err(e) => {
+                state
+                    .log(
+                        app,
+                        activity("error", session_id, format!("read {path} — {e}"), false),
+                    )
+                    .await;
+                return (500, json!({"error": e.to_string()}));
+            }
+        };
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.len() >= MAX_READ_FILE {
+            buf.truncate(MAX_READ_FILE);
+            truncated = true;
+            break;
+        }
+    }
+
+    let bytes = buf.len();
+    let content = String::from_utf8_lossy(&buf).to_string();
+    state
+        .log(
+            app,
+            activity("read", session_id, format!("read {path} ({bytes} bytes)"), true),
+        )
+        .await;
+    (
+        200,
+        json!({ "content": content, "bytes": bytes, "truncated": truncated }),
+    )
+}
+
+fn default_download_dir(app: &AppHandle) -> String {
+    app.path()
+        .download_dir()
+        .or_else(|_| app.path().app_data_dir())
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| ".".to_string())
+}
+
+async fn op_download(
+    app: &AppHandle,
+    state: &Arc<BridgeState>,
+    session_id: &str,
+    remote_path: &str,
+    local_dir: Option<String>,
+) -> (u16, Value) {
+    let manager = app.state::<AppState>().sessions.clone();
+    let Some(sess) = manager.get(session_id).await else {
+        return (400, json!({"error": "session not found"}));
+    };
+    let name = sess.profile().name.clone();
+    let local_dir = local_dir.unwrap_or_else(|| default_download_dir(app));
+    // Download is a *local write* (to an agent-supplied directory), so it's
+    // classed Write — only auto-approved under allow-all, never under auto-read.
+    if let Err(resp) = gate(
+        app,
+        state,
+        session_id,
+        &name,
+        OpClass::Write,
+        "download",
+        &format!("download {remote_path} → {local_dir}"),
+        None,
+    )
+    .await
+    {
+        return resp;
+    }
+    let transfers = app.state::<AppState>().transfers.clone();
+    match transfers
+        .start_download(
+            sess.clone(),
+            remote_path.to_string(),
+            local_dir.clone(),
+            OverwritePolicy::Rename,
+            app.clone(),
+        )
+        .await
+    {
+        Ok(id) => {
+            state
+                .log(
+                    app,
+                    activity(
+                        "download",
+                        session_id,
+                        format!("download {remote_path} → {local_dir}"),
+                        true,
+                    ),
+                )
+                .await;
+            (
+                200,
+                json!({ "transferId": id, "localDir": local_dir, "status": "started" }),
+            )
+        }
+        Err(e) => {
+            state
+                .log(
+                    app,
+                    activity(
+                        "error",
+                        session_id,
+                        format!("download {remote_path} — {e}"),
+                        false,
+                    ),
+                )
+                .await;
+            (500, json!({"error": e.to_string()}))
+        }
+    }
+}
+
+async fn op_upload(
+    app: &AppHandle,
+    state: &Arc<BridgeState>,
+    session_id: &str,
+    local_path: &str,
+    remote_dir: &str,
+) -> (u16, Value) {
+    let manager = app.state::<AppState>().sessions.clone();
+    let Some(sess) = manager.get(session_id).await else {
+        return (400, json!({"error": "session not found"}));
+    };
+    let name = sess.profile().name.clone();
+    if let Err(resp) = gate(
+        app,
+        state,
+        session_id,
+        &name,
+        OpClass::Write,
+        "upload",
+        &format!("upload {local_path} → {remote_dir}"),
+        None,
+    )
+    .await
+    {
+        return resp;
+    }
+    let transfers = app.state::<AppState>().transfers.clone();
+    match transfers
+        .start_upload(
+            sess.clone(),
+            local_path.to_string(),
+            remote_dir.to_string(),
+            OverwritePolicy::Rename,
+            app.clone(),
+        )
+        .await
+    {
+        Ok(id) => {
+            state
+                .log(
+                    app,
+                    activity(
+                        "upload",
+                        session_id,
+                        format!("upload {local_path} → {remote_dir}"),
+                        true,
+                    ),
+                )
+                .await;
+            (200, json!({ "transferId": id, "status": "started" }))
+        }
+        Err(e) => {
+            state
+                .log(
+                    app,
+                    activity(
+                        "error",
+                        session_id,
+                        format!("upload {local_path} — {e}"),
+                        false,
+                    ),
+                )
+                .await;
+            (500, json!({"error": e.to_string()}))
+        }
+    }
+}
+
+async fn op_search(
+    app: &AppHandle,
+    state: &Arc<BridgeState>,
+    session_id: &str,
+    root: &str,
+    query: &str,
+) -> (u16, Value) {
+    let manager = app.state::<AppState>().sessions.clone();
+    let Some(sess) = manager.get(session_id).await else {
+        return (400, json!({"error": "session not found"}));
+    };
+    let name = sess.profile().name.clone();
+    if let Err(resp) = gate(
+        app,
+        state,
+        session_id,
+        &name,
+        OpClass::Read,
+        "search",
+        &format!("search \"{query}\" in {root}"),
+        None,
+    )
+    .await
+    {
+        return resp;
+    }
+
+    let fs = crate::commands::fs_for_session(&sess);
+    let needle = query.to_lowercase();
+    let mut hits: Vec<Value> = Vec::new();
+    let mut stack: Vec<(String, usize)> = vec![(root.to_string(), 0)];
+    let mut visited = 0usize;
+    while let Some((dir, depth)) = stack.pop() {
+        if hits.len() >= SEARCH_MAX_RESULTS || visited >= SEARCH_MAX_DIRS {
+            break;
+        }
+        visited += 1;
+        let entries = match fs.list_dir(&dir).await {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries {
+            if entry.name.to_lowercase().contains(&needle) {
+                hits.push(json!({
+                    "name": entry.name,
+                    "path": entry.path,
+                    "kind": entry.kind,
+                    "size": entry.size,
+                }));
+                if hits.len() >= SEARCH_MAX_RESULTS {
+                    break;
+                }
+            }
+            if matches!(entry.kind, FileKind::Directory) && depth < SEARCH_MAX_DEPTH {
+                stack.push((entry.path.clone(), depth + 1));
+            }
+        }
+    }
+    let truncated = hits.len() >= SEARCH_MAX_RESULTS || visited >= SEARCH_MAX_DIRS;
+    state
+        .log(
+            app,
+            activity(
+                "search",
+                session_id,
+                format!("search \"{query}\" in {root} ({} hits)", hits.len()),
+                true,
+            ),
+        )
+        .await;
+    (200, json!({ "matches": hits, "truncated": truncated }))
+}
+
+/// Status of a transfer the agent previously started. No gate — the agent owns
+/// the (random) transfer id, and this is local metadata about its own action.
+async fn op_transfer_status(app: &AppHandle, transfer_id: &str) -> (u16, Value) {
+    let transfers = app.state::<AppState>().transfers.clone();
+    match transfers.snapshot(transfer_id).await {
+        Some(t) => (
+            200,
+            json!({
+                "transferId": t.id,
+                "kind": t.kind,
+                "status": t.status,
+                "source": t.source,
+                "destination": t.destination,
+                "size": t.size,
+                "transferred": t.transferred,
+                "error": t.error,
+            }),
+        ),
+        None => (404, json!({"error": "no transfer with that id (it may have been cleared)"})),
+    }
+}
+
+/// Context about a session — Faro-local metadata only, so no remote round-trip
+/// and no interactive approval. Still gated on the per-session opt-in: we must
+/// not leak host/username/port for sessions the user hasn't granted access to.
+async fn op_server_info(
+    app: &AppHandle,
+    state: &Arc<BridgeState>,
+    session_id: &str,
+) -> (u16, Value) {
+    if !state.is_enabled(session_id).await {
+        return (403, json!({"error": "session has not granted agent access"}));
+    }
+    let manager = app.state::<AppState>().sessions.clone();
+    let Some(sess) = manager.get(session_id).await else {
+        return (400, json!({"error": "session not found"}));
+    };
+    let p = sess.profile();
+    (
+        200,
+        json!({
+            "id": session_id,
+            "name": p.name,
+            "protocol": sess.protocol(),
+            "host": p.host,
+            "port": p.port,
+            "username": p.username,
+            "canExec": matches!(&*sess, Session::Ssh(_)),
+            "defaultRemotePath": p.default_remote_path,
+        }),
+    )
+}
+
 // ---- MCP (Model Context Protocol) over Streamable HTTP ----
 //
 // One stateless JSON-RPC endpoint. Claude Code connects with:
 //   claude mcp add --transport http faro http://127.0.0.1:<port>/mcp \
 //     --header "Authorization: Bearer <token>"
-// and auto-discovers the `faro_list_sessions` and `faro_exec` tools.
+// and auto-discovers the faro_* tools below.
 
 async fn handle_mcp(
     app: &AppHandle,
@@ -564,23 +1373,115 @@ fn mcp_initialize(params: &Value) -> Value {
 }
 
 fn mcp_tools_list() -> Value {
+    let session_prop = json!({
+        "type": "string",
+        "description": "Session id or name. Optional when only one session is available."
+    });
     json!({
         "tools": [
             {
                 "name": "faro_list_sessions",
-                "description": "List the servers (SSH sessions) the user has granted this agent access to in Faro. Call this first to discover available session ids/names.",
+                "description": "List the servers (sessions) the user has granted this agent access to in Faro. Call this first to discover available session ids/names and which support exec (SSH).",
                 "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
             },
             {
+                "name": "faro_server_info",
+                "description": "Get context about a session: protocol, host, port, username, default remote path, and whether it supports shell exec.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": { "session": session_prop },
+                    "additionalProperties": false
+                }
+            },
+            {
                 "name": "faro_exec",
-                "description": "Run a non-interactive shell command on the user's remote server through Faro's authenticated SSH session. The user must approve each command in the Faro window before it runs. If exactly one session has access you may omit `session`.",
+                "description": "Run a non-interactive shell command on the user's remote server through Faro's authenticated SSH session. Subject to the user's approval policy (may prompt). SSH sessions only.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "command": { "type": "string", "description": "The shell command to run. Keep it non-interactive (no pagers/prompts)." },
-                        "session": { "type": "string", "description": "Session id or name. Optional when only one session is available." }
+                        "session": session_prop
                     },
                     "required": ["command"],
+                    "additionalProperties": false
+                }
+            },
+            {
+                "name": "faro_list_dir",
+                "description": "List a directory on the remote server (works for SFTP, FTP and S3 sessions). Returns entries with name, path, kind, size and modified time.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Remote directory path. Defaults to \".\"." },
+                        "session": session_prop
+                    },
+                    "additionalProperties": false
+                }
+            },
+            {
+                "name": "faro_read_file",
+                "description": "Read the contents of a remote text file (SSH/SFTP only). Output is capped at 256 KiB; check the `truncated` flag.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Remote file path to read." },
+                        "session": session_prop
+                    },
+                    "required": ["path"],
+                    "additionalProperties": false
+                }
+            },
+            {
+                "name": "faro_search",
+                "description": "Search for files/directories whose name contains a substring (case-insensitive), recursively under a root path. Works for all protocols. Bounded in depth and results.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": { "type": "string", "description": "Case-insensitive substring to match against entry names." },
+                        "path": { "type": "string", "description": "Root directory to search under. Defaults to \".\"." },
+                        "session": session_prop
+                    },
+                    "required": ["query"],
+                    "additionalProperties": false
+                }
+            },
+            {
+                "name": "faro_download",
+                "description": "Download a remote file to the user's machine via Faro's transfer engine. Returns a transferId; the transfer also appears in Faro's transfer panel.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Remote file path to download." },
+                        "localDir": { "type": "string", "description": "Local destination directory. Defaults to the user's Downloads folder." },
+                        "session": session_prop
+                    },
+                    "required": ["path"],
+                    "additionalProperties": false
+                }
+            },
+            {
+                "name": "faro_upload",
+                "description": "Upload a local file to a remote directory via Faro's transfer engine. Returns a transferId.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "localPath": { "type": "string", "description": "Path to the local file to upload." },
+                        "remoteDir": { "type": "string", "description": "Remote destination directory." },
+                        "session": session_prop
+                    },
+                    "required": ["localPath", "remoteDir"],
+                    "additionalProperties": false
+                }
+            },
+            {
+                "name": "faro_transfer_status",
+                "description": "Check whether a download/upload (started via faro_download/faro_upload) has finished. Returns status (queued|transferring|done|skipped|error|canceled), bytes transferred, and any error. Poll this after starting a transfer to confirm success.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "transferId": { "type": "string", "description": "The transferId returned by faro_download or faro_upload." }
+                    },
+                    "required": ["transferId"],
                     "additionalProperties": false
                 }
             }
@@ -588,25 +1489,40 @@ fn mcp_tools_list() -> Value {
     })
 }
 
+fn arg_str(args: &Value, key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Wrap an op's `(status, json)` result as an MCP tool response.
+fn mcp_wrap(res: (u16, Value)) -> Value {
+    let (status, body) = res;
+    if status == 200 {
+        tool_text(serde_json::to_string_pretty(&body).unwrap_or_default())
+    } else {
+        tool_error(body.get("error").and_then(|v| v.as_str()).unwrap_or("error"))
+    }
+}
+
 async fn mcp_tools_call(app: &AppHandle, state: &Arc<BridgeState>, params: &Value) -> Value {
     let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let args = params.get("arguments").cloned().unwrap_or_else(|| json!({}));
+    let session_arg = args.get("session").and_then(|v| v.as_str());
+
+    // Tools that don't need a session.
+    if name == "faro_list_sessions" {
+        let (_, body) = handle_sessions(app, state).await;
+        return tool_text(serde_json::to_string_pretty(&body).unwrap_or_default());
+    }
+
     match name {
-        "faro_list_sessions" => {
-            let (_, body) = handle_sessions(app, state).await;
-            tool_text(serde_json::to_string_pretty(&body).unwrap_or_default())
-        }
         "faro_exec" => {
-            let command = args
-                .get("command")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            if command.is_empty() {
+            let Some(command) = arg_str(&args, "command") else {
                 return tool_error("`command` is required");
-            }
-            let session_arg = args.get("session").and_then(|v| v.as_str());
-            let session_id = match resolve_session(app, state, session_arg).await {
+            };
+            let session_id = match resolve_session(app, state, session_arg, true).await {
                 Ok(id) => id,
                 Err(msg) => return tool_error(&msg),
             };
@@ -616,6 +1532,63 @@ async fn mcp_tools_call(app: &AppHandle, state: &Arc<BridgeState>, params: &Valu
             } else {
                 tool_error(body.get("error").and_then(|v| v.as_str()).unwrap_or("error"))
             }
+        }
+        "faro_server_info" => match resolve_session(app, state, session_arg, false).await {
+            Ok(id) => mcp_wrap(op_server_info(app, state, &id).await),
+            Err(msg) => tool_error(&msg),
+        },
+        "faro_list_dir" => {
+            let path = arg_str(&args, "path").unwrap_or_else(|| ".".to_string());
+            match resolve_session(app, state, session_arg, false).await {
+                Ok(id) => mcp_wrap(op_list_dir(app, state, &id, &path).await),
+                Err(msg) => tool_error(&msg),
+            }
+        }
+        "faro_read_file" => {
+            let Some(path) = arg_str(&args, "path") else {
+                return tool_error("`path` is required");
+            };
+            match resolve_session(app, state, session_arg, true).await {
+                Ok(id) => mcp_wrap(op_read_file(app, state, &id, &path).await),
+                Err(msg) => tool_error(&msg),
+            }
+        }
+        "faro_search" => {
+            let Some(query) = arg_str(&args, "query") else {
+                return tool_error("`query` is required");
+            };
+            let root = arg_str(&args, "path").unwrap_or_else(|| ".".to_string());
+            match resolve_session(app, state, session_arg, false).await {
+                Ok(id) => mcp_wrap(op_search(app, state, &id, &root, &query).await),
+                Err(msg) => tool_error(&msg),
+            }
+        }
+        "faro_download" => {
+            let Some(path) = arg_str(&args, "path") else {
+                return tool_error("`path` is required");
+            };
+            let local_dir = arg_str(&args, "localDir");
+            match resolve_session(app, state, session_arg, false).await {
+                Ok(id) => mcp_wrap(op_download(app, state, &id, &path, local_dir).await),
+                Err(msg) => tool_error(&msg),
+            }
+        }
+        "faro_upload" => {
+            let (Some(local_path), Some(remote_dir)) =
+                (arg_str(&args, "localPath"), arg_str(&args, "remoteDir"))
+            else {
+                return tool_error("`localPath` and `remoteDir` are required");
+            };
+            match resolve_session(app, state, session_arg, false).await {
+                Ok(id) => mcp_wrap(op_upload(app, state, &id, &local_path, &remote_dir).await),
+                Err(msg) => tool_error(&msg),
+            }
+        }
+        "faro_transfer_status" => {
+            let Some(transfer_id) = arg_str(&args, "transferId") else {
+                return tool_error("`transferId` is required");
+            };
+            mcp_wrap(op_transfer_status(app, &transfer_id).await)
         }
         other => tool_error(&format!("unknown tool: {other}")),
     }
@@ -628,37 +1601,59 @@ async fn enabled_sessions(app: &AppHandle, state: &Arc<BridgeState>) -> Vec<(Str
     let mut out = Vec::new();
     for id in ids {
         if let Some(sess) = manager.get(&id).await {
-            let is_ssh = matches!(&*sess, crate::session::Session::Ssh(_));
+            let is_ssh = matches!(&*sess, Session::Ssh(_));
             out.push((id, sess.profile().name.clone(), is_ssh));
         }
     }
     out
 }
 
+/// Resolve the `session` argument to a concrete session id. When `require_exec`
+/// is set, only SSH sessions are valid (exec/read_file need a shell/SFTP) — but
+/// we resolve against ALL enabled sessions first so a non-SSH match yields an
+/// accurate "that's not SSH" error rather than a misleading "no match".
 async fn resolve_session(
     app: &AppHandle,
     state: &Arc<BridgeState>,
     arg: Option<&str>,
+    require_exec: bool,
 ) -> Result<String, String> {
-    let ssh: Vec<(String, String)> = enabled_sessions(app, state)
-        .await
-        .into_iter()
-        .filter(|(_, _, is_ssh)| *is_ssh)
-        .map(|(id, name, _)| (id, name))
-        .collect();
+    let all = enabled_sessions(app, state).await; // (id, name, is_ssh)
 
     if let Some(a) = arg {
-        return ssh
+        return match all
             .iter()
-            .find(|(id, name)| id == a || name.eq_ignore_ascii_case(a))
-            .map(|(id, _)| id.clone())
-            .ok_or_else(|| format!("no enabled SSH session matches \"{a}\""));
+            .find(|(id, name, _)| id == a || name.eq_ignore_ascii_case(a))
+        {
+            Some((id, _, is_ssh)) => {
+                if require_exec && !*is_ssh {
+                    Err(format!(
+                        "session \"{a}\" is not an SSH session — exec and read_file need SSH; use list_dir/download/upload for this server"
+                    ))
+                } else {
+                    Ok(id.clone())
+                }
+            }
+            None => Err(format!("no enabled session matches \"{a}\"")),
+        };
     }
-    match ssh.len() {
-        0 => Err("no server has granted agent access — ask the user to enable it in Faro's Agent Bridge panel".into()),
-        1 => Ok(ssh[0].0.clone()),
+
+    let candidates: Vec<&(String, String, bool)> = all
+        .iter()
+        .filter(|(_, _, is_ssh)| !require_exec || *is_ssh)
+        .collect();
+    match candidates.len() {
+        0 if require_exec && !all.is_empty() => Err(
+            "the enabled session(s) are not SSH — exec and read_file need SSH; use list_dir/download/upload instead"
+                .into(),
+        ),
+        0 => Err(
+            "no server has granted agent access — ask the user to enable it in Faro's Agent Bridge panel"
+                .into(),
+        ),
+        1 => Ok(candidates[0].0.clone()),
         _ => {
-            let names: Vec<&str> = ssh.iter().map(|(_, n)| n.as_str()).collect();
+            let names: Vec<&str> = candidates.iter().map(|(_, n, _)| n.as_str()).collect();
             Err(format!(
                 "multiple sessions are available ({}); pass the `session` argument",
                 names.join(", ")
@@ -679,10 +1674,19 @@ fn format_exec_result(body: &Value) -> String {
     let stdout = body.get("stdout").and_then(|v| v.as_str()).unwrap_or("");
     let stderr = body.get("stderr").and_then(|v| v.as_str()).unwrap_or("");
     let code = body.get("exitCode").and_then(|v| v.as_i64());
+    let truncated = body.get("truncated").and_then(|v| v.as_bool()).unwrap_or(false);
+    let timed_out = body.get("timedOut").and_then(|v| v.as_bool()).unwrap_or(false);
     let mut out = format!(
         "exit code: {}\n",
-        code.map(|c| c.to_string()).unwrap_or_else(|| "unknown".into())
+        code.map(|c| c.to_string())
+            .unwrap_or_else(|| "unknown".into())
     );
+    if timed_out {
+        out.push_str("NOTE: command timed out before finishing — output is partial and the exit code is unknown.\n");
+    }
+    if truncated {
+        out.push_str("NOTE: output was truncated (exceeded the size cap).\n");
+    }
     if !stdout.is_empty() {
         out.push_str("\n--- stdout ---\n");
         out.push_str(stdout);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -53,7 +53,14 @@ pub async fn connect(
         .await
         .map_err(err)?
         .ok_or_else(|| format!("profile {profile_id} not found"))?;
-    state.sessions.connect(profile, app).await.map_err(err)
+    let session_id = state.sessions.connect(profile, app).await.map_err(err)?;
+    // Re-apply a previously-granted Agent Bridge access for this profile (session
+    // ids are per-connect, so the bridge tracks the persistent grant by profile).
+    state
+        .bridge
+        .on_session_connected(&session_id, &profile_id)
+        .await;
+    Ok(session_id)
 }
 
 #[tauri::command]
@@ -300,7 +307,7 @@ async fn fs_for(
     Ok(fs_for_session(&session))
 }
 
-fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
+pub fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
     match &**session {
         Session::Ssh(ssh) => Box::new(crate::remotefs::sftp::SftpFs::new(ssh.clone())),
         Session::Ftp(ftp) => Box::new(crate::remotefs::ftp::FtpFs::new(ftp.clone())),
@@ -546,7 +553,7 @@ pub async fn stop_edit(
 
 // ---------- Agent Bridge ----------
 
-use crate::bridge::{ActivityEntry, ApprovalDecision, BridgeStatus};
+use crate::bridge::{ActivityEntry, ApprovalDecision, ApprovalPolicy, BridgeStatus};
 
 #[tauri::command]
 pub async fn bridge_start(
@@ -571,9 +578,19 @@ pub async fn bridge_status(state: State<'_, AppState>) -> Result<BridgeStatus, S
 pub async fn bridge_set_session_access(
     session_id: String,
     enabled: bool,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<BridgeStatus, String> {
-    state.bridge.set_access(&session_id, enabled).await;
+    state.bridge.set_access(&app, &session_id, enabled).await;
+    Ok(state.bridge.status().await)
+}
+
+#[tauri::command]
+pub async fn bridge_set_policy(
+    policy: ApprovalPolicy,
+    state: State<'_, AppState>,
+) -> Result<BridgeStatus, String> {
+    state.bridge.set_policy(policy).await;
     Ok(state.bridge.status().await)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,7 +48,9 @@ pub fn run() {
                 profiles: profile_store,
                 transfers: Arc::new(transfer::TransferManager::new()),
                 editors: Arc::new(editor::EditManager::new()),
-                bridge: Arc::new(bridge::BridgeState::new()),
+                bridge: Arc::new(
+                    bridge::BridgeState::load_or_create(&handle).unwrap_or_default(),
+                ),
             };
             app.manage(state);
             Ok(())
@@ -89,6 +91,7 @@ pub fn run() {
             commands::bridge_stop,
             commands::bridge_status,
             commands::bridge_set_session_access,
+            commands::bridge_set_policy,
             commands::respond_to_bridge_approval,
             commands::bridge_activity,
         ])

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -13,6 +13,7 @@ use russh_sftp::client::SftpSession;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::{oneshot, Mutex, OnceCell};
 use uuid::Uuid;
@@ -236,9 +237,27 @@ impl SshSession {
     }
 
     /// Run a single non-interactive command on a fresh exec channel and collect
-    /// its full stdout/stderr + exit code. Used by the Agent Bridge so a local
-    /// AI agent can run commands through this already-authenticated session.
+    /// its full stdout/stderr + exit code, unbounded. Thin wrapper over
+    /// `exec_bounded` with no caps.
     pub async fn exec(&self, command: &str) -> Result<ExecOutput> {
+        self.exec_bounded(command, usize::MAX, Duration::from_secs(86_400), None)
+            .await
+    }
+
+    /// Like `exec`, but bounds total captured output to `max_bytes` and the
+    /// whole run to `timeout` (so `tail -f`, `top`, or a huge dump can't hang
+    /// the bridge or balloon memory). If `stream` is set, stdout/stderr chunks
+    /// are emitted as `agent://output` events as they arrive, so Faro's UI can
+    /// show the agent's command output live. The returned `ExecOutput` carries
+    /// `truncated`/`timed_out` flags so the caller (and the agent) can tell the
+    /// output was cut short or the command didn't finish.
+    pub async fn exec_bounded(
+        &self,
+        command: &str,
+        max_bytes: usize,
+        timeout: Duration,
+        stream: Option<&ExecStream>,
+    ) -> Result<ExecOutput> {
         let mut channel = {
             let h = self.handle.lock().await;
             h.channel_open_session().await?
@@ -248,29 +267,82 @@ impl SshSession {
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let mut exit_code = None;
-        loop {
-            let Some(msg) = channel.wait().await else { break };
-            match msg {
-                ChannelMsg::Data { ref data } => stdout.extend_from_slice(data),
-                ChannelMsg::ExtendedData { ref data, ext } => {
-                    // ext == 1 is the conventional stderr stream.
-                    if ext == 1 {
-                        stderr.extend_from_slice(data);
-                    } else {
-                        stdout.extend_from_slice(data);
+        let mut truncated = false;
+
+        let collect = async {
+            loop {
+                let Some(msg) = channel.wait().await else { break };
+                match msg {
+                    ChannelMsg::Data { ref data } => {
+                        let total = stdout.len() + stderr.len();
+                        append_capped(&mut stdout, data, max_bytes, total, &mut truncated);
+                        if let Some(s) = stream {
+                            emit_chunk(s, "stdout", data);
+                        }
                     }
+                    ChannelMsg::ExtendedData { ref data, ext } => {
+                        // ext == 1 is the conventional stderr stream.
+                        let total = stdout.len() + stderr.len();
+                        let is_err = ext == 1;
+                        if is_err {
+                            append_capped(&mut stderr, data, max_bytes, total, &mut truncated);
+                        } else {
+                            append_capped(&mut stdout, data, max_bytes, total, &mut truncated);
+                        }
+                        if let Some(s) = stream {
+                            emit_chunk(s, if is_err { "stderr" } else { "stdout" }, data);
+                        }
+                    }
+                    ChannelMsg::ExitStatus { exit_status } => exit_code = Some(exit_status as i32),
+                    ChannelMsg::Eof | ChannelMsg::Close => break,
+                    _ => {}
                 }
-                ChannelMsg::ExitStatus { exit_status } => exit_code = Some(exit_status as i32),
-                ChannelMsg::Eof | ChannelMsg::Close => break,
-                _ => {}
+                if truncated {
+                    break;
+                }
             }
-        }
+        };
+
+        let timed_out = tokio::time::timeout(timeout, collect).await.is_err();
 
         Ok(ExecOutput {
             stdout: String::from_utf8_lossy(&stdout).to_string(),
             stderr: String::from_utf8_lossy(&stderr).to_string(),
             exit_code,
+            truncated,
+            timed_out,
         })
+    }
+}
+
+/// Sink for live exec output — emits `agent://output` events tagged with `op_id`.
+pub struct ExecStream {
+    pub app: AppHandle,
+    pub op_id: String,
+}
+
+fn emit_chunk(s: &ExecStream, stream: &str, data: &[u8]) {
+    let _ = s.app.emit(
+        "agent://output",
+        serde_json::json!({
+            "opId": s.op_id,
+            "stream": stream,
+            "chunk": String::from_utf8_lossy(data),
+        }),
+    );
+}
+
+/// Append `data` to `buf`, but never let `buf+other` exceed `max_bytes`. Sets
+/// `truncated` if anything was dropped.
+fn append_capped(buf: &mut Vec<u8>, data: &[u8], max_bytes: usize, total: usize, truncated: &mut bool) {
+    if total >= max_bytes {
+        *truncated = true;
+        return;
+    }
+    let take = (max_bytes - total).min(data.len());
+    buf.extend_from_slice(&data[..take]);
+    if take < data.len() {
+        *truncated = true;
     }
 }
 
@@ -280,6 +352,8 @@ pub struct ExecOutput {
     pub stdout: String,
     pub stderr: String,
     pub exit_code: Option<i32>,
+    pub truncated: bool,
+    pub timed_out: bool,
 }
 
 /// Open a Session for any supported protocol given a profile and a verifier.

--- a/src-tauri/src/transfer.rs
+++ b/src-tauri/src/transfer.rs
@@ -136,6 +136,12 @@ impl TransferManager {
         self.transfers.lock().await.get(id).cloned()
     }
 
+    /// Public snapshot of a single transfer by id (used by the Agent Bridge so
+    /// an agent can poll whether a download/upload it started has finished).
+    pub async fn snapshot(&self, id: &str) -> Option<Transfer> {
+        self.transfers.lock().await.get(id).cloned()
+    }
+
     async fn update<F: FnOnce(&mut Transfer)>(&self, id: &str, f: F) {
         if let Some(t) = self.transfers.lock().await.get_mut(id) {
             f(t);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { Toaster } from "./components/ui/Toaster";
 import { CommandPalette } from "./components/CommandPalette";
 import { KeyboardShortcutsDialog } from "./components/KeyboardShortcutsDialog";
 import { AgentBridge, AgentBridgeHost } from "./components/AgentBridge";
+import { AgentConsole } from "./components/AgentConsole";
 import { useShortcuts } from "./hooks/useShortcuts";
 import { relTime } from "./lib/format";
 import { cn } from "./lib/cn";
@@ -69,6 +70,7 @@ export default function App() {
       {dialog === "import" && <ImportDialog onClose={closeDialog} />}
       {dialog === "about" && <AboutDialog onClose={closeDialog} />}
       {dialog === "agentBridge" && <AgentBridge onClose={closeDialog} />}
+      {dialog === "agentConsole" && <AgentConsole onClose={closeDialog} />}
       <HostKeyModal />
       <Toaster />
       <AgentBridgeHost />
@@ -156,7 +158,9 @@ function StatusBar({
               style={{ background: profile.color || "rgb(var(--accent))" }}
             />
           </div>
-          <span className="font-medium">{profile.name}</span>
+          <span className="max-w-[18rem] truncate font-medium" title={profile.name}>
+            {profile.name}
+          </span>
           <span className="font-mono text-text-dim">
             {profile.username}@{profile.host}:{profile.port}
           </span>

--- a/src/components/AgentBridge.tsx
+++ b/src/components/AgentBridge.tsx
@@ -15,9 +15,27 @@ import {
 } from "lucide-react";
 import { useBridge } from "@/stores/bridgeStore";
 import { useConnections } from "@/stores/connectionsStore";
+import { useLayout } from "@/stores/layoutStore";
 import { cn } from "@/lib/cn";
 import { relTime } from "@/lib/format";
-import type { BridgeApproval } from "@/lib/types";
+import type { BridgeApproval, ApprovalPolicy } from "@/lib/types";
+
+// Phrase the approval prompt per operation kind.
+const APPROVAL_COPY: Record<string, { title: string; foot: string }> = {
+  exec: { title: "Agent wants to run a command", foot: "Runs over your authenticated SSH session." },
+  read: { title: "Agent wants to read from the server", foot: "Reads through your authenticated Faro session." },
+  download: { title: "Agent wants to download a file", foot: "Downloads through Faro's transfer engine." },
+  upload: { title: "Agent wants to upload a file", foot: "Uploads through Faro's transfer engine." },
+  search: { title: "Agent wants to search the server", foot: "Searches through your authenticated Faro session." },
+};
+function approvalCopy(kind: string) {
+  return (
+    APPROVAL_COPY[kind] ?? {
+      title: "Agent wants to run an operation",
+      foot: "Runs through your authenticated Faro session.",
+    }
+  );
+}
 
 // Always-mounted: boots the bridge store (status + event listeners) and renders
 // the per-command approval modal whenever a request is pending.
@@ -64,13 +82,14 @@ function ApprovalModal({
   onApprove: () => void;
   onDeny: () => void;
 }) {
+  const copy = approvalCopy(approval.kind);
   return (
     <div className="fixed inset-0 z-[85] flex items-center justify-center bg-black/60 backdrop-blur-sm">
       <div className="anim-modal w-[28rem] max-w-[92vw] rounded-xl border border-border bg-bg-panel shadow-elev-3">
         <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
           <ShieldCheck size={15} className="text-accent" />
           <span className="text-[15px] font-semibold tracking-tight">
-            Agent wants to run a command
+            {copy.title}
           </span>
         </div>
         <div className="px-5 py-4">
@@ -82,7 +101,7 @@ function ApprovalModal({
             {approval.command}
           </pre>
           <div className="mt-3 flex items-center gap-1.5 text-[11px] text-text-dim">
-            <TerminalIcon size={11} /> Runs over your authenticated SSH session.
+            <TerminalIcon size={11} /> {copy.foot}
           </div>
         </div>
         <div className="flex items-center justify-between gap-2 border-t border-border px-5 py-3">
@@ -112,25 +131,18 @@ function ApprovalModal({
 function skillMd(url: string, token: string, sessionId: string): string {
   return `---
 name: faro-server
-description: Run shell commands on a remote server through Faro's authenticated SSH session. Use when the user asks to inspect, run, or operate on a server they have open in Faro.
+description: Operate on a remote server through Faro's authenticated session — run commands, browse, read, search and transfer files. Use when the user asks to inspect, run, or operate on a server they have open in Faro.
 ---
 
 # Faro server access
 
-Faro is bridging a live SSH session at \`${url}\`. You can run commands on the
-server without any credentials — Faro holds the authenticated session and the
-user approves each command in the Faro window.
+Faro is bridging a live session at \`${url}\`. You can operate on the server
+without any credentials — Faro holds the authenticated session and the user
+approves requests in the Faro window (some kinds may be auto-approved per the
+user's policy). Authenticate every call with the bearer token below.
 
-## Run a command
-
-\`\`\`bash
-curl -s ${url}/exec \\
-  -H "Authorization: Bearer ${token}" \\
-  -H "Content-Type: application/json" \\
-  -d '{"sessionId":"${sessionId}","command":"df -h"}'
-\`\`\`
-
-Response: \`{ "stdout": "...", "stderr": "...", "exitCode": 0 }\`.
+All endpoints are \`POST\` with a JSON body and require these headers:
+\`-H "Authorization: Bearer ${token}" -H "Content-Type: application/json"\`.
 
 ## List available sessions
 
@@ -138,9 +150,48 @@ Response: \`{ "stdout": "...", "stderr": "...", "exitCode": 0 }\`.
 curl -s ${url}/sessions -H "Authorization: Bearer ${token}"
 \`\`\`
 
+## Run a command (SSH only)
+
+\`\`\`bash
+curl -s ${url}/exec -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" \\
+  -d '{"sessionId":"${sessionId}","command":"df -h"}'
+\`\`\`
+
+Response: \`{ "stdout": "...", "stderr": "...", "exitCode": 0 }\`. Keep commands
+non-interactive (no prompts/pagers); add flags like \`-y\`, \`| cat\`.
+
+## Browse / read / search
+
+\`\`\`bash
+# list a directory
+curl -s ${url}/list   -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d '{"sessionId":"${sessionId}","path":"/var/log"}'
+# read a text file (SSH/SFTP, capped at 256 KiB)
+curl -s ${url}/read   -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d '{"sessionId":"${sessionId}","path":"/etc/hostname"}'
+# search by name (recursive, case-insensitive)
+curl -s ${url}/search -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d '{"sessionId":"${sessionId}","path":"/var/log","query":".log"}'
+# session context
+curl -s ${url}/info   -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d '{"sessionId":"${sessionId}"}'
+\`\`\`
+
+## Transfer files
+
+\`\`\`bash
+# download to the user's machine (defaults to their Downloads folder)
+curl -s ${url}/download -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d '{"sessionId":"${sessionId}","path":"/etc/hosts"}'
+# upload a local file to a remote directory
+curl -s ${url}/upload   -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d '{"sessionId":"${sessionId}","localPath":"/tmp/a.txt","remoteDir":"/home/user"}'
+# check whether a transfer finished (poll until status is done/error)
+curl -s ${url}/transfer -H "Authorization: Bearer ${token}" -H "Content-Type: application/json" -d '{"transferId":"<id from download/upload>"}'
+\`\`\`
+
 Notes:
-- Every \`/exec\` call blocks until the user approves it in Faro (or it times out).
-- Keep commands non-interactive (no prompts/pagers); add flags like \`-y\`, \`| cat\`.
+- Requests block until the user approves them in Faro (or time out), unless the
+  user has enabled auto-approve for that kind of operation.
+- Transfers run in the background and also appear in Faro's transfer panel:
+  \`/download\`/\`/upload\` return a \`transferId\`; poll \`/transfer\` to learn the
+  outcome (status \`done\` or \`error\`).
+- \`/exec\` output is capped (512 KiB) and times out after 60s; the result's
+  \`truncated\`/\`timedOut\` flags tell you if it was cut short.
 `;
 }
 
@@ -155,7 +206,9 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
   const start = useBridge((s) => s.start);
   const stop = useBridge((s) => s.stop);
   const setSessionAccess = useBridge((s) => s.setSessionAccess);
+  const setPolicy = useBridge((s) => s.setPolicy);
   const refresh = useBridge((s) => s.refresh);
+  const openDialog = useLayout((s) => s.openDialog);
 
   const activeSessionId = useConnections((s) => s.activeSessionId);
   const activeProfileId = useConnections((s) => s.activeProfileId);
@@ -164,6 +217,9 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
   const isSsh = activeProfile?.protocol === "sftp";
   const granted =
     !!activeSessionId && status.enabledSessions.includes(activeSessionId);
+  const policy = status.policy;
+  const patchPolicy = (patch: Partial<ApprovalPolicy>) =>
+    setPolicy({ ...policy, ...patch });
 
   const [showToken, setShowToken] = useState(false);
 
@@ -194,6 +250,12 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
           )}
           <div className="flex-1" />
           <button
+            onClick={() => openDialog("agentConsole")}
+            className="flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] text-text-muted hover:bg-bg-hover hover:text-text"
+          >
+            <TerminalIcon size={12} /> Live console
+          </button>
+          <button
             onClick={onClose}
             className="rounded-md p-1.5 text-text-muted hover:bg-bg-hover hover:text-text"
           >
@@ -203,10 +265,11 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
 
         <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
           <p className="text-xs leading-relaxed text-text-muted">
-            Let a local AI agent (Claude Code, Cursor…) run commands on your
-            connected server through Faro — no agent install on the server, no
-            credentials shared. Faro brokers its authenticated SSH session over a
-            localhost endpoint and asks you to approve every command.
+            Let a local AI agent (Claude Code, Cursor…) operate on your connected
+            servers through Faro — run commands, browse, read, search and transfer
+            files, with no agent install on the server and no credentials shared.
+            Faro brokers its authenticated session over a localhost endpoint and
+            asks you to approve each request (unless you relax that below).
           </p>
 
           {/* Server */}
@@ -261,11 +324,6 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
               <div className="text-xs text-text-dim">
                 Connect to a server first, then grant the agent access to it here.
               </div>
-            ) : !isSsh ? (
-              <div className="text-xs text-text-dim">
-                The active connection ({activeProfile?.name}) isn’t SSH/SFTP —
-                command execution needs an SSH session.
-              </div>
             ) : (
               <div className="flex items-center gap-3">
                 <div className="min-w-0 flex-1">
@@ -276,6 +334,12 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
                   <div className="truncate font-mono text-[11px] text-text-dim">
                     {activeProfile?.username}@{activeProfile?.host}
                   </div>
+                  {!isSsh && (
+                    <div className="mt-0.5 text-[11px] text-text-dim">
+                      File ops only (browse, read, search, transfer) — exec needs
+                      an SSH session.
+                    </div>
+                  )}
                 </div>
                 <Toggle
                   checked={granted}
@@ -285,13 +349,54 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
             )}
           </Card>
 
+          {/* Auto-approve */}
+          <Card title="Auto-approve">
+            <div className="mb-2.5 text-xs text-text-muted">
+              By default Faro asks before every agent request. Loosen that here —
+              applies to all enabled sessions.
+            </div>
+            <div className="space-y-2.5">
+              <PolicyRow
+                label="Allow all — no prompts"
+                help="Approve every agent request (commands, reads, transfers) automatically. Most permissive."
+                checked={policy.allowAll}
+                onChange={(v) => patchPolicy({ allowAll: v })}
+                danger
+              />
+              <PolicyRow
+                label="Auto-approve read-only operations"
+                help="List directories, read files and search run without asking. Downloads & uploads write to disk, so they still prompt unless Allow all is on."
+                checked={policy.allowAll || policy.autoRead}
+                disabled={policy.allowAll}
+                onChange={(v) => patchPolicy({ autoRead: v })}
+              />
+              <PolicyRow
+                label="Auto-approve safe shell commands"
+                help="Read-only commands (ls, cat, df, grep…) run without asking; anything that could change the server still prompts. Best-effort heuristic."
+                checked={policy.allowAll || policy.autoSafeExec}
+                disabled={policy.allowAll}
+                onChange={(v) => patchPolicy({ autoSafeExec: v })}
+              />
+            </div>
+            {policy.allowAll && (
+              <div className="mt-2.5 flex items-start gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-300/90">
+                <CircleAlert size={12} className="mt-0.5 shrink-0" />
+                The agent can run anything on enabled sessions without confirmation.
+              </div>
+            )}
+          </Card>
+
           {/* Setup */}
           <Card title="Connect Claude Code">
             <div className="mb-2 text-xs text-text-muted">
               Native MCP — run this in your project and Claude Code gains{" "}
-              <span className="font-mono">faro_exec</span> +{" "}
-              <span className="font-mono">faro_list_sessions</span> tools (you
-              still approve every command):
+              <span className="font-mono">faro_exec</span>,{" "}
+              <span className="font-mono">faro_list_dir</span>,{" "}
+              <span className="font-mono">faro_read_file</span>,{" "}
+              <span className="font-mono">faro_search</span>,{" "}
+              <span className="font-mono">faro_download</span>/
+              <span className="font-mono">upload</span> + more (approval follows
+              your policy above):
             </div>
             <div className="flex items-center gap-2">
               <code className="min-w-0 flex-1 truncate rounded border border-border bg-bg-panel px-2 py-1 font-mono text-[10px] text-text-muted">
@@ -353,8 +458,13 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
 
         <div className="border-t border-border px-5 py-3 text-[11px] text-text-dim">
           <ShieldCheck size={11} className="mr-1 inline" />
-          Bound to 127.0.0.1 only · token required · per-session opt-in · every
-          command needs your approval.
+          Bound to 127.0.0.1 only · token required · per-session opt-in ·{" "}
+          {policy.allowAll
+            ? "auto-approving all requests"
+            : policy.autoRead || policy.autoSafeExec
+              ? "auto-approving some requests"
+              : "you approve every request"}
+          .
         </div>
       </div>
     </div>
@@ -417,18 +527,22 @@ function CopyButton({
 function Toggle({
   checked,
   onChange,
+  disabled,
 }: {
   checked: boolean;
   onChange: (v: boolean) => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={checked}
+      disabled={disabled}
       onClick={() => onChange(!checked)}
       className={cn(
         "relative h-5 w-9 shrink-0 rounded-full border transition-colors",
+        disabled && "cursor-not-allowed opacity-50",
         checked
           ? "border-accent bg-accent"
           : "border-border bg-bg-subtle hover:border-text-dim"
@@ -441,6 +555,34 @@ function Toggle({
         )}
       />
     </button>
+  );
+}
+
+function PolicyRow({
+  label,
+  help,
+  checked,
+  onChange,
+  disabled,
+  danger,
+}: {
+  label: string;
+  help: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="min-w-0 flex-1">
+        <div className={cn("text-sm", danger && "font-medium text-amber-300")}>
+          {label}
+        </div>
+        <div className="text-[11px] leading-snug text-text-dim">{help}</div>
+      </div>
+      <Toggle checked={checked} onChange={onChange} disabled={disabled} />
+    </div>
   );
 }
 

--- a/src/components/AgentConsole.tsx
+++ b/src/components/AgentConsole.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef } from "react";
+import {
+  X,
+  Trash2,
+  TerminalSquare,
+  FileText,
+  Download,
+  Upload,
+  Search,
+  Ban,
+  CircleAlert,
+  CheckCircle2,
+  Loader2,
+  Radio,
+} from "lucide-react";
+import { useBridge } from "@/stores/bridgeStore";
+import { cn } from "@/lib/cn";
+import { relTime } from "@/lib/format";
+import type { AgentConsoleEntry } from "@/lib/types";
+
+// A live, read-only view of everything the agent does through the bridge —
+// commands stream their output in real time; file ops show as a feed. This is
+// the human's window into the agent; it doesn't accept input.
+export function AgentConsole({ onClose }: { onClose: () => void }) {
+  const entries = useBridge((s) => s.console);
+  const clear = useBridge((s) => s.clearConsole);
+  const running = entries.filter((e) => e.status === "running").length;
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [entries]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="anim-modal flex max-h-[85vh] w-[44rem] max-w-[95vw] flex-col rounded-xl border border-border bg-bg-panel shadow-elev-3"
+      >
+        <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
+          <Radio size={15} className="text-accent" />
+          <span className="text-[15px] font-semibold tracking-tight">
+            Agent console
+          </span>
+          {running > 0 && (
+            <span className="flex items-center gap-1 rounded-full bg-accent/15 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+              <Loader2 size={10} className="animate-spin" /> {running} running
+            </span>
+          )}
+          <div className="flex-1" />
+          <button
+            onClick={clear}
+            disabled={entries.length === 0}
+            className="flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] text-text-muted hover:bg-bg-hover hover:text-text disabled:opacity-40"
+          >
+            <Trash2 size={11} /> Clear
+          </button>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1.5 text-text-muted hover:bg-bg-hover hover:text-text"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div ref={scrollRef} className="flex-1 space-y-2 overflow-y-auto px-4 py-3">
+          {entries.length === 0 ? (
+            <div className="flex h-40 flex-col items-center justify-center gap-2 text-center text-xs text-text-dim">
+              <TerminalSquare size={20} className="opacity-50" />
+              <div>
+                Nothing yet. When the agent runs commands or transfers files
+                through the bridge, they stream here live.
+              </div>
+            </div>
+          ) : (
+            entries.map((e) => <ConsoleEntry key={e.id} entry={e} />)
+          )}
+        </div>
+
+        <div className="border-t border-border px-5 py-3 text-[11px] text-text-dim">
+          <Radio size={11} className="mr-1 inline" />
+          Live, read-only — this is your view of what the agent is doing over the
+          Agent Bridge.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function KindIcon({ entry }: { entry: AgentConsoleEntry }) {
+  if (entry.status === "running")
+    return <Loader2 size={12} className="mt-0.5 shrink-0 animate-spin text-accent" />;
+  if (entry.kind === "denied")
+    return <Ban size={12} className="mt-0.5 shrink-0 text-text-dim" />;
+  if (entry.kind === "error" || entry.ok === false)
+    return <CircleAlert size={12} className="mt-0.5 shrink-0 text-danger" />;
+  switch (entry.kind) {
+    case "exec":
+      return <TerminalSquare size={12} className="mt-0.5 shrink-0 text-accent" />;
+    case "read":
+      return <FileText size={12} className="mt-0.5 shrink-0 text-text-muted" />;
+    case "search":
+      return <Search size={12} className="mt-0.5 shrink-0 text-text-muted" />;
+    case "download":
+      return <Download size={12} className="mt-0.5 shrink-0 text-text-muted" />;
+    case "upload":
+      return <Upload size={12} className="mt-0.5 shrink-0 text-text-muted" />;
+    default:
+      return <CheckCircle2 size={12} className="mt-0.5 shrink-0 text-emerald-400" />;
+  }
+}
+
+function ConsoleEntry({ entry }: { entry: AgentConsoleEntry }) {
+  const failed = entry.kind === "error" || entry.ok === false;
+  return (
+    <div className="rounded-md border border-border-subtle bg-bg-subtle/40 px-3 py-2">
+      <div className="flex items-start gap-2">
+        <KindIcon entry={entry} />
+        <span
+          className={cn(
+            "min-w-0 flex-1 break-words font-mono text-[12px]",
+            failed ? "text-danger" : "text-text"
+          )}
+        >
+          {entry.command}
+        </span>
+        {entry.sessionName && (
+          <span className="shrink-0 truncate text-[10px] text-text-dim" title={entry.sessionName}>
+            {entry.sessionName}
+          </span>
+        )}
+        <span className="shrink-0 text-[10px] text-text-dim">{relTime(entry.at)}</span>
+      </div>
+      {entry.output && (
+        <pre className="selectable mt-1.5 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-bg-panel px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-text-muted">
+          {entry.output}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -172,19 +172,21 @@ function ProfileRow({
         onClick={onConnect}
         title={
           p.protocol === "s3"
-            ? `s3://${p.bucket ?? "?"}${p.endpoint ? ` @ ${p.endpoint}` : ""}`
+            ? `${p.name}\ns3://${p.bucket ?? "?"}${p.endpoint ? ` @ ${p.endpoint}` : ""}`
             : p.protocol === "azure"
-              ? `azure://${p.account ?? "?"}/${p.bucket ?? "?"}`
-              : `${p.username}@${p.host}:${p.port}`
+              ? `${p.name}\nazure://${p.account ?? "?"}/${p.bucket ?? "?"}`
+              : `${p.name}\n${p.username}@${p.host}:${p.port}`
         }
       >
         <div className="flex items-center gap-1 truncate text-[13px] font-medium">
           {p.protocol === "s3" || p.protocol === "azure" ? (
-            <Cloud size={11} className="text-text-dim" />
+            <Cloud size={11} className="shrink-0 text-text-dim" />
           ) : (
-            <Server size={11} className="text-text-dim" />
+            <Server size={11} className="shrink-0 text-text-dim" />
           )}
-          <span className="truncate">{p.name}</span>
+          <span className="truncate" title={p.name}>
+            {p.name}
+          </span>
         </div>
         <div className="truncate font-mono text-[11px] text-text-dim">
           {p.protocol === "s3"

--- a/src/components/FilePane.tsx
+++ b/src/components/FilePane.tsx
@@ -626,8 +626,11 @@ export function FilePane({
         isDropTarget && "ring-2 ring-inset ring-accent/60 bg-accent/5"
       )}
     >
-      <div className="flex items-center gap-1 border-b border-border bg-bg-subtle px-2 py-1.5">
-        <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+      <div className="flex min-w-0 items-center gap-1 border-b border-border bg-bg-subtle px-2 py-1.5">
+        <span
+          title={title}
+          className="min-w-0 truncate text-xs font-semibold uppercase tracking-wider text-text-muted"
+        >
           {title}
         </span>
         {selectionCount > 0 && (

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,4 +1,5 @@
-import { X, Palette, ArrowDownUp, FolderTree, TerminalSquare, Plug } from "lucide-react";
+import { useEffect } from "react";
+import { X, Palette, ArrowDownUp, FolderTree, TerminalSquare, Plug, Radio } from "lucide-react";
 import {
   useSettings,
   APP_THEMES,
@@ -10,6 +11,7 @@ import {
   type PaneDensity,
   type TerminalTheme,
 } from "@/stores/settingsStore";
+import { useBridge } from "@/stores/bridgeStore";
 import { cn } from "@/lib/cn";
 
 interface Props {
@@ -18,6 +20,15 @@ interface Props {
 
 export function Settings({ onClose }: Props) {
   const s = useSettings();
+
+  // Agent Bridge approval policy lives in the Rust backend (it enforces it), so
+  // these toggles read/write the same source as the Agent Bridge panel.
+  const policy = useBridge((b) => b.status.policy);
+  const setPolicy = useBridge((b) => b.setPolicy);
+  const refreshBridge = useBridge((b) => b.refresh);
+  useEffect(() => {
+    refreshBridge();
+  }, [refreshBridge]);
 
   return (
     <div
@@ -197,6 +208,35 @@ export function Settings({ onClose }: Props) {
                 onChange={s.setDefaultPort}
               />
             </Field>
+          </Section>
+
+          <Section title="Agent Bridge" icon={<Radio size={13} />}>
+            <ToggleField
+              label="Allow all — no prompts"
+              help="Let connected AI agents run every request (commands, reads, transfers) on enabled sessions without asking. Most permissive."
+              checked={policy.allowAll}
+              onChange={(v) => setPolicy({ ...policy, allowAll: v })}
+            />
+            {!policy.allowAll && (
+              <>
+                <ToggleField
+                  label="Auto-approve read-only operations"
+                  help="List directories, read files and search run without asking. Downloads & uploads write to disk, so they still prompt unless Allow all is on."
+                  checked={policy.autoRead}
+                  onChange={(v) => setPolicy({ ...policy, autoRead: v })}
+                />
+                <ToggleField
+                  label="Auto-approve safe shell commands"
+                  help="Read-only commands (ls, cat, df, grep…) run without asking; anything that could change the server still prompts. Best-effort heuristic."
+                  checked={policy.autoSafeExec}
+                  onChange={(v) => setPolicy({ ...policy, autoSafeExec: v })}
+                />
+              </>
+            )}
+            <Help>
+              Same setting as the Agent Bridge panel — applies to every
+              agent-enabled session and persists across restarts.
+            </Help>
           </Section>
         </div>
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -149,7 +149,7 @@ function TabChip({
         setDraft(tab.title);
         setEditing(true);
       }}
-      title="Double-click to rename"
+      title={`${tab.title} — double-click to rename`}
       className={cn(
         "group/tab flex h-6 shrink-0 items-center gap-1.5 rounded-md px-2 text-[11px] transition-colors",
         active
@@ -157,8 +157,8 @@ function TabChip({
           : "text-text-muted hover:bg-bg-hover hover:text-text"
       )}
     >
-      <TerminalSquare size={11} className={active ? "text-accent" : ""} />
-      <span className="max-w-[10rem] truncate">{tab.title}</span>
+      <TerminalSquare size={11} className={cn("shrink-0", active && "text-accent")} />
+      <span className="max-w-[18rem] truncate">{tab.title}</span>
       <span
         role="button"
         tabIndex={-1}

--- a/src/lib/commands.tsx
+++ b/src/lib/commands.tsx
@@ -93,6 +93,14 @@ export function useCommands(): Command[] {
       run: () => openDialog("agentBridge"),
     },
     {
+      id: "agent-console",
+      title: "Agent console (live)…",
+      group: "General",
+      icon: <TerminalSquare size={14} />,
+      keywords: "agent console live output stream terminal bridge watch",
+      run: () => openDialog("agentConsole"),
+    },
+    {
       id: "about",
       title: "About Faro",
       group: "General",

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -23,6 +23,9 @@ import type {
   BridgeActivity,
   BridgeApproval,
   ApprovalDecision,
+  ApprovalPolicy,
+  AgentExecStart,
+  AgentOutput,
 } from "./types";
 
 // Typed wrappers around the Tauri command surface. The string names must match
@@ -174,6 +177,8 @@ export const ipc = {
   bridgeStatus: () => invoke<BridgeStatus>("bridge_status"),
   bridgeSetSessionAccess: (sessionId: SessionId, enabled: boolean) =>
     invoke<BridgeStatus>("bridge_set_session_access", { sessionId, enabled }),
+  bridgeSetPolicy: (policy: ApprovalPolicy) =>
+    invoke<BridgeStatus>("bridge_set_policy", { policy }),
   respondToBridgeApproval: (requestId: string, decision: ApprovalDecision) =>
     invoke<void>("respond_to_bridge_approval", { requestId, decision }),
   bridgeActivity: () => invoke<BridgeActivity[]>("bridge_activity"),
@@ -219,6 +224,18 @@ export async function onBridgeActivity(
   cb: (event: BridgeActivity) => void
 ): Promise<UnlistenFn> {
   return listen<BridgeActivity>("bridge://activity", (e) => cb(e.payload));
+}
+
+export async function onAgentExecStart(
+  cb: (event: AgentExecStart) => void
+): Promise<UnlistenFn> {
+  return listen<AgentExecStart>("agent://exec-start", (e) => cb(e.payload));
+}
+
+export async function onAgentOutput(
+  cb: (event: AgentOutput) => void
+): Promise<UnlistenFn> {
+  return listen<AgentOutput>("agent://output", (e) => cb(e.payload));
 }
 
 export async function onTransferEvent(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -198,12 +198,22 @@ export interface HostPromptEvent {
 
 // ---- Agent Bridge ----
 
+export interface ApprovalPolicy {
+  /** Master switch — approve every agent request on enabled sessions. */
+  allowAll: boolean;
+  /** Auto-approve read-only ops (list_dir, read_file, download, search). */
+  autoRead: boolean;
+  /** Auto-approve shell commands that look read-only (best-effort heuristic). */
+  autoSafeExec: boolean;
+}
+
 export interface BridgeStatus {
   running: boolean;
   url: string | null;
   port: number | null;
   token: string | null;
   enabledSessions: string[];
+  policy: ApprovalPolicy;
 }
 
 export interface BridgeActivity {
@@ -219,10 +229,39 @@ export interface BridgeApproval {
   requestId: string;
   sessionId: string;
   sessionName: string;
+  /** Operation kind: "exec" | "read" | "download" | "upload" | "search". */
+  kind: string;
+  /** Human-readable summary of what the agent wants to do. */
   command: string;
 }
 
 export type ApprovalDecision = "approve" | "deny";
+
+// Live agent console (streamed exec output + op feed).
+export interface AgentExecStart {
+  opId: string;
+  sessionId: string;
+  sessionName: string;
+  command: string;
+}
+
+export interface AgentOutput {
+  opId: string;
+  stream: "stdout" | "stderr";
+  chunk: string;
+}
+
+export interface AgentConsoleEntry {
+  id: string;
+  sessionId: string;
+  sessionName?: string;
+  kind: string; // exec | read | download | upload | search | denied | error
+  command: string; // command (exec) or op summary
+  output: string; // streamed stdout/stderr (exec only)
+  status: "running" | "done";
+  ok?: boolean;
+  at: number;
+}
 
 export type TransferKind = "download" | "upload";
 export type TransferStatus =

--- a/src/stores/bridgeStore.ts
+++ b/src/stores/bridgeStore.ts
@@ -1,12 +1,24 @@
 import { create } from "zustand";
-import { ipc, onBridgeApproval, onBridgeActivity } from "@/lib/ipc";
+import {
+  ipc,
+  onBridgeApproval,
+  onBridgeActivity,
+  onAgentExecStart,
+  onAgentOutput,
+} from "@/lib/ipc";
 import { toast } from "./toastStore";
 import type {
   BridgeStatus,
   BridgeActivity,
   BridgeApproval,
   ApprovalDecision,
+  ApprovalPolicy,
+  AgentConsoleEntry,
 } from "@/lib/types";
+
+const MAX_CONSOLE = 200;
+// Cap a single entry's streamed output so a runaway command can't bloat memory.
+const MAX_ENTRY_OUTPUT = 256 * 1024;
 
 const EMPTY: BridgeStatus = {
   running: false,
@@ -14,12 +26,14 @@ const EMPTY: BridgeStatus = {
   port: null,
   token: null,
   enabledSessions: [],
+  policy: { allowAll: false, autoRead: false, autoSafeExec: false },
 };
 
 interface BridgeStoreState {
   status: BridgeStatus;
   activity: BridgeActivity[];
   approvals: BridgeApproval[];
+  console: AgentConsoleEntry[];
   loaded: boolean;
 
   init: () => Promise<() => void>;
@@ -27,13 +41,16 @@ interface BridgeStoreState {
   start: () => Promise<void>;
   stop: () => Promise<void>;
   setSessionAccess: (sessionId: string, enabled: boolean) => Promise<void>;
+  setPolicy: (policy: ApprovalPolicy) => Promise<void>;
   respond: (requestId: string, decision: ApprovalDecision) => Promise<void>;
+  clearConsole: () => void;
 }
 
 export const useBridge = create<BridgeStoreState>((set, get) => ({
   status: EMPTY,
   activity: [],
   approvals: [],
+  console: [],
   loaded: false,
 
   init: async () => {
@@ -53,11 +70,69 @@ export const useBridge = create<BridgeStoreState>((set, get) => ({
       set((s) => ({ approvals: [...s.approvals, a] }));
     });
     const unActivity = await onBridgeActivity((e) => {
-      set((s) => ({ activity: [e, ...s.activity].slice(0, 200) }));
+      set((s) => {
+        // Finalize a streamed exec entry (same id), or add a fresh done entry
+        // for ops that don't stream (read/list/download/upload/search/denied).
+        const idx = s.console.findIndex((c) => c.id === e.id);
+        let console_: AgentConsoleEntry[];
+        if (idx >= 0) {
+          console_ = s.console.slice();
+          console_[idx] = {
+            ...console_[idx],
+            status: "done" as const,
+            ok: e.ok,
+            kind: e.kind,
+            command: console_[idx].command || e.detail,
+          };
+        } else {
+          console_ = [
+            ...s.console,
+            {
+              id: e.id,
+              sessionId: e.sessionId,
+              kind: e.kind,
+              command: e.detail,
+              output: "",
+              status: "done" as const,
+              ok: e.ok,
+              at: e.at,
+            },
+          ].slice(-MAX_CONSOLE);
+        }
+        return { activity: [e, ...s.activity].slice(0, 200), console: console_ };
+      });
+    });
+    const unExecStart = await onAgentExecStart((e) => {
+      set((s) => ({
+        console: [
+          ...s.console,
+          {
+            id: e.opId,
+            sessionId: e.sessionId,
+            sessionName: e.sessionName,
+            kind: "exec",
+            command: e.command,
+            output: "",
+            status: "running" as const,
+            at: Date.now(),
+          },
+        ].slice(-MAX_CONSOLE),
+      }));
+    });
+    const unOutput = await onAgentOutput((e) => {
+      set((s) => ({
+        console: s.console.map((c) =>
+          c.id === e.opId
+            ? { ...c, output: (c.output + e.chunk).slice(-MAX_ENTRY_OUTPUT) }
+            : c
+        ),
+      }));
     });
     return () => {
       unApproval();
       unActivity();
+      unExecStart();
+      unOutput();
     };
   },
 
@@ -98,6 +173,18 @@ export const useBridge = create<BridgeStoreState>((set, get) => ({
     }
   },
 
+  setPolicy: async (policy) => {
+    // Optimistic: reflect the toggle immediately, reconcile with the backend.
+    set((s) => ({ status: { ...s.status, policy } }));
+    try {
+      const status = await ipc.bridgeSetPolicy(policy);
+      set({ status });
+    } catch (e) {
+      toast.error("Couldn't update auto-approve policy", String(e));
+      void get().refresh();
+    }
+  },
+
   respond: async (requestId, decision) => {
     // Drop it from the local queue immediately for snappy UI.
     set((s) => ({
@@ -109,4 +196,6 @@ export const useBridge = create<BridgeStoreState>((set, get) => ({
       // the request may have already timed out on the backend
     }
   },
+
+  clearConsole: () => set({ console: [] }),
 }));

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -8,7 +8,8 @@ export type AppDialog =
   | "newConnection"
   | "import"
   | "about"
-  | "agentBridge";
+  | "agentBridge"
+  | "agentConsole";
 
 interface LayoutState {
   terminalOpen: boolean;


### PR DESCRIPTION
## Summary
Expands the Agent Bridge from a single `exec` capability into a full toolset with a configurable auto-approve policy and a live console, plus connection-name readability fixes.

### Connection names
- Full-name hover tooltips in the sidebar, terminal tabs, pane title and status bar; lifted the hardcoded terminal-tab width cap.

### Bridge — new capabilities (REST + MCP), reusing the RemoteFs/transfer engine
- `faro_list_dir`, `faro_read_file`, `faro_search`, `faro_download`, `faro_upload`, `faro_server_info`, `faro_transfer_status`.
- File ops work for SFTP/FTP/S3; `exec`/`read_file` stay SSH-only with accurate "not an SSH session" errors.
- Non-SSH sessions can now be granted agent access (file ops).

### Auto-approve policy `{ allowAll, autoRead, autoSafeExec }`
- Super toggle + read-only-ops + a best-effort safe-shell-command heuristic (shell-metacharacter reject + `NEVER_SAFE` denylist + curated read-only allowlist). **Heuristic, not a security boundary.**
- Surfaced in the Bridge popup **and** Settings (single Rust-side source of truth).
- Persisted to `bridge.json` (policy + profile-keyed grants, re-applied on reconnect).

### Bounded exec + live console
- `SshSession::exec_bounded` — 512 KiB output cap + 60s timeout; `ExecOutput` gains `truncated`/`timed_out`, surfaced to the agent.
- `agent://exec-start` + `agent://output` stream exec output into a read-only **Agent console** (`AgentConsole.tsx`, dialog `"agentConsole"`).
- `faro_transfer_status` closes the async download/upload loop.

## Verification
- `cargo check`, `tsc --noEmit`, and `vite build` all pass.
- Two adversarial multi-agent review passes; all confirmed findings fixed (command-allowlist hardening, `server_info` opt-in enforcement, `download` reclassified as a write, REST/MCP error parity, console `op_id` correlation on the error path).

## Caveat
Not yet runtime-smoke-tested end-to-end with a live agent + server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)