### PR TITLE
Disk Usage Explorer, seven new backends, and safer folder sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ Thumbs.db
 # Local one-shot execution runbook (not shipped; the plans beside it are)
 docs/plans/prompt.md
 
+# PR description drafts from the create-pr skill (local scratch, not shipped)
+.pr/
+
 # Generated demo screenshots — rebuild with `npm run shots` (already covered by
 # the global *.png rule above; listed explicitly so the intent is clear).
 docs/screenshots/*.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# Faro — working agreement
+
+Faro is a Tauri 2 desktop client that unifies SFTP/SSH, FTP/FTPS, S3-compatible
+object storage, and Azure Blob behind one connection list and one `RemoteFs`
+trait — a dual-pane file manager, terminal, transfers, folder sync, in-place
+remote editing, and an Agent Bridge that lends a live session to a local agent.
+See `PRODUCT.md` for the full pitch.
+
+- **Backend:** Rust in `src-tauri/src/`.
+- **Frontend:** React 18 + TypeScript + Zustand + Tailwind in `src/`.
+
+## Git & release workflow — read this first
+
+**Two branches, nothing else: `main` and `dev`.**
+
+- **Do all work on `dev`.** Never create per-feature branches (`feat/…`, `fix/…`,
+  `chore/…`) — stay on `dev`.
+- **Commit locally; never push.** Make small, focused commits on `dev` as you go.
+  **Do not `git push`, do not merge into `main`, do not open PRs.** The maintainer
+  reviews the local commits and pushes / merges to `main` himself.
+- **`main` is the release branch.** Every push to `main` auto-cuts a public
+  release (`.github/workflows/release.yml`); `[skip ci]` in the commit message
+  pushes without releasing. Because a push to `main` ships to users, that step is
+  always the maintainer's — not yours.
+- **Shipping a slice = `dev` → `main`, done by the maintainer.** When a slice is
+  complete and verified, say so. If a PR write-up helps, run the **`create-pr`**
+  skill — it only *writes a description file* to `.pr/`, it does not open or push
+  anything.
+- Keep the repo's commit trailer: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+### PR titles are plain English
+
+No conventional-commit prefixes in PR titles — no `feat(scope):`, `fix:`, or
+`[tag]`. Write a normal, human title: `Folder sync: exclude patterns and
+mirror-delete guard`, not `feat(sync): add exclude patterns`. Faro cuts a patch
+release on *every* push to `main` regardless of wording, so the prefix never
+carried release weight here. The `create-pr` skill produces titles in this style.
+
+## Autonomy — decide, don't ask
+
+The plans in `docs/plans/` are the spec. Execute end-to-end without checking in at
+every step. Don't ask which phase is next, whether to commit, or what to name
+things — pick the sensible default (mirror the existing code) and proceed. Only
+stop to ask when genuinely blocked: the plan contradicts the code irreconcilably,
+an action is destructive/irreversible (data loss, history rewrite), or you need a
+secret only the maintainer has. Batch questions; don't drip them. Progress over
+permission — implement, commit locally, verify, move on, report at the end.
+
+## Build / verify
+
+Windows dev box. **Force the rustup MSVC toolchain onto PATH** or Rust builds fail
+with dlltool/E0514 (Chocolatey shadows it):
+
+```bash
+export PATH="$HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/bin:$HOME/.cargo/bin:$PATH"
+cd src-tauri && cargo check -p faro     # backend type-check
+cargo build -p faro                     # full compile + link
+```
+
+Frontend: `npx tsc --noEmit` (repo root) must exit 0.
+
+**"Compiles" is not "works."** Smoke-test the real flow a change touches:
+`npm run tauri dev` launches the app. If the agent is involved, a paired Android
+phone runs one — `adb forward tcp:8722 tcp:8722` reaches it at `127.0.0.1:8722`.
+
+**Definition of done (per slice):** `cargo check -p faro` clean · `npx tsc
+--noEmit` exit 0 · a real runtime observation of the new behavior · committed
+locally on `dev` (not pushed).
+
+## Where things live
+
+- **`RemoteFs`** (`src-tauri/src/remotefs/`) — metadata + mutation only
+  (`list_dir, rename, delete, create_dir, chmod, capabilities`). **No byte
+  transfer** — that's `TransferManager` (`src-tauri/src/transfer.rs`).
+- **Sync:** `sync::plan(...)` (`src-tauri/src/sync.rs`) →
+  `commands::execute_sync_plan(...)`. Continuous folder sync engine:
+  `src-tauri/src/foldersync.rs`.
+- **Stateful subsystems** follow the shape of `src-tauri/src/agent_host.rs`
+  (`load / persist / auto_start_if_enabled / start / stop / status`, JSON config
+  under the app data dir, `"subsystem://event"` via `tauri::Emitter`), registered
+  in `src-tauri/src/lib.rs`.
+- **Frontend wiring:** typed IPC wrappers in `src/lib/ipc.ts` (never raw
+  `invoke`/`listen` in components); Zustand stores in `src/stores/` (model new ones
+  on `bridgeStore.ts`); settings in `src/components/Settings.tsx`; status-bar pill
+  + store init in `src/App.tsx`. There is **no system tray** — use the status-bar
+  pill.
+
+## Plans & runbook
+
+- `docs/plans/ROADMAP.md` sequences the tracks; numbered plans (`1_…` … `11_…`)
+  are the specs, **numbered in build order** (see the ROADMAP's "Plan build
+  order" table). E.g. `docs/plans/5_additional-backends.md` adds one `RemoteFs`
+  impl + `Session` variant + New-Connection UI entry per backend.
+- `docs/plans/prompt.md` is a local (gitignored) one-shot runbook for pasting into
+  a fresh session to execute a single plan; it mirrors the rules above.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,22 @@
+# Third-party licenses
+
+Faro bundles assets and code from third parties. Their licenses are reproduced
+below. (npm dependencies retain their own licenses in `node_modules`; this file
+covers redistributed **assets** that ship inside the built app.)
+
+## Material Icon Theme
+
+File-type icons in the file browser are from
+[Material Icon Theme](https://github.com/material-extensions/vscode-material-icon-theme)
+(`material-icon-theme` on npm), used under the MIT License.
+
+```
+The MIT License (MIT)
+Copyright (c) 2025 Material Extensions
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/docs/plans/10_iconify-brand-icons.md
+++ b/docs/plans/10_iconify-brand-icons.md
@@ -1,4 +1,4 @@
-# Plan 5 — Iconify for brand & protocol logos
+# Plan 10 — Iconify for brand & protocol logos
 
 ## Context
 

--- a/docs/plans/10_scoped-connection-sharing.md
+++ b/docs/plans/10_scoped-connection-sharing.md
@@ -1,0 +1,76 @@
+# Plan 10 — Scoped, time-boxed connection sharing
+
+## Context
+
+The goal: give a teammate access to **one server (or one path), for a limited
+time, without handing over full server credentials** — an agency giving an
+employee scoped access to a box. The instinct was "maybe deploy Faro to the
+browser like code-server." That's one option, but it's the heavy one (needs a
+web frontend + a login system). The lighter, more Faro-native path already
+exists in the **agent protocol**, which does pairing + per-peer policy +
+revocation today.
+
+## The key insight — sharing without a login system
+
+A shared connection is really a **scoped, expiring grant to reach a machine**.
+The Faro Agent (`faro-agentd`) already has the machinery:
+- **pairing** (a 6-digit code → a pinned peer),
+- **per-peer policy** (`allowExec` / `allowWrite`, read-only),
+- **revocation** (drop a peer).
+
+Extend that with **scope** (a path jail) and **expiry** (a TTL) and you get
+"share this box, read-only, under `/var/www`, for 24h" — no accounts, no
+website. The teammate pairs their own Faro to the shared agent with a grant that
+auto-expires and is path/permission-limited.
+
+## Approach
+
+### Track 10a — Scoped agent grants (the tractable, no-login path)
+Extend `faro-agentd` peers/policy (`src-tauri/faro-agentd/src/config.rs`,
+`server.rs`, and `agent_host.rs` on the GUI side):
+- **Path scope** — a peer grant can pin a root prefix; the daemon rejects ops
+  outside it (validate in `ops.rs` against the grant, like a chroot). Reuses the
+  existing per-op gating.
+- **Expiry** — a grant carries `expiresAt`; the daemon refuses a pinned peer past
+  it and auto-prunes (mirror the pairing-window `Instant` expiry already there).
+- **Share UX** — "Share this connection" produces a scoped pairing code (role:
+  read-only / path / TTL). The recipient pairs their Faro and sees only the
+  jailed, time-boxed view. Revoke early anytime (already supported).
+- Works for a box running the embedded host **or** a headless `faro-agentd`; and
+  since DeviceKit/ServerKit hosts can run the agent, this shares those too.
+
+### Track 10b — Browser view (deferred; needs auth)
+A code-server-style web Faro (browse/transfer/terminal in a browser tab, handed
+to someone via a link). This is the big one: it needs a web-served frontend and
+**a real auth/login layer** — explicitly out of scope for now, captured here so
+the design is on record. If pursued, the scoped-grant model from 10a becomes its
+permission backbone (a web session = a scoped grant), so 10a is the right
+foundation to build first regardless.
+
+## Phases
+1. **Grant model** — add scope (path) + expiry to agent peer grants; enforce in
+   `ops.rs`; auto-prune expired.
+2. **Share flow** — "Share connection" → scoped/TTL pairing code; recipient pairs
+   into the jailed view; sharer sees/revokes active shares.
+3. **Polish** — named shares, activity log per share, one-click revoke-all.
+4. **(Deferred) Browser view** — web frontend + login; reuse the grant model as
+   its permission layer. Its own project.
+
+## Integration points
+`src-tauri/faro-agentd/src/{config.rs,server.rs,ops.rs}` (scope + expiry on
+grants), `src-tauri/src/agent_host.rs` (issue/list/revoke scoped shares),
+`faro-agent-proto` (grant fields in pairing), the GUI "Share connection" flow.
+
+## Risks
+- **Path-jail correctness is security-critical** — validate every op's resolved
+  path against the grant root (defend `..`/symlink escapes); default-deny.
+- Clock skew on expiry — enforce on the daemon side (authoritative), not the
+  controller.
+- Don't over-build into a login system by accident — 10a deliberately needs no
+  accounts; keep 10b clearly separate and deferred.
+
+## Verification
+Pair a second Faro into a scoped, read-only, path-jailed, short-TTL grant:
+confirm it can only see under the jail, can't write, and stops working at expiry;
+early revoke cuts it immediately; path-escape attempts (`../`, symlinks) are
+denied.

--- a/docs/plans/10_scoped-connection-sharing.md
+++ b/docs/plans/10_scoped-connection-sharing.md
@@ -1,5 +1,13 @@
 # Plan 10 — Scoped, time-boxed connection sharing
 
+> **Status: DEFERRED — blocked on a login/auth foundation.** The target use case
+> (share a box with a remote employee via a link, over the internet) needs
+> authentication regardless of delivery. Rather than build half of it, this is
+> parked until a login/auth system exists. When it lands, the scoped-grant
+> permission model below is still the right backbone — build a login first, then
+> resume here. (The LAN + Faro-installed slice, 10a, could ship without login,
+> but it doesn't cover the real scenario, so we're holding the whole track.)
+
 ## Context
 
 The goal: give a teammate access to **one server (or one path), for a limited

--- a/docs/plans/11_scoped-connection-sharing.md
+++ b/docs/plans/11_scoped-connection-sharing.md
@@ -1,4 +1,4 @@
-# Plan 10 — Scoped, time-boxed connection sharing
+# Plan 11 — Scoped, time-boxed connection sharing
 
 > **Status: DEFERRED — blocked on a login/auth foundation.** The target use case
 > (share a box with a remote employee via a link, over the internet) needs

--- a/docs/plans/2_continuous-folder-sync.md
+++ b/docs/plans/2_continuous-folder-sync.md
@@ -37,13 +37,15 @@ direction, strategy, enabled, poll_interval, conflict_policy }`.
 Reuses the existing `SyncDirection` (LocalToRemote/RemoteToLocal) and
 `SyncStrategy` (Additive/Mirror) enums from `sync.rs`.
 
-**State index** — the piece that turns *copy* into *sync*. A local **SQLite**
-DB (one row per file per pair): `sync_state(pair_id, rel_path, local_mtime,
-local_size, local_hash?, remote_signal, last_synced_rev, state)`. Without this
-the engine can't tell "deleted on the remote" from "never existed," nor detect
-that nothing changed since last run. Today's `SyncReason`
-(Missing/Newer/SizeChanged) compares the two *live* sides — fine for one-shot,
-insufficient for continuous. The index is the engine's memory.
+**State index → cut out into [Plan 3](3_scan-index-foundation.md).** The
+piece that turns *copy* into *sync* — a persisted per-file index — is **shared
+infrastructure** (Plan 4's scan cache, Plan 6's hash cache, and Plan 7's search
+index want the same `faro.db`), so it was moved out of this plan into the
+foundation plan. Phases 1–2 shipped **without** it, on live two-sided diff
+(`SyncReason` Missing/Newer/SizeChanged) — correct for one-way, but blind to
+same-size edits and unable to distinguish a remote delete from never-existed.
+Plan 3 adds the index (and the `change_signal` capability below); **bidirectional
+sync depends on it.**
 
 **Local watcher** — the [`notify`](https://docs.rs/notify) crate
 (inotify / FSEvents / ReadDirectoryChangesW), debounced, marks dirty rel-paths.
@@ -70,6 +72,8 @@ about). Emits Tauri events like the agent host does.
 **Capabilities the engine queries** (via the existing `Capabilities` struct):
 - *change signal*: cheapest reliable "did this file change" — S3 ETag,
   mtime+size, or a content hash (backends differ; ask, don't assume).
+  **Added in [Plan 3](3_scan-index-foundation.md)** as `change_signal` +
+  an optional `DirEntry.etag`.
 - *has real directories* / *atomic rename*: object stores fake dirs (key
   prefixes) and have no atomic rename (copy+delete). `object.rs` already fakes
   folders; the engine must treat folderness/rename as flags, not givens.
@@ -78,11 +82,12 @@ about). Emits Tauri events like the agent host does.
 
 ## Phases
 
-### Phase 1 — Continuous one-way, real files (LocalToRemote)
-Watcher + poller + SQLite state index + reconciler on top of `sync.rs`. Ship
-**Additive** first (copy new/changed up), then **Mirror** (also delete remote
-files gone locally). Per-pair status + tray indicator. This alone delivers
-"attach a folder → edits auto-push to S3 / Azure / SFTP / the phone."
+### Phase 1 — Continuous one-way, real files (LocalToRemote) — ✅ shipped
+Watcher + poller + reconciler on top of `sync.rs`, diffing the two **live**
+sides (the persistent index is [Plan 3](3_scan-index-foundation.md), not
+here). Ship **Additive** first (copy new/changed up), then **Mirror** (also
+delete remote files gone locally). Per-pair status + a StatusBar pill. This alone
+delivers "attach a folder → edits auto-push to S3 / Azure / SFTP / the phone."
 
 ### Phase 2 — Continuous one-way, RemoteToLocal
 Same engine, reversed authority (remote is source → download mirror). Enables
@@ -105,19 +110,22 @@ Flag this as its own sub-decision when we reach it.
 ### Deferred — bidirectional + conflict resolution
 Out of scope here, matching the existing note at `sync.rs:5` ("Bidirectional …
 needs conflict resolution UI that's a project of its own"). Bidirectional needs
-the state index (Phase 1 builds it) plus a conflict policy (newest-wins /
-keep-both "conflicted copy" / prompt). Its own future plan.
+the state index ([Plan 3](3_scan-index-foundation.md) builds it) plus a
+conflict policy (newest-wins / keep-both "conflicted copy" / prompt). Its own
+future plan.
 
 ---
 
 ## Key files
-- `src-tauri/src/sync.rs` (existing one-shot engine → refactor into `sync/`)
-- new `src-tauri/src/sync/{engine.rs,index.rs,watcher.rs,poller.rs,pairs.rs}`
-- `src-tauri/src/transfer.rs` (reuse chunked transfer)
-- `src-tauri/src/remotefs/mod.rs` (`Capabilities` — add a `change_signal` hint)
-- new SQLite store + a `sync-pairs.json` config; Tauri commands mirroring
-  `agent_host.rs` (`sync_pair_list/add/remove/set_enabled/status`)
-- frontend: a Sync panel + tray status
+- `src-tauri/src/foldersync.rs` (the shipped engine — pairs, watcher, poller,
+  reconciler; JSON config `foldersync.json`). Mirrors `agent_host.rs`; Tauri
+  commands `foldersync_*` registered in `lib.rs`.
+- `src-tauri/src/sync.rs` (one-shot `plan()`/`execute()`, reused as primitives)
+- `src-tauri/src/transfer.rs` (chunked transfer)
+- **Persistence + `change_signal`: [Plan 3](3_scan-index-foundation.md)** —
+  the state index (`faro.db`) and the `Capabilities.change_signal` hint live
+  there, not here.
+- frontend: a Sync panel in `Settings.tsx` + a StatusBar pill
 
 ## Risks / gotchas
 - **No remote change feed** on S3/Azure/SFTP/FTP/Agent → polling cost, latency,

--- a/docs/plans/3_scan-index-foundation.md
+++ b/docs/plans/3_scan-index-foundation.md
@@ -1,0 +1,132 @@
+# Plan 3 — Shared scan engine + connection index (the `faro.db` foundation)
+
+## Context
+
+**Cut out of Plan 2.** The continuous-sync engine (Plan 2, Phases 1–2) shipped
+*without* persistent per-file memory: it diffs the two **live** sides via
+`sync::plan` (size + mtime). That is correct for one-shot copy but blind to
+same-size edits and unable to tell "deleted on the remote" from "never existed."
+The fix — a persisted per-file index — turns out to be the first instance of a
+primitive that **four** plans want:
+
+- **Plan 2** — per-file sync state: distinguishes remote deletes, detects
+  same-size edits, resumes without a full re-upload, and is the prerequisite for
+  bidirectional.
+- **Plan 4 (Disk Usage)** — "remember last scan per connection": a cached
+  per-file size tree.
+- **Plan 6 (Diff)** — cache content hashes so repeat diffs don't re-hash.
+- **Plan 7 (Search)** — a filename index (later, SQLite FTS).
+
+They are the same row shape — `(connection_id, path, size, mtime, etag/hash,
+seen_at)` keyed by connection — and they are all fed by the same operation: a
+**recursive `RemoteFs` walk**. That walk *also* already exists three times across
+the plans (Plan 2's poller, Plan 4's `ScanManager`, Plan 7's fallback), each
+re-specifying the same three strategies. This plan extracts both shared pieces so
+the later plans become **additive tables and new callers**, not new databases and
+re-implemented walks. It ships no new user-facing surface of its own beyond
+making sync smarter — it is foundation.
+
+## Scope
+
+**In:** (1) a reusable **scan engine** — bounded-concurrency recursive walk with
+progress + cancel and per-backend strategy selection; (2) a shared **SQLite
+`faro.db`** handle in `AppState` with migrations, tables per-feature; (3)
+`change_signal` on `Capabilities` + an optional `etag` on `DirEntry`; (4) the
+**sync state index** (`sync_state` table) wired into the folder-sync reconciler
+as the first consumer.
+
+**Out:** the disk-usage tree/treemap (Plan 4), diff/search surfaces (Plans 7/8),
+and bidirectional sync (deferred — but this unlocks it).
+
+## Architecture
+
+### Scan engine — `src-tauri/src/scan.rs` (extract from `sync.rs::walk`)
+One place that walks a `RemoteFs` tree, picking the fastest strategy available
+from `Capabilities` + protocol:
+
+1. **Generic walk (always works).** Recurse `RemoteFs::list_dir`, bounded
+   concurrency (latency, not CPU, dominates on SFTP/FTP), streaming partial
+   results.
+2. **Exec fast path (SSH / exec-allowed agent).** One command instead of
+   thousands of round-trips — the caller supplies the command shape (`du -ab` /
+   `find -printf` for sizes, `rg`/`grep` for search). Falls back to the generic
+   walk if exec is disabled or the tool is missing.
+3. **Object-store flat listing (S3 / Azure).** One flat listing under the prefix;
+   build the tree from key segments. No recursion.
+
+Progress + cancel mirror `TransferManager` / `agent_host.rs` (`Arc` in
+`AppState`, abort handle, `scan://…` events). Plan 2's poller, Plan 4's disk
+scan, Plan 6's diff, and Plan 7's search all call **this** instead of rolling
+their own.
+
+### `faro.db` — shared SQLite in `AppState`
+`rusqlite` with the **bundled** feature (compiles SQLite from source — no system
+SQLite dependency), one `faro.db` under `app.path().app_data_dir()`. A tiny
+`db.rs` opens the connection and runs forward-only, versioned migrations at
+startup; every subsystem gets tables in the **same** file:
+
+- `sync_state(pair_id, rel_path, size, mtime, remote_signal, last_synced_ms, state)`
+  — this plan.
+- (later) `scan_cache`, `search_index`, `diff_hash` — Plans 6 / 8 / 7, additive.
+
+Shared **connection + migrations**; **per-feature tables**. No grand unified
+schema — the win is not spawning four private DBs, not a universal index.
+
+### `Capabilities.change_signal` + `DirEntry.etag`
+The cheapest reliable "did this file change" differs per backend: object stores
+have ETags, POSIX has mtime+size, some need a content hash. Add a `change_signal`
+hint to `Capabilities` (`MtimeSize` / `Etag` / `Hash`) and an optional
+`etag: Option<String>` on `DirEntry` so object stores stop guessing from mtime.
+Every backend's `capabilities()` (`sftp.rs`, `ftp.rs`, `object.rs`, `local.rs`,
+`agent.rs`) declares it honestly. Consumed by Plan 2 (reconcile), Plan 5 (each
+new backend declares it), and Plan 6 (`--hash` diff).
+
+### State index wired into the reconciler
+`foldersync.rs`'s reconcile consults + updates `sync_state`: detect same-size
+local edits (mtime/etag changed, size did not), distinguish a remote deletion
+(was in the index, gone from the listing) from never-existed, and skip when
+nothing changed since `last_synced_ms`. Kill & relaunch resumes with **no full
+re-upload**. The index is an optimization layered over — never a replacement for
+— a real listing; startup always reconciles against reality.
+
+## Phases
+
+1. **`faro.db` + `db.rs`** — `rusqlite` bundled, `AppState` handle, migration
+   runner, `sync_state` schema. No behavior change yet.
+2. **Scan engine extraction** — pull `sync.rs::walk` into `scan.rs` with
+   progress / cancel / bounded concurrency + a strategy hook. The folder-sync
+   poller switches to it (no behavior change — just the shared path).
+3. **`change_signal` + `etag`** — extend `Capabilities` + `DirEntry`; every
+   backend declares honestly.
+4. **State index live** — the reconciler reads/writes `sync_state`:
+   same-size-edit detection, remote-delete vs never-existed, resume without
+   re-upload. This is the payoff.
+
+## Key files
+- new `src-tauri/src/scan.rs` (extract from `sync.rs::walk`),
+  `src-tauri/src/db.rs` (faro.db + migrations)
+- `src-tauri/Cargo.toml` — `rusqlite = { version = "0.32", features = ["bundled"] }`
+- `src-tauri/src/remotefs/mod.rs` (`Capabilities.change_signal`, `DirEntry.etag`)
+  + every backend's `capabilities()`
+- `src-tauri/src/foldersync.rs` (reconcile against `sync_state`)
+- `src-tauri/src/lib.rs` (`AppState.db` field + setup construction)
+
+## Risks
+- **Schema churn** — keep migrations forward-only and versioned from day one
+  (a `user_version` pragma), so Plans 6/7/8 add tables without a rewrite.
+- **Bundled SQLite build cost** — `rusqlite`'s `bundled` feature compiles SQLite
+  from source (one-time; fine on the Windows MSVC toolchain — see the dlltool
+  note in the runbook).
+- **ETag ≠ MD5** on multipart S3 uploads — `change_signal = Etag` must treat the
+  ETag as an opaque change *token*, not a content hash.
+- **Index/reality drift** — always reconcile against a real listing on startup;
+  the index accelerates, it never becomes the source of truth.
+
+## Verification
+`cargo check -p faro` + `npx tsc --noEmit`; then runtime: attach a folder to the
+paired phone agent (or a test S3 bucket), edit a file **without changing its
+size** → confirm it re-syncs (proves the index; today's mtime-only path may miss
+it); delete a remote file → the poller sees "was indexed, now gone" and mirrors
+the delete; kill & relaunch → **no full re-upload**. Then confirm the extracted
+scan engine still drives the existing poller unchanged on a second backend
+(Azure/SFTP), proving the extraction was behavior-preserving.

--- a/docs/plans/4_disk-usage-explorer.md
+++ b/docs/plans/4_disk-usage-explorer.md
@@ -1,4 +1,4 @@
-# Plan 6 — Disk Usage Explorer (WinDirStat / WizTree, for any backend)
+# Plan 4 — Disk Usage Explorer (WinDirStat / WizTree, for any backend)
 
 ## Context
 

--- a/docs/plans/5_additional-backends.md
+++ b/docs/plans/5_additional-backends.md
@@ -95,17 +95,37 @@ Verified by parser unit tests + a live `#[ignore]` end-to-end test against
 
 ### Phase 5 — OAuth consumer clouds (Dropbox / OneDrive / Drive / Box) — the hard tier
 Big user draw, meaningfully harder. Shared infrastructure first:
-- **`oauth.rs` helper** used by all of them: loopback/PKCE flow (the `oauth2`
-  crate), token storage (OS keychain — see cross-cutting), refresh handling.
-- Rate limits + retry/backoff.
+- ✅ **`oauth.rs` helper** — **shipped and reusable.** Hand-rolled loopback +
+  PKCE (S256) authorization-code flow (no `oauth2` crate): a fixed-port
+  (`:53682`) local listener catches the redirect, the code is exchanged against
+  a configurable token endpoint, refresh is a second form POST. Endpoints are
+  `OAuthConfig` fields, so a new provider is just a different config. Tokens live
+  in the OS keychain (`keyring`, native backends), never in profile JSON.
+- Rate limits + retry/backoff: a transparent 401→refresh-retry is in place;
+  broader backoff is future work.
 
 Then sequence by API friction, **not** brand size:
-1. **Dropbox** — API v2 is *path-based*; slots straight into the trait. Pilot
-   the OAuth infra here.
-2. **OneDrive** — Microsoft Graph supports path addressing
-   (`/drive/root:/path`); near-Dropbox effort.
-3. **Google Drive** — strictly ID-addressed; needs the path↔ID resolver/cache.
-4. **Box** — enterprise draw; ID-addressed like Drive, reuses its resolver.
+1. ✅ **Dropbox** — **shipped.** API v2 path-based → straight into the trait.
+   `session/dropbox.rs` (`DropboxSession`: bearer RPC/content helpers,
+   transparent refresh) + `remotefs/dropbox.rs` (`DropboxFs`: list_folder+continue,
+   move_v2, delete_v2, create_folder_v2; `rev` as the change token) +
+   streaming download / simple upload in `transfer.rs` (>150 MB refused pending
+   chunked `upload_session`) + a `dropbox_authorize` command driving the browser
+   flow + a `DropboxSection` "Connect with Dropbox" editor. Verified by parser
+   unit tests + a live `#[ignore]` end-to-end test (`tests/dropbox_mock.py`)
+   covering token exchange, the 401→refresh retry, and
+   list/create/upload/download/move/delete.
+   **Maintainer prerequisite to go live:** register a scoped Dropbox app
+   (<https://www.dropbox.com/developers/apps>), redirect URI
+   `http://localhost:53682/`, enable the `account_info.read` /
+   `files.metadata.read` / `files.content.read` / `files.content.write` scopes,
+   and set the App key in `session/dropbox.rs` (`DROPBOX_APP_KEY`) or via
+   `FARO_DROPBOX_APP_KEY`. PKCE ⇒ no app secret. The browser-consent leg needs a
+   real app key + account and is the only unverified step.
+2. ⬜ **OneDrive** — Microsoft Graph supports path addressing
+   (`/drive/root:/path`); near-Dropbox effort, reuses `oauth.rs`.
+3. ⬜ **Google Drive** — strictly ID-addressed; needs the path↔ID resolver/cache.
+4. ⬜ **Box** — enterprise draw; ID-addressed like Drive, reuses its resolver.
 5. *(Optional)* **pCloud** — path-based API, small effort, smaller audience.
 
 Dropbox, Drive, and OneDrive all expose **delta cursors**

--- a/docs/plans/5_additional-backends.md
+++ b/docs/plans/5_additional-backends.md
@@ -122,15 +122,35 @@ Then sequence by API friction, **not** brand size:
    and set the App key in `session/dropbox.rs` (`DROPBOX_APP_KEY`) or via
    `FARO_DROPBOX_APP_KEY`. PKCE ⇒ no app secret. The browser-consent leg needs a
    real app key + account and is the only unverified step.
-2. ⬜ **OneDrive** — Microsoft Graph supports path addressing
-   (`/drive/root:/path`); near-Dropbox effort, reuses `oauth.rs`.
-3. ⬜ **Google Drive** — strictly ID-addressed; needs the path↔ID resolver/cache.
-4. ⬜ **Box** — enterprise draw; ID-addressed like Drive, reuses its resolver.
-5. *(Optional)* **pCloud** — path-based API, small effort, smaller audience.
+2. ✅ **OneDrive** — **shipped.** Microsoft Graph path addressing
+   (`/me/drive/root:/path:`). `session/onedrive.rs` + `remotefs/onedrive.rs`
+   (list + nextLink paging, PATCH move, MKCOL/delete, cTag token) + streaming
+   download / simple-or-chunked-session upload + `onedrive_authorize`. Verified
+   against `tests/onedrive_mock.py`.
+3. ✅ **Google Drive** — **shipped.** Strictly ID-addressed → a path↔ID
+   resolver with a cache (`session/gdrive.rs`): `files?q='<parent>' in parents`,
+   multipart create / media update, PATCH add/removeParents move, md5 token.
+   Verified against `tests/gdrive_mock.py` (nested-path resolver + full CRUD).
+4. ✅ **Box** — **shipped.** ID-addressed like Drive, reuses the resolver shape
+   (`session/boxdrive.rs`): `/folders/{id}/items`, multipart/form-data upload,
+   PUT move, recursive delete, sha1 token. Verified against `tests/box_mock.py`.
+5. *(Optional, not built)* **pCloud** — path-based API, small effort, smaller
+   audience.
 
-Dropbox, Drive, and OneDrive all expose **delta cursors**
-(`list_folder/continue`, `changes.list`, Graph delta) — surface as a
-push/delta capability so the folder-sync engine can skip polling for them.
+All four reuse `oauth.rs` (loopback+PKCE+keychain) and the shared
+`RefreshingToken` (proactive refresh + 401-retry). Each needs the same
+maintainer step to go live: register the provider app with redirect
+`http://localhost:53682/` and set its client id
+(`{DROPBOX,ONEDRIVE,GDRIVE,BOX}_CLIENT_ID` constant or `FARO_*_CLIENT_ID`).
+Every provider's OAuth-token/API path is verified against a local mock; the only
+unverified leg is the interactive browser consent, which needs a real app + account.
+
+**Not yet done:** the **delta-cursor** capability. Dropbox
+(`list_folder/continue`), Graph delta, and Drive `changes.list` could surface as
+a push/delta signal so folder-sync skips polling — a follow-up (needs a new
+`Capabilities` field + sync-engine support), not part of the RemoteFs pilot.
+**Chunked upload** is only implemented for OneDrive; Dropbox refuses >150 MB and
+GDrive/Box buffer the file for multipart — a follow-up for very large files.
 
 ### Considered and passed (for now)
 - **Mega** — client-side crypto protocol, no sane Rust path.

--- a/docs/plans/5_additional-backends.md
+++ b/docs/plans/5_additional-backends.md
@@ -1,4 +1,4 @@
-# Plan 3 — Additional connection sources (backends)
+# Plan 5 — Additional connection sources (backends)
 
 ## Context
 

--- a/docs/plans/5_additional-backends.md
+++ b/docs/plans/5_additional-backends.md
@@ -2,92 +2,161 @@
 
 ## Context
 
-Faro today speaks SFTP, FTP/FTPS, S3-compatible object storage, local disk, and
-the Faro Agent — each a `RemoteFs` impl in `src-tauri/src/remotefs/`
-(`sftp.rs`, `ftp.rs`, `object.rs`, `local.rs`, `agent.rs`). Because browse,
-transfer, directory sync, and the (planned) continuous sync engine all sit on
-that one trait, **every new backend inherits all of them for free** — proven by
-the Agent, which slotted in and immediately worked with the explorer and
-transfers. This plan widens the connection list, cheapest-first.
+Faro today speaks SFTP, FTP/FTPS, S3-compatible object storage, **Azure Blob**
+(both via `object_store`), local disk, and the Faro Agent — each a `RemoteFs`
+impl in `src-tauri/src/remotefs/` (`sftp.rs`, `ftp.rs`, `object.rs`,
+`local.rs`, `agent.rs`). Because browse, transfer, directory sync, and the
+continuous folder-sync engine all sit on that one trait, **every new backend
+inherits all of them for free** — proven by the Agent, which slotted in and
+immediately worked with the explorer and transfers. This plan widens the
+connection list, cheapest-first.
 
-Each backend is the same recipe: implement `RemoteFs`
-(`list_dir`/`stat`/`read`/`write`/`rename`/`delete`/`create_dir`/`chmod` +
-`capabilities`), add a `Session` variant, add a New-Connection UI entry, and
-wire chunked read/write into `transfer.rs`.
+Each backend is the same recipe:
+
+1. Implement `RemoteFs` (`list_dir`/`rename`/`delete`/`create_dir`/`chmod` +
+   `capabilities` — declare an honest `ChangeSignal`).
+2. Add a `Session` variant (`session/mod.rs`) and its connect path.
+3. Wire chunked read/write + stat into the `transfer.rs` match arms.
+4. Add a New-Connection UI entry (`ProfileEditor.tsx`, `src/lib/types.ts`).
 
 ---
 
 ## Phases (priority order)
 
-### Phase 0 — S3-compatible presets (≈ no backend code)
-`object.rs` already speaks the S3 API, so these are **endpoint/region presets**,
-not new backends: **Cloudflare R2, Backblaze B2, Wasabi, MinIO, DigitalOcean
-Spaces, Storj, Google Cloud Storage (interop mode)**. Work: a preset list in the
-New Connection dialog so users pick a provider and only enter keys. Highest
-value-to-effort in the whole plan.
+### Phase 0 — More S3-compatible presets (≈ no backend code) — partially shipped
+`S3_PROVIDER_PRESETS` (`src/lib/types.ts`) + `guessProvider` already ship
+**AWS, Cloudflare R2, Backblaze B2**. Extend the same table:
+- **First tier:** Wasabi, MinIO, DigitalOcean Spaces, Storj, Hetzner Object
+  Storage, GCS interop mode (HMAC keys — superseded by Phase 1 native auth but
+  still zero-code).
+- **Long tail (cheap to add, judge demand):** Scaleway, Linode/Akamai, Vultr,
+  Oracle OCI, IBM COS, Supabase Storage; self-hosted **Ceph RGW, Garage,
+  SeaweedFS** (one generic "S3-compatible / self-hosted" preset may cover all
+  three).
+Work per entry: preset row (label, endpoint hint, default region) + a
+`guessProvider` endpoint pattern. Highest value-to-effort in the whole plan.
 
-### Phase 1 — WebDAV (`webdav.rs`)
-One protocol covers **Nextcloud, ownCloud, and a long tail of generic servers**.
+### Phase 1 — Native Google Cloud Storage (nearly free now)
+Azure Blob shipped by flipping `object_store`'s `azure` feature and adding one
+builder in `session/object.rs` — **GCS is the identical move**: enable the
+`gcp` feature, `GoogleCloudStorageBuilder` with service-account JSON (file
+path or pasted key), protocol `"gcs"`, one `ProfileEditor` section. No new
+files, no new crate. Do this before WebDAV; it was budgeted as a whole crate
+(`google-cloud-storage`) when this plan was first written and is now an
+afternoon.
+
+### Phase 2 — WebDAV (`webdav.rs`)
+One protocol covers **Nextcloud, ownCloud, Hetzner Storage Box, Koofr, Yandex
+Disk, Fastmail Files, Synology WebDAV, and a long tail of generic servers**.
 `reqwest` + `PROPFIND` (list/stat), `GET`/`PUT` (read/write, ranged),
 `DELETE`, `MKCOL` (mkdir), `MOVE` (rename). Auth: Basic or Bearer.
-Capabilities: real directories yes, `chmod` no, rename via `MOVE`. Low effort,
-high coverage — do this first among real backends.
+Capabilities: real directories yes, `chmod` no, rename via `MOVE`,
+`change_signal: Etag` (populate `DirEntry.etag` from `getetag`; servers that
+omit it degrade to mtime+size).
+- Ship **WebDAV provider presets** (the Phase 0 idea generalized beyond S3):
+  Nextcloud/ownCloud prefill the `/remote.php/dav/files/<user>/` path
+  template; Hetzner Storage Box prefills `https://<user>.your-storagebox.de`.
+- Note: `object_store` has an `http` feature that lists via PROPFIND, but it
+  imposes object semantics (no real dirs) — hand-roll this one so
+  `has_directories: true` is honest.
 
-### Phase 2 — SMB/CIFS (`smb.rs`)
+### Phase 3 — SMB/CIFS (`smb.rs`) + the LAN/NAS tier
 Windows shares and **every NAS** (Synology, QNAP, TrueNAS). LAN-first, plain
-user/pass — no OAuth. Implement over a Rust SMB client
-([`pavao`](https://crates.io/crates/pavao) wraps libsmbclient, or an `smb2`
-crate); optional mDNS/NetBIOS discovery. Capabilities: real dirs + rename yes,
-`chmod` no. Biggest single real-world gap for a FileZilla-class tool. Watch the
-Rust SMB ecosystem maturity (may need a `libsmbclient` FFI dependency).
+user/pass — no OAuth. Options: [`pavao`](https://crates.io/crates/pavao)
+(wraps libsmbclient, C FFI build cost) vs the pure-Rust `smb` crate that has
+been maturing — re-evaluate at build time. Optional mDNS/NetBIOS discovery.
+Capabilities: real dirs + rename yes, `chmod` no, `change_signal: MtimeSize`.
+Biggest single real-world gap for a FileZilla-class tool.
+- **Free bonus:** Azure Files shares speak SMB 3 over port 445 — an enterprise
+  backend for zero extra code once SMB works.
+- **Stretch — NFS:** rounds out the NAS story; Rust client crates (e.g.
+  `nfs3_client`) are immature, so read-mostly first or defer until they firm up.
 
-### Phase 3 — Azure Blob + native Google Cloud Storage
-The two big object stores your S3 backend can't reach as-is (different APIs).
-Reuse `object.rs`'s object-semantics patterns (faked dirs, copy+delete rename).
-- **Azure Blob:** `azure_storage_blobs` crate; auth via account key or SAS.
-- **GCS (native):** `google-cloud-storage` crate; service-account JSON.
+### Phase 4 — Read-only HTTP(S) source (optional mini-phase)
+Browse any static file server: nginx/Apache autoindex (HTML or nginx JSON
+listing) parsed into `list_dir`; ranged `GET` for reads. Capabilities: all
+mutations `false`; change signal from `ETag`/`Last-Modified` headers. Listing
+parse is inherently fragile — scope it to the two common autoindex formats
+plus a "no listing, paste a direct URL" mode. Small code, occasionally magic:
+pull a release artifact straight into any pane.
 
-### Phase 4 — OAuth consumer clouds (Drive / OneDrive / Dropbox) — the hard tier
-Big user draw, meaningfully harder:
-- **OAuth flow** (loopback/PKCE), token storage (reuse the identity-file
-  pattern from `faro-agent-proto`), and refresh handling — a shared
-  `oauth.rs` helper used by all three.
-- **Path-vs-ID impedance:** Drive/OneDrive address files by opaque ID, not
-  path; the trait is path-based. Each backend needs a path↔ID resolver/cache.
-- Rate limits + ret/backoff.
-Dropbox and Drive also expose **delta cursors** — worth surfacing as a
-push/delta capability so the Plan 2 sync engine can skip polling for them.
+### Phase 5 — OAuth consumer clouds (Dropbox / OneDrive / Drive / Box) — the hard tier
+Big user draw, meaningfully harder. Shared infrastructure first:
+- **`oauth.rs` helper** used by all of them: loopback/PKCE flow (the `oauth2`
+  crate), token storage (OS keychain — see cross-cutting), refresh handling.
+- Rate limits + retry/backoff.
+
+Then sequence by API friction, **not** brand size:
+1. **Dropbox** — API v2 is *path-based*; slots straight into the trait. Pilot
+   the OAuth infra here.
+2. **OneDrive** — Microsoft Graph supports path addressing
+   (`/drive/root:/path`); near-Dropbox effort.
+3. **Google Drive** — strictly ID-addressed; needs the path↔ID resolver/cache.
+4. **Box** — enterprise draw; ID-addressed like Drive, reuses its resolver.
+5. *(Optional)* **pCloud** — path-based API, small effort, smaller audience.
+
+Dropbox, Drive, and OneDrive all expose **delta cursors**
+(`list_folder/continue`, `changes.list`, Graph delta) — surface as a
+push/delta capability so the folder-sync engine can skip polling for them.
+
+### Considered and passed (for now)
+- **Mega** — client-side crypto protocol, no sane Rust path.
+- **Proton Drive / iCloud Drive** — no official public API.
+- **rsync daemon** — wire-protocol effort exceeds payoff; folder sync over
+  SFTP already covers the use case.
+- **Git repos / artifact registries** — different mental model; if ever, as a
+  Plan 9 virtual folder, not a `RemoteFs`.
 
 ---
 
 ## Cross-cutting
-- Each backend declares honest `Capabilities` — the sync engine (Plan 2) and UI
-  rely on `change_signal`, `has real dirs`, and `atomic rename` flags.
-- Chunked read/write must plug into `transfer.rs` for resumable transfers.
-- New Connection UI: group backends (SSH-family / Object storage / Network
-  shares / Cloud drives) as the list grows.
+- Each backend declares honest `Capabilities` — sync and UI rely on
+  `change_signal` (`Etag` for WebDAV/object/HTTP, `MtimeSize` for SMB/NFS),
+  `has_directories`, and rename semantics. `has_shell` stays `false` for
+  everything in this plan.
+- **`transfer.rs` refactor before the backend wave:** each `Session` variant
+  today appears in ~6 match arms (read/write streams, stat, fs construction).
+  Fold those into session-level helpers first so a new backend is one impl,
+  not six scattered diffs.
+- **OS keychain** (`keyring` crate or Tauri plugin) for passwords and OAuth
+  tokens — prerequisite for Phase 5, nice-to-have before it.
+- **OpenDAL option:** Apache `opendal` ships WebDAV/Drive/OneDrive/Dropbox/Box
+  services behind one trait and could collapse Phases 2 + 5 implementation
+  cost. Trade-offs: a second abstraction beside `object_store`, uneven
+  per-service maturity, and OAuth token acquisition is still ours. Evaluate
+  seriously before hand-rolling Phase 5.
+- New Connection UI: group backends (SSH family / Object storage / Network
+  shares / Cloud drives / Other) as the list grows; presets are a generic
+  mechanism (S3 today, WebDAV/SFTP hosts tomorrow).
 
-## Recommended first batch
-**Phase 0 + Phase 1 + Phase 2** (S3 presets + WebDAV + SMB): the largest
-coverage gain for the least code, all username/password (no OAuth), all a clean
-fit for the trait. That single batch turns "SFTP/FTP/S3 client" into "connects
-to almost any file source on a LAN or in the cloud." Azure/GCS and the OAuth
-drives follow once the token infrastructure is worth building.
+## Recommended batches
+1. **Phase 0 + Phase 1** — presets + native GCS: near-zero code, immediate
+   provider-list growth.
+2. **Phase 2 + Phase 3** — WebDAV + SMB: the coverage jump that turns
+   "SFTP/FTP/object-store client" into "connects to almost any file source on
+   a LAN or in the cloud." All username/password, no OAuth.
+3. **Phase 5** — OAuth tier once the token infrastructure is worth building,
+   Dropbox first. Phase 4 (HTTP) slots wherever a small win is welcome.
 
 ## Key files
-- new `src-tauri/src/remotefs/{webdav.rs,smb.rs,azure.rs,gcs.rs,gdrive.rs,onedrive.rs,dropbox.rs}`
-- `src-tauri/src/remotefs/mod.rs` (register impls; extend `Capabilities`)
-- `src-tauri/src/session/` (add `Session` variants)
-- new `src-tauri/src/oauth.rs` (Phase 4 shared helper)
-- frontend New Connection dialog (presets + grouped backend picker)
+- new `src-tauri/src/remotefs/{webdav.rs,smb.rs,http.rs,dropbox.rs,onedrive.rs,gdrive.rs,boxdrive.rs}`
+- `src-tauri/src/remotefs/mod.rs` (register impls)
+- `src-tauri/src/session/mod.rs` + `session/object.rs` (GCS builder; new
+  `Session` variants) · `src-tauri/src/transfer.rs` (match arms → helpers)
+- new `src-tauri/src/oauth.rs` (Phase 5 shared helper)
+- `src/lib/types.ts` (preset tables) + `src/components/ProfileEditor.tsx`
+  (grouped picker, new sections)
 
 ## Risks
 - SMB Rust maturity → possible C FFI (`libsmbclient`) and its build/deploy cost.
-- OAuth clouds' ID-addressing fights a path-based trait — needs a resolver layer.
+- ID-addressed APIs (Drive, Box) fight a path-based trait — resolver/cache
+  layer, and path renames invalidate cached IDs.
 - Provider rate limits; multipart ETag ≠ MD5 (ties into sync change detection).
-- Credential storage for many providers → consider OS keychain integration.
+- Autoindex HTML parsing (Phase 4) breaks per-server — keep the scope narrow.
+- Credential sprawl across many providers → OS keychain integration.
+- If OpenDAL is adopted, its per-service quality becomes a dependency risk.
 
 ## Verification
 Per backend: connect, browse, up/download a file (chunked), rename, delete;
-then attach it to a Plan 2 sync pair unchanged to confirm the engine is truly
-backend-agnostic.
+then attach it to a folder-sync pair unchanged to confirm the shipped engine
+is truly backend-agnostic.

--- a/docs/plans/5_additional-backends.md
+++ b/docs/plans/5_additional-backends.md
@@ -23,44 +23,51 @@ Each backend is the same recipe:
 
 ## Phases (priority order)
 
-### Phase 0 — More S3-compatible presets (≈ no backend code) — partially shipped
-`S3_PROVIDER_PRESETS` (`src/lib/types.ts`) + `guessProvider` already ship
-**AWS, Cloudflare R2, Backblaze B2**. Extend the same table:
-- **First tier:** Wasabi, MinIO, DigitalOcean Spaces, Storj, Hetzner Object
-  Storage, GCS interop mode (HMAC keys — superseded by Phase 1 native auth but
-  still zero-code).
-- **Long tail (cheap to add, judge demand):** Scaleway, Linode/Akamai, Vultr,
-  Oracle OCI, IBM COS, Supabase Storage; self-hosted **Ceph RGW, Garage,
-  SeaweedFS** (one generic "S3-compatible / self-hosted" preset may cover all
-  three).
-Work per entry: preset row (label, endpoint hint, default region) + a
-`guessProvider` endpoint pattern. Highest value-to-effort in the whole plan.
+### Phase 0 — More S3-compatible presets (≈ no backend code) — ✅ shipped
+`S3_PROVIDER_PRESETS` (`src/lib/types.ts`) + `guessProvider` now ship **AWS,
+Cloudflare R2, Backblaze B2, Wasabi, DigitalOcean Spaces, MinIO, Storj, Hetzner
+Object Storage, Scaleway, Oracle OCI, IBM COS, Supabase**, and a generic
+**S3-compatible / self-hosted** preset (covers Ceph RGW, Garage, SeaweedFS).
+Each carries a vendor sub-label, endpoint template, and default region; the
+provider grid renders straight from the table and `guessProvider` recognizes
+every endpoint pattern. GCS interop mode was skipped in favour of Phase 1's
+native auth. (Linode/Akamai and Vultr not added — judge demand.)
 
-### Phase 1 — Native Google Cloud Storage (nearly free now)
-Azure Blob shipped by flipping `object_store`'s `azure` feature and adding one
-builder in `session/object.rs` — **GCS is the identical move**: enable the
-`gcp` feature, `GoogleCloudStorageBuilder` with service-account JSON (file
-path or pasted key), protocol `"gcs"`, one `ProfileEditor` section. No new
-files, no new crate. Do this before WebDAV; it was budgeted as a whole crate
-(`google-cloud-storage`) when this plan was first written and is now an
-afternoon.
+### Phase 1 — Native Google Cloud Storage (nearly free now) — ✅ shipped
+Shipped exactly as the Azure move: `object_store`'s `gcp` feature +
+`gcs_connect` in `session/object.rs` using `GoogleCloudStorageBuilder` with a
+service-account key (JSON file path via Key auth, or pasted JSON via Password
+auth), protocol `"gcs"`, one `GcsSection` in `ProfileEditor`. A GCS session is
+an `ObjectSession`, so browse/transfer/sync/disk-usage/rename all work through
+the existing `ObjectFs` + object transfer arms unchanged. No new files, no new
+crate.
 
-### Phase 2 — WebDAV (`webdav.rs`)
+### Phase 2 — WebDAV (`webdav.rs`) — ✅ shipped
 One protocol covers **Nextcloud, ownCloud, Hetzner Storage Box, Koofr, Yandex
 Disk, Fastmail Files, Synology WebDAV, and a long tail of generic servers**.
-`reqwest` + `PROPFIND` (list/stat), `GET`/`PUT` (read/write, ranged),
-`DELETE`, `MKCOL` (mkdir), `MOVE` (rename). Auth: Basic or Bearer.
-Capabilities: real directories yes, `chmod` no, rename via `MOVE`,
-`change_signal: Etag` (populate `DirEntry.etag` from `getetag`; servers that
-omit it degrade to mtime+size).
-- Ship **WebDAV provider presets** (the Phase 0 idea generalized beyond S3):
-  Nextcloud/ownCloud prefill the `/remote.php/dav/files/<user>/` path
-  template; Hetzner Storage Box prefills `https://<user>.your-storagebox.de`.
-- Note: `object_store` has an `http` feature that lists via PROPFIND, but it
-  imposes object semantics (no real dirs) — hand-roll this one so
-  `has_directories: true` is honest.
+Shipped as `session/webdav.rs` (`WebdavSession`: shared `reqwest` client, base
+URL carrying the DAV root, Basic/Bearer auth, connect-time depth-0 PROPFIND
+validation) + `remotefs/webdav.rs` (`WebdavFs`: `PROPFIND` list, `MOVE` rename,
+`DELETE`, `MKCOL`, no chmod). Byte transfer streams via `GET`/`PUT` in
+`transfer.rs`; edit-in-place wired in `editor.rs`. `change_signal: Etag` from
+`getetag`, with the mtime+size the entries still carry as the fallback.
+- Shipped **WebDAV provider presets** (`WEBDAV_PROVIDER_PRESETS`): Nextcloud /
+  ownCloud prefill `…/remote.php/dav/files/<user>/`, Hetzner Storage Box
+  `https://<user>.your-storagebox.de`, plus a generic template; the
+  `WebdavSection` also has a Basic/Bearer auth toggle.
+- Hand-rolled (not `object_store`'s `http` feature) so `has_directories: true`
+  is honest. The multistatus parser is namespace-prefix agnostic (Nextcloud
+  `d:`, Apache `D:`/`lp1:`, bare); RFC1123 `getlastmodified` is parsed without a
+  date crate. Verified by parser unit tests + a live `#[ignore]` end-to-end test
+  (connect → MKCOL → PUT → PROPFIND → GET → MOVE → DELETE) against wsgidav.
 
-### Phase 3 — SMB/CIFS (`smb.rs`) + the LAN/NAS tier
+### Phase 3 — SMB/CIFS (`smb.rs`) + the LAN/NAS tier — ⬜ blocked on Windows
+**Build-time re-evaluation (2026-07):** `pavao` links **libsmbclient** (Samba's
+C library), which has no practical MSVC build — a hard blocker on the mandated
+Windows toolchain — and the pure-Rust `smb` crate is still immature. SMB also
+needs a live NAS/Windows share to verify, which isn't available in the dev
+environment. Deferred until either the pure-Rust client firms up or a
+libsmbclient build path exists. Everything below stands as the original spec.
 Windows shares and **every NAS** (Synology, QNAP, TrueNAS). LAN-first, plain
 user/pass — no OAuth. Options: [`pavao`](https://crates.io/crates/pavao)
 (wraps libsmbclient, C FFI build cost) vs the pure-Rust `smb` crate that has

--- a/docs/plans/5_additional-backends.md
+++ b/docs/plans/5_additional-backends.md
@@ -79,13 +79,19 @@ Biggest single real-world gap for a FileZilla-class tool.
 - **Stretch — NFS:** rounds out the NAS story; Rust client crates (e.g.
   `nfs3_client`) are immature, so read-mostly first or defer until they firm up.
 
-### Phase 4 — Read-only HTTP(S) source (optional mini-phase)
-Browse any static file server: nginx/Apache autoindex (HTML or nginx JSON
-listing) parsed into `list_dir`; ranged `GET` for reads. Capabilities: all
-mutations `false`; change signal from `ETag`/`Last-Modified` headers. Listing
-parse is inherently fragile — scope it to the two common autoindex formats
-plus a "no listing, paste a direct URL" mode. Small code, occasionally magic:
-pull a release artifact straight into any pane.
+### Phase 4 — Read-only HTTP(S) source (optional mini-phase) — ✅ shipped
+Shipped as `session/http.rs` (`HttpSession`: shared `reqwest` client, optional
+Basic auth, HEAD reachability probe; connect picks **Listing** vs **DirectFile**
+mode from the URL shape) + `remotefs/http.rs` (`HttpFs`: `list_dir` parses
+nginx/Apache autoindex HTML — anchor-based, survives the `<pre>` and `<table>`
+variants — or nginx JSON; `GET` reads; every mutation returns a read-only
+error). DirectFile mode HEADs a pasted file URL and surfaces one entry, so you
+can pull a release artifact straight into a pane with no listing. Capabilities:
+all mutations `false`, `change_signal: Etag` (from the file's own
+ETag/Last-Modified, populated on read/HEAD — a listing carries none). Byte reads
+stream via `GET` in `transfer.rs`; edit-in-place opens read-only (save errors).
+Verified by parser unit tests + a live `#[ignore]` end-to-end test against
+`python -m http.server` in both listing and direct-file modes.
 
 ### Phase 5 — OAuth consumer clouds (Dropbox / OneDrive / Drive / Box) — the hard tier
 Big user draw, meaningfully harder. Shared infrastructure first:

--- a/docs/plans/5_iconify-brand-icons.md
+++ b/docs/plans/5_iconify-brand-icons.md
@@ -1,0 +1,99 @@
+# Plan 5 — Iconify for brand & protocol logos
+
+## Context
+
+The app runs two icon systems today, each doing its own job well:
+- **lucide** — all UI chrome (buttons, menus, the rail, status bar).
+- **Material Icon Theme** — file-type icons in the browser (`.psd → Photoshop`,
+  `.py → Python`), driven by its extension→icon manifest (see
+  `packages/file-ui/src/lib/materialIcons.ts`).
+
+Neither gives **recognizable brand/protocol logos** — an actual AWS S3, Azure,
+SSH, WordPress, or Postgres mark. That's the gap this plan fills, using
+[Iconify](https://iconify.design), which aggregates 200+ open-source icon sets
+behind one component and, crucially, can be **bundled offline** (no CDN/network).
+
+## Scope
+
+**In:** brand/protocol logos where recognizability adds value — connection
+bubbles in the rail, the connection list, the New Connection protocol picker,
+and a reusable `<BrandIcon>` for tech badges.
+
+**Explicitly out (do not do):**
+- **Do NOT route file-type icons through Iconify.** Iconify's Material Icon
+  Theme set is **903 icons and carries no extension→icon mapping**; the
+  standalone `material-icon-theme` package has **1250 icons + the manifest**.
+  Switching would lose icons *and* the mapping. File icons stay as-is.
+- **Do NOT rip out lucide** for UI chrome. A single-system consolidation is a
+  large refactor and a separate future decision (Phase 4), not this plan.
+
+So this is **additive**: Iconify covers a domain (brand logos) that neither
+existing system does. No icon is imported twice.
+
+## Approach — offline, no network
+
+- Use **`@iconify/react`** + per-set JSON bundles **`@iconify-json/<prefix>`** —
+  NOT the hosted Iconify API/CDN. Register only the sets we use via
+  `addCollection(...)` once at startup (or import specific icons), so the bundle
+  carries only what we reference and makes **zero network calls**.
+- **Sets (permissive licences only):** `logos` (CC0) for colour brand marks,
+  `simple-icons` (CC0) for monochrome brands, `devicon` (MIT) for dev/tech,
+  `mdi` / `material-symbols` (Apache-2.0) as neutral fallbacks. **Avoid GPL and
+  CC-BY-SA;** CC-BY-4.0 is usable but needs visible attribution — prefer CC0/MIT/
+  Apache to keep attribution trivial. Record whatever ships in
+  `THIRD_PARTY_LICENSES.md` (already exists).
+- A single **`protocolIcon(protocol)`** map is the core data:
+  | protocol | icon |
+  |---|---|
+  | `sftp` / ssh | an SSH/terminal glyph (`logos:` or `simple-icons:openssh`) |
+  | `ftp` / `ftps` | network-folder glyph |
+  | `s3` | `logos:aws-s3` |
+  | `azure` | `logos:microsoft-azure` |
+  | `faro-agent` | the Faro lighthouse mark |
+
+## Phases
+
+### Phase 1 — Foundation
+Add `@iconify/react` + the chosen `@iconify-json/*` sets. New
+`src/lib/brandIcons.ts`: registers the sets offline (`addCollection`) and exports
+`protocolIcon(protocol)` + a thin `<BrandIcon icon size />` wrapper over
+`@iconify/react`'s `<Icon>`. Confirm the offline registration makes no request to
+`api.iconify.design`. Attribution in `THIRD_PARTY_LICENSES.md`.
+
+### Phase 2 — Protocol logos on connections
+Wire `protocolIcon()` into:
+- `src/components/ServerRail.tsx` — the connection bubble (behind/beside the
+  colour monogram; keep the monogram as the fallback and identity colour).
+- the connection list rows.
+- `src/components/ProfileEditor.tsx` — the New Connection protocol picker, so
+  each protocol shows its real logo.
+
+### Phase 3 — Tech badges (optional polish)
+A `<BrandIcon>` for known services elsewhere (a WordPress/Docker/Postgres mark
+where the type is known), and the ServerKit/DeviceKit hand-off surfaces.
+
+### Phase 4 — Consolidation (deferred, separate decision)
+Evaluate moving lucide UI icons onto Iconify for a single icon system across the
+app. Large refactor; only if the maintenance simplification is judged worth it.
+Not part of shipping Phases 1–3.
+
+## Integration points
+- `package.json` — `@iconify/react`, `@iconify-json/logos`,
+  `@iconify-json/simple-icons`, `@iconify-json/devicon` (as chosen).
+- new `src/lib/brandIcons.ts` — offline registration + `protocolIcon` + `BrandIcon`.
+- `src/components/ServerRail.tsx`, the connection list, `src/components/ProfileEditor.tsx`.
+- `THIRD_PARTY_LICENSES.md` — attribution for any CC-BY set (ideally none).
+
+## Risks
+- **Bundle size** if whole sets are imported — prefer per-icon imports or a
+  curated subset; measure the delta (the app already warns near 500 KB).
+- **Licensing** — stay on CC0/MIT/Apache; attribute CC-BY; never GPL/CC-BY-SA.
+- **Identity regression** — connections rely on the colour monogram; add the
+  logo without removing that recognizability (logo + colour, not logo instead).
+- **Keep Material Icon Theme untouched** — this plan must not change file icons.
+
+## Verification
+`tsc` clean + `vite build`; **offline check** (disable network / grep the build
+for `api.iconify.design` → must be absent) so logos render with no connection;
+visually confirm protocol logos on the rail, list, and protocol picker without
+losing the monogram/colour.

--- a/docs/plans/6_directory-diff.md
+++ b/docs/plans/6_directory-diff.md
@@ -1,4 +1,4 @@
-# Plan 7 — Directory Diff (GUI + CLI + MCP)
+# Plan 6 — Directory Diff (GUI + CLI + MCP)
 
 ## Context
 

--- a/docs/plans/6_disk-usage-explorer.md
+++ b/docs/plans/6_disk-usage-explorer.md
@@ -1,0 +1,115 @@
+# Plan 6 — Disk Usage Explorer (WinDirStat / WizTree, for any backend)
+
+## Context
+
+WinDirStat and WizTree answer "what's eating my disk?" with a **treemap** +
+a size-sorted tree. They're local-only (WizTree is fast because it reads the
+NTFS MFT directly). Faro can do something they can't: the **same analysis over
+any connection** — an SFTP server, an S3 bucket, an FTP host, or a paired Faro
+Agent — because every backend already implements the same `RemoteFs` walk. "See
+where the space went on a remote server (or an S3 bucket), visually" is the hook.
+
+It opens as a **workspace tab**, exactly like the SSH terminal: a toolbar button
+("Analyze disk usage") on the file browser spawns a *Disk Usage* tab that scans
+the current directory on the active connection.
+
+## Scope
+
+**In:** recursive size scan over `RemoteFs`, a treemap + size-ranked list with
+drill-down, progress + cancel, and per-backend fast paths so it's usable at
+scale. **Out:** the MFT trick (NTFS-only; we go cross-backend). Local NTFS could
+get an MFT fast path later, but the generic + exec paths cover everything first.
+
+## Architecture
+
+### The scan (backend) — `src-tauri/src/diskscan.rs`
+A `ScanManager` (mirrors the `agent_host.rs` / `TransferManager` pattern:
+`Arc` in `AppState`, running scans in a `Mutex<HashMap<scanId, …>>`, progress via
+`diskscan://…` events, cancel via an abort handle). A scan produces a **tree of
+aggregated sizes**: each node = { name, path, kind, ownSize, totalSize, children }.
+
+Three scan strategies, picked by `Capabilities` + protocol (fastest available):
+
+1. **Generic walk (always works).** Recurse `RemoteFs::list_dir` (the `walk` in
+   `src-tauri/src/sync.rs` is the starting point), summing file sizes up the
+   tree. Parallelize directory listings (bounded concurrency) since latency, not
+   CPU, dominates on SFTP/FTP. Stream partial results so the treemap fills in.
+2. **Shell fast path (SSH / servers — the killer feature).** When
+   `capabilities.has_shell` (SSH) or a Faro Agent with exec allowed, run one
+   command instead of thousands of round-trips:
+   `du -ab <path>` (or `find <path> -printf '%s %p\n'`) and parse the output into
+   the tree. Orders of magnitude faster than an SFTP walk on a big server —
+   this is what makes "WinDirStat on a server" actually practical. Falls back to
+   the generic walk if exec is disabled or `du` is missing.
+   - SSH: run via the existing SSH exec channel (`src-tauri/src/session/…` /
+     `terminal.rs`).
+   - Faro Agent: the `Exec { command, timeoutMs, maxBytes }` request
+     (`faro-agent-proto` msg.rs), gated by the daemon's `allowExec` policy.
+3. **Object-store flat listing (S3 / Azure — naturally fast).** Object stores
+   have no real directories; one flat listing under the prefix returns every key
+   + size. Sum by synthetic path segments to build the tree — no recursion, one
+   pass. `ObjectFs` (`src-tauri/src/remotefs/object.rs`) already lists objects.
+   Instant "what's in this bucket / what's it costing" breakdown.
+
+Tauri commands: `diskscan_start(sessionId, path) -> scanId`,
+`diskscan_tree(scanId)` (snapshot for progressive render), `diskscan_cancel`,
+`diskscan_status`. Registered in `src-tauri/src/lib.rs` like the other subsystems.
+
+### The visualization (frontend)
+A new **Disk Usage tab** in the workspace tab system, alongside the terminal
+(mirror `terminalsStore` + the tab bar). Contents:
+- **Treemap** — the centerpiece. Squarified treemap on a **Canvas** (not SVG —
+  thousands of rects; canvas keeps it smooth), color-by-type (reuse the file-type
+  palette / Material Icon Theme colours) or by depth. Hover → path + size;
+  click → drill in; breadcrumb to go back up. Layout math via `d3-hierarchy`
+  (MIT, tiny) or a hand-rolled squarify.
+- **Size-ranked list** beside it — folders/files sorted by `totalSize` with
+  percentage-of-parent bars, the "biggest offenders" view.
+- **Progress + cancel** while scanning; the map fills in live from streamed
+  partials.
+- **Actions** — reveal in the file browser, delete (with confirm), re-scan.
+- Store: `src/stores/diskScanStore.ts` (Zustand, modeled on `bridgeStore.ts`),
+  wired through `src/lib/ipc.ts` wrappers + a `onDiskScanProgress` event.
+
+### Entry point
+An "Analyze disk usage" button in the file-browser toolbar
+(`packages/file-ui`) that opens a Disk Usage tab for the current path + session.
+
+## Phases
+
+1. **Scan engine + generic walk** — `diskscan.rs`, the aggregated-size tree,
+   progress/cancel, commands. Correct on every backend, no fast paths yet.
+2. **Treemap tab + size list** — the Disk Usage workspace tab, canvas treemap,
+   ranked list, drill-down, the toolbar button. This is the "wow".
+3. **Fast paths** — shell `du`/`find` for SSH + Faro Agent (exec-gated), and
+   object-store flat listing. Makes it usable on real servers/buckets. Show which
+   path was used (and why the generic fallback, if exec was denied).
+4. **Actions + polish** — delete/reveal from the map, re-scan, remember last
+   scan per connection, colour-by options.
+
+## Integration points
+- `src-tauri/src/diskscan.rs` (new); `src-tauri/src/lib.rs` (module + `AppState`
+  + commands + auto-nothing); reuse `sync.rs::walk`, `RemoteFs`, `Capabilities`,
+  the SSH exec channel, `ObjectFs` listing, the Agent `Exec` request.
+- `src/stores/diskScanStore.ts` (new), `src/lib/ipc.ts` (wrappers + event), a new
+  Disk Usage tab component + a Canvas treemap component, the file-browser toolbar
+  button in `packages/file-ui`.
+
+## Risks
+- **Latency on deep trees over SFTP/FTP** — the whole reason Phase 3 exists;
+  Phase 1 must stream + cancel so a slow scan is never a hang. Bound concurrency
+  so we don't exhaust the SFTP channel.
+- **Exec availability** — `du` may be absent, or exec disabled (read-only agent,
+  policy off). Always fall back to the generic walk; never hard-depend on exec.
+- **Object-store listing cost/limits** — huge buckets paginate; stream and cap,
+  and `log` when truncated (no silent partial totals).
+- **Symlinks / hardlinks** — `du` and a naive walk can double-count or loop;
+  skip symlinks (as `sync.rs::walk` already does) and note the caveat.
+- **Treemap perf** — canvas + squarify; virtualize the ranked list.
+
+## Verification
+`cargo check` + `tsc` + `vite build`; then a real scan on each strategy:
+a local folder (generic walk), an SSH server (confirm the `du` fast path fires
+and matches `du` run manually), the paired phone agent (`/sdcard`), and an S3
+bucket (flat-listing breakdown). Confirm progress streams, cancel works, and the
+treemap drill-down + delete behave.

--- a/docs/plans/7_directory-diff.md
+++ b/docs/plans/7_directory-diff.md
@@ -1,0 +1,56 @@
+# Plan 7 — Directory Diff (GUI + CLI + MCP)
+
+## Context
+
+A Meld/Beyond Compare for directory trees, across **any** Faro backend —
+including **remote↔remote** (staging vs prod, two servers, two buckets), which
+no local diff tool can do. It reuses the diff `sync.rs` already computes; the new
+work is surfacing it three ways: the **GUI**, the **`faro-cli`**, and as an
+**MCP/Agent-Bridge tool** so the AI can diff and reason about the result.
+
+## Approach
+
+### Diff engine — `src-tauri/src/diff.rs`
+`sync::plan` already walks two `RemoteFs` sides and classifies
+Missing/Newer/SizeChanged. Generalize that into a symmetric diff:
+`{ onlyInA[], onlyInB[], different[] (size/mtime, optional content hash), same[] }`.
+Optional `--hash` mode confirms "different" by content (server-side `sha256sum`
+via exec / S3 ETag where available; falls back to streamed hashing). Files-only
+first (as `walk` already is), directories implied.
+
+### Three surfaces
+1. **CLI** — `faro-cli diff <a> <b> [--hash] [--json]`. `<a>`/`<b>` are
+   `profile:path` (or `local:path`), so **remote↔remote** works from the
+   terminal. `--json` for scripting. Reuses `resolve_server`/profile resolution
+   already in `faro-cli/src/main.rs`.
+2. **MCP / Agent Bridge tool** — add `faro_diff` alongside the existing
+   `faro_*` tools (`src-tauri/src/bridge.rs`), so an AI agent can call
+   "diff these two trees" and get structured results to act on (e.g. "sync the
+   3 files that differ"). This is the piece you asked for — diff available to
+   the MCP.
+3. **GUI** — a diff view built from `packages/file-ui`: two trees side by side,
+   rows colour-coded (only-in-A, only-in-B, differ, same), filters, and
+   per-row actions (copy A→B / B→A, reuse the transfer engine). Opens from a
+   "Compare with…" action or as a workspace tab.
+
+## Phases
+1. `diff.rs` engine (symmetric classification, optional hash).
+2. `faro-cli diff` + `--json` (fastest to ship, unlocks remote↔remote in the
+   terminal).
+3. `faro_diff` MCP/bridge tool.
+4. GUI two-tree diff view + copy-across actions.
+
+## Integration points
+`src-tauri/src/diff.rs` (new; reuse `sync.rs::walk`, `RemoteFs`, exec-hash on
+SSH/agent), `faro-cli/src/main.rs` (new `Diff` subcommand), `src-tauri/src/bridge.rs`
+(register `faro_diff`), `packages/file-ui` (diff view) + `src/lib/ipc.ts`.
+
+## Risks
+- Cost of hashing large trees — make `--hash` opt-in; prefer server-side hashing.
+- Object-store "directories" are prefixes — normalize paths before comparing.
+- Symlinks skipped (as today) — note in output.
+
+## Verification
+`cargo check` + `tsc`; `faro-cli diff` local↔remote and **remote↔remote** (two
+profiles) with/without `--hash`; the `faro_diff` tool returns structured output
+to the bridge; GUI colour-coding + copy-across match the CLI result.

--- a/docs/plans/7_fleet-search.md
+++ b/docs/plans/7_fleet-search.md
@@ -1,4 +1,4 @@
-# Plan 8 — Fleet Search (name + content, any backend)
+# Plan 7 — Fleet Search (name + content, any backend)
 
 ## Context
 

--- a/docs/plans/8_fleet-search.md
+++ b/docs/plans/8_fleet-search.md
@@ -1,0 +1,60 @@
+# Plan 8 — Fleet Search (name + content, any backend)
+
+## Context
+
+Spotlight/Everything for a connection: instant **filename** search and
+**content grep** across a remote tree — on servers, buckets, agents, or local.
+The differentiator vs desktop search tools is the same as Disk Usage: it works
+over `RemoteFs`, with an exec fast path that makes it genuinely fast on servers.
+
+## Approach
+
+### Search engine — `src-tauri/src/search.rs`
+Two query kinds: **name** (glob/substring) and **content** (regex/literal grep).
+Strategy picked by capability (fastest first):
+
+1. **Exec fast path (SSH / agent)** — one command instead of a walk:
+   `rg --json <pattern> <path>` (ripgrep, if present) or
+   `grep -rn` / `find -name`. Parse to structured hits. `has_shell` (SSH) or an
+   exec-allowed Faro Agent. This is what makes content search on a big server
+   usable.
+2. **Object stores** — name search over a flat key listing (S3/Azure); content
+   search requires fetching objects (cap + warn), so default to name-only unless
+   the user opts in.
+3. **Generic walk fallback** — `RemoteFs::list_dir` for names; for content,
+   stream-read candidate files and match client-side (bounded concurrency + size
+   cap). Always available.
+
+Streams hits with progress + cancel (mirror the `diskscan`/scan-manager pattern:
+`Arc` in `AppState`, `search://hit`/`search://done` events, abort handle).
+
+### Surfaces
+- **GUI** — a search panel/tab: query box (name | content toggle, regex, case,
+  include/exclude globs), streaming results grouped by file with line previews,
+  click-to-open in the browser or (content hit) jump to the line.
+- **CLI** — `faro-cli search <profile:path> <pattern> [--content] [--json]`.
+- **MCP** — a `faro_search` bridge tool so the AI can locate files/log lines.
+
+## Phases
+1. Engine + generic walk (names) + client-side content match.
+2. Exec fast path (`rg`/`grep`/`find`) for SSH + agent.
+3. GUI search panel (streaming, previews, jump-to-line).
+4. CLI + `faro_search` MCP tool.
+
+## Integration points
+`src-tauri/src/search.rs` (new), `src-tauri/src/lib.rs` (commands + events),
+reuse `RemoteFs`, `Capabilities.has_shell`, the SSH exec channel, the Agent
+`Exec` request, `ObjectFs` listing; `packages/file-ui` search panel;
+`faro-cli/src/main.rs`; `src-tauri/src/bridge.rs` (`faro_search`).
+
+## Risks
+- Content search over SFTP/object = many reads → keep exec the default on SSH,
+  cap + warn on the fallback, always cancellable.
+- ripgrep may be absent → probe, fall back to `grep`/`find`, then the walk.
+- Huge result sets → stream + virtualize the list, cap with a visible notice.
+
+## Verification
+`cargo check` + `tsc`; name + content search on: a local folder (walk), an SSH
+server (confirm `rg`/`grep` fires and matches a manual run), the phone agent,
+and an S3 bucket (name-only default). Progress streams; cancel works; CLI
+`--json` and the `faro_search` tool return structured hits.

--- a/docs/plans/8_fleet-skills.md
+++ b/docs/plans/8_fleet-skills.md
@@ -1,4 +1,4 @@
-# Plan 9 — Fleet Skills (AI-authored, MCP-native automations)
+# Plan 8 — Fleet Skills (AI-authored, MCP-native automations)
 
 ## Context
 

--- a/docs/plans/9_fleet-skills.md
+++ b/docs/plans/9_fleet-skills.md
@@ -1,0 +1,75 @@
+# Plan 9 — Fleet Skills (AI-authored, MCP-native automations)
+
+## Context
+
+Reshape of "multi-server command runner." Instead of static saved snippets, the
+angle is **reusable Skills the AI can compose, save, and run across the fleet
+through MCP** — the same idea as Claude Code / MCP skills, but for server ops.
+"Restart the web tier", "rotate logs everywhere", "audit for world-writable
+files" become named, parameterized, multi-step Skills an agent can invoke on one
+server or many.
+
+This builds directly on primitives that already exist: the Agent Bridge already
+has **saved commands** (`bridge_save_command` / `bridge_list_commands` /
+`bridge_delete_command`) and MCP registration (`bridge_register_mcp`), plus the
+`faro_exec` tool over any connected server. A Skill is the next abstraction up.
+
+## What a Skill is
+
+A named, parameterized workflow: `{ name, description, params[], steps[],
+targets (session selector), policy }`. Steps are `faro_exec` / file ops /
+conditionals over `${params}`. Crucially it's **MCP-native**: each Skill is
+exposed to the AI as a callable tool (`skill:<name>`), so the agent can *author*
+a Skill (compose + save it via a `faro_save_skill` tool) and later *invoke* it —
+the "MCPs create skills" angle.
+
+## Approach
+- **Storage** — extend the bridge's saved-commands store into a Skills store
+  (`src-tauri/src/bridge.rs`), JSON under the app data dir. Migrate existing
+  saved commands into single-step Skills.
+- **Runner** — execute a Skill across a `targets` selector (one server / a group
+  / all connected), fanning `faro_exec` out with bounded concurrency and
+  aggregating output per target. Reuse the Agent Bridge's exec + approval path.
+- **MCP surface** — `faro_list_skills`, `faro_run_skill(name, params, targets)`,
+  and `faro_save_skill(def)` bridge tools, so an agent can list, run, and
+  **create** Skills. Each saved Skill also surfaces as its own `skill:<name>`
+  tool for direct invocation.
+- **CLI** — `faro-cli skill run <name> [--target ...] [--param k=v]` and
+  `faro-cli skill list`.
+- **GUI** — a Skills panel: browse/edit Skills, pick targets, dry-run, run,
+  watch aggregated output. Author-by-hand as well as author-by-AI.
+
+## Safety (non-negotiable for fleet exec)
+- Every step is policy-gated (the daemon/bridge exec policy already exists);
+  a Skill can't exceed a target's allowed actions.
+- **Dry-run** mode (show the resolved commands per target without running).
+- Explicit confirm before a multi-target run; per-target success/fail summary.
+- Full audit log (the bridge already logs activity — extend per Skill run).
+- AI-authored Skills are saved as **proposals** requiring one human approval
+  before they're runnable, so the agent can't self-grant a destructive workflow.
+
+## Phases
+1. Skills store + runner (single target), migrate saved commands.
+2. Multi-target fan-out + aggregation + dry-run + audit.
+3. MCP tools (`list`/`run`/`save_skill` + per-Skill `skill:<name>` tools).
+4. GUI Skills panel; CLI `skill` subcommands.
+
+## Integration points
+`src-tauri/src/bridge.rs` (Skills store, runner, MCP tools — builds on the
+existing saved-commands + `faro_exec` + approval machinery), `src-tauri/src/lib.rs`
+(commands), `faro-cli/src/main.rs` (`skill` subcommand), a GUI Skills panel +
+`src/lib/ipc.ts`.
+
+## Risks
+- Fleet exec is inherently dangerous → dry-run, approval-gated AI authoring,
+  policy caps, and audit are requirements, not extras.
+- Partial failure across targets → clear per-target reporting, no silent
+  "mostly worked."
+- Scope creep toward a full orchestration engine → keep Skills linear + simple;
+  defer branching/looping unless needed.
+
+## Verification
+`cargo check` + `tsc`; author a Skill by hand and via the AI (save-as-proposal →
+approve); dry-run then run across two connected servers with aggregated output;
+confirm policy denial on a read-only target; audit entries present; CLI + MCP
+tools list/run/save correctly.

--- a/docs/plans/9_on-demand-virtual-folders.md
+++ b/docs/plans/9_on-demand-virtual-folders.md
@@ -1,4 +1,4 @@
-# Plan 4 — On-demand virtual folders (Plan 2, Phase 3)
+# Plan 9 — On-demand virtual folders (Plan 2, Phase 3)
 
 ## Status: DESIGNED, NOT BUILT
 

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -40,7 +40,7 @@ thematic detail.
 | 2 | `2_continuous-folder-sync` | 🔄 Phases 1–2 + safety merged; runtime test left | The shipped sync engine. |
 | 3 | `3_scan-index-foundation` | ✅ built (runtime test on a live backend left) | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
 | 4 | `4_disk-usage-explorer` | ✅ built (GUI click-through on a live backend left) | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
-| 5 | `5_additional-backends` | 🔄 Phases 0–2 + 4 shipped (S3 presets, GCS, WebDAV, HTTP) | More `RemoteFs` impls. Remaining: SMB (blocked on MSVC/libsmbclient), OAuth clouds. |
+| 5 | `5_additional-backends` | 🔄 Phases 0–2, 4 + OAuth infra & Dropbox shipped | More `RemoteFs` impls. Remaining: SMB (blocked on MSVC/libsmbclient), OneDrive/Drive/Box. |
 | 6 | `6_directory-diff` | ⬜ | Reuses #3's scan engine (two trees) + `change_signal`/`etag`. |
 | 7 | `7_fleet-search` | ⬜ | Reuses #3's scan engine; later a `faro.db` filename index. |
 | 8 | `8_fleet-skills` | ⬜ | AI-authored fleet automations over the bridge. Independent. |
@@ -118,8 +118,10 @@ transfer / sync for free.
 - ✅ **Phase 4** — read-only HTTP(S) source: nginx/Apache autoindex browse +
   nginx JSON + direct-URL mode, streaming GET reads, mutations refused. Verified
   against `python -m http.server`. *Shipped.*
-- ⬜ **Phase 5** — OAuth clouds, easiest API first: Dropbox → OneDrive → Drive →
-  Box. Hardest (OAuth + ID-vs-path for Drive/Box).
+- 🔄 **Phase 5** — OAuth clouds. Shared `oauth.rs` (loopback+PKCE, keychain) +
+  **Dropbox shipped** (needs a maintainer-registered app key to go live;
+  verified against a mock). Remaining: OneDrive → Drive → Box (reuse `oauth.rs`;
+  Drive/Box add an ID↔path resolver).
 
 ## Track C — On-demand virtual folders (Plan 9)
 

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -118,6 +118,34 @@ actually fast at scale.
   + the Canvas treemap tab and size list. ⬜ Phase 3 — `du`/`find` + flat-listing
   fast paths. ⬜ Phase 4 — delete/reveal actions + polish.
 
+## Track G — Directory Diff (Plan 7)
+Meld/Beyond Compare for any two backends (incl. remote↔remote), surfaced in the
+**GUI, `faro-cli`, and as an MCP `faro_diff` tool**. Reuses `sync.rs`'s diff. ⬜
+
+## Track H — Fleet Search (Plan 8)
+Name + content search across any connection; exec `rg`/`grep` fast path on
+SSH/agent, walk fallback. GUI + CLI + `faro_search` MCP tool. ⬜
+
+## Track I — Fleet Skills (Plan 9)
+Reusable, parameterized, **AI-authorable** automations over the fleet, MCP-native
+(the AI composes/saves Skills, then runs them across servers). Builds on the
+bridge's existing saved-commands + `faro_exec` + approvals. Safety-gated. ⬜
+
+## Track J — Scoped connection sharing (Plan 10)
+Share a box read-only / path-jailed / time-boxed **without a login system**, by
+extending the agent's pairing + policy + revocation with scope + expiry. A
+browser-served Faro (code-server-style) is the deferred, login-requiring 10b. ⬜
+
+## Near-term quick wins (small, high-value)
+- **Editable permissions dialog** — today Properties *shows* mode read-only; add
+  a FileZilla-style chmod editor (rwx checkboxes + octal). Backend (`chmod_path`,
+  `can_chmod`) already exists. Also the visual foundation for idea #10
+  (permissions/security view).
+- **CLI conflict policy** — expose `--overwrite` / `--on-conflict
+  overwrite|skip|rename` on `faro-cli` single-file `upload`/`download`/`cp`
+  (only `upload-dir` has it today; default is rename). Backend `OverwritePolicy`
+  already supports all three.
+
 ## Recommended global sequence
 
 1. **Track A safety hardening + runtime test** — finish making the shipped sync

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -40,7 +40,7 @@ thematic detail.
 | 2 | `2_continuous-folder-sync` | 🔄 Phases 1–2 + safety merged; runtime test left | The shipped sync engine. |
 | 3 | `3_scan-index-foundation` | ✅ built (runtime test on a live backend left) | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
 | 4 | `4_disk-usage-explorer` | ✅ built (GUI click-through on a live backend left) | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
-| 5 | `5_additional-backends` | 🔄 Phases 0–2, 4 + OAuth infra & Dropbox shipped | More `RemoteFs` impls. Remaining: SMB (blocked on MSVC/libsmbclient), OneDrive/Drive/Box. |
+| 5 | `5_additional-backends` | 🔄 Phases 0–2, 4, 5 shipped (S3/GCS/WebDAV/HTTP + all 4 OAuth clouds) | Only SMB (Phase 3) remains — blocked on MSVC/libsmbclient. |
 | 6 | `6_directory-diff` | ⬜ | Reuses #3's scan engine (two trees) + `change_signal`/`etag`. |
 | 7 | `7_fleet-search` | ⬜ | Reuses #3's scan engine; later a `faro.db` filename index. |
 | 8 | `8_fleet-skills` | ⬜ | AI-authored fleet automations over the bridge. Independent. |
@@ -118,10 +118,11 @@ transfer / sync for free.
 - ✅ **Phase 4** — read-only HTTP(S) source: nginx/Apache autoindex browse +
   nginx JSON + direct-URL mode, streaming GET reads, mutations refused. Verified
   against `python -m http.server`. *Shipped.*
-- 🔄 **Phase 5** — OAuth clouds. Shared `oauth.rs` (loopback+PKCE, keychain) +
-  **Dropbox shipped** (needs a maintainer-registered app key to go live;
-  verified against a mock). Remaining: OneDrive → Drive → Box (reuse `oauth.rs`;
-  Drive/Box add an ID↔path resolver).
+- ✅ **Phase 5** — OAuth clouds: shared `oauth.rs` (loopback+PKCE, keychain) +
+  **Dropbox, OneDrive, Google Drive, and Box all shipped** (Drive/Box add an
+  ID↔path resolver). Each verified end-to-end against a local mock; going live
+  needs a maintainer-registered app client id per provider. Follow-ups: chunked
+  upload for Dropbox/Drive/Box, and a delta-cursor capability. *Shipped.*
 
 ## Track C — On-demand virtual folders (Plan 9)
 

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -39,7 +39,7 @@ thematic detail.
 | 1 | `1_faro-agent-pairing-and-distribution` | ✅ shipped | The agent — foundation everything else leans on. |
 | 2 | `2_continuous-folder-sync` | 🔄 Phases 1–2 + safety merged; runtime test left | The shipped sync engine. |
 | 3 | `3_scan-index-foundation` | ✅ built (runtime test on a live backend left) | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
-| 4 | `4_disk-usage-explorer` | ⬜ **next** | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
+| 4 | `4_disk-usage-explorer` | ✅ built (GUI click-through on a live backend left) | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
 | 5 | `5_additional-backends` | ⬜ | More `RemoteFs` impls (S3 presets → GCS → WebDAV → SMB → OAuth clouds). Independent; can slot anywhere. |
 | 6 | `6_directory-diff` | ⬜ | Reuses #3's scan engine (two trees) + `change_signal`/`etag`. |
 | 7 | `7_fleet-search` | ⬜ | Reuses #3's scan engine; later a `faro.db` filename index. |
@@ -172,11 +172,17 @@ differentiator vs the desktop tools: it works on **remote servers and buckets**,
 with a shell `du` fast path (SSH/Agent) and object-store flat listing so it's
 actually fast at scale.
 
-- ⬜ **Phase 1–2** — the Canvas treemap tab and size list on top of the
-  **Track A2 scan engine** (the walk + `du`/flat-listing strategies live there).
-  ⬜ Phase 3 — wire the exec `du`/`find` + object flat-listing fast paths.
-  ⬜ Phase 4 — delete/reveal actions + `faro.db` "remember last scan per
-  connection" + polish.
+- ✅ **Phase 1–2** — a Canvas treemap + size-ranked list on top of the
+  **Track A2 scan engine**, opening as a full-screen explorer overlay from the
+  file-browser toolbar / a directory's context menu.
+  ✅ Phase 3 — exec `find -printf` fast path (SSH + Faro Agent, exec-gated,
+  falls back to the walk) + object-store flat listing; the chosen strategy shows
+  as a header badge with a fallback note.
+  ✅ Phase 4 — reveal / copy-path / delete (live tree prune) from the map +
+  colour-by type/depth + rescan. "Remember last scan per connection" deferred
+  (the entry point always carries the current dir — no `faro.db` table yet).
+  ⬜ Remaining: GUI click-through on a live SSH/S3/agent backend (core scan
+  verified at runtime against a real filesystem; app boots clean).
 
 **Built on Track A2** (scan engine + `faro.db`). This is the first *visible*
 consumer of the foundation and it's read-only, so it's the lowest-risk way to

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -38,8 +38,8 @@ thematic detail.
 |---|-----------|--------|----------|
 | 1 | `1_faro-agent-pairing-and-distribution` | ✅ shipped | The agent — foundation everything else leans on. |
 | 2 | `2_continuous-folder-sync` | 🔄 Phases 1–2 + safety merged; runtime test left | The shipped sync engine. |
-| 3 | `3_scan-index-foundation` | ⬜ **next** | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
-| 4 | `4_disk-usage-explorer` | ⬜ | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
+| 3 | `3_scan-index-foundation` | ✅ built (runtime test on a live backend left) | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
+| 4 | `4_disk-usage-explorer` | ⬜ **next** | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
 | 5 | `5_additional-backends` | ⬜ | More `RemoteFs` impls (S3 presets → WebDAV → SMB → …). Independent; can slot anywhere. |
 | 6 | `6_directory-diff` | ⬜ | Reuses #3's scan engine (two trees) + `change_signal`/`etag`. |
 | 7 | `7_fleet-search` | ⬜ | Reuses #3's scan engine; later a `faro.db` filename index. |
@@ -83,10 +83,15 @@ consumer is the folder-sync **state index** (`sync_state`) — same-size-edit
 detection, remote-delete vs never-existed, resume-without-re-upload, and the
 prerequisite for bidirectional.
 
-- ⬜ **Phase 1** — `faro.db` + migrations in `AppState`.
-- ⬜ **Phase 2** — extract `sync.rs::walk` → `scan.rs` (the poller switches to it).
-- ⬜ **Phase 3** — `change_signal` + `etag` across all backends.
-- ⬜ **Phase 4** — state index live in the reconciler.
+- ✅ **Phase 1** — `faro.db` + migrations in `AppState` (`db.rs`, rusqlite bundled).
+- ✅ **Phase 2** — extract `sync.rs::walk` → `scan.rs`, bounded-concurrency, with
+  progress/cancel hooks; `sync::plan` calls it.
+- ✅ **Phase 3** — `change_signal` + `etag` across all backends (object stores
+  report ETag; SFTP/FTP/local/agent report mtime+size).
+- ✅ **Phase 4** — `sync_state` index live in the reconciler: `sync::plan_indexed`
+  catches same-size edits (`SyncReason::Edited`), snapshots the source after each
+  pass (seed + prune), resume is a no-op. Verified via a real-Db + real-files
+  test; a live-backend runtime pass (phone agent / S3) is the remaining check.
 
 Disk Usage (Track F), Diff (Track G), and Search (Track H) build on this — the
 scan engine and `faro.db` become additive callers + tables, not new subsystems.

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -40,7 +40,7 @@ thematic detail.
 | 2 | `2_continuous-folder-sync` | 🔄 Phases 1–2 + safety merged; runtime test left | The shipped sync engine. |
 | 3 | `3_scan-index-foundation` | ✅ built (runtime test on a live backend left) | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
 | 4 | `4_disk-usage-explorer` | ✅ built (GUI click-through on a live backend left) | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
-| 5 | `5_additional-backends` | ⬜ | More `RemoteFs` impls (S3 presets → GCS → WebDAV → SMB → OAuth clouds). Independent; can slot anywhere. |
+| 5 | `5_additional-backends` | 🔄 Phases 0–2 shipped (S3 presets, GCS, WebDAV) | More `RemoteFs` impls. Remaining: SMB (blocked on MSVC/libsmbclient), read-only HTTP, OAuth clouds. |
 | 6 | `6_directory-diff` | ⬜ | Reuses #3's scan engine (two trees) + `change_signal`/`etag`. |
 | 7 | `7_fleet-search` | ⬜ | Reuses #3's scan engine; later a `faro.db` filename index. |
 | 8 | `8_fleet-skills` | ⬜ | AI-authored fleet automations over the bridge. Independent. |
@@ -103,14 +103,18 @@ transfer / sync for free.
 
 - ✅ Already present (pre-existing): SFTP, FTP/FTPS, S3, **Azure Blob** (via
   `object_store`), Faro Agent, local.
-- 🔄 **Phase 0** — S3-compatible presets: AWS/R2/B2 shipped; Wasabi, MinIO,
-  Spaces, Storj, Hetzner + long tail remain. ~No backend code. *Cheapest win.*
-- ⬜ **Phase 1** — native GCS: `object_store` `gcp` feature, same one-builder
-  move that shipped Azure. Nearly free.
-- ⬜ **Phase 2** — WebDAV (Nextcloud/ownCloud/Storage Box/generic). Low effort,
-  high coverage.
+- ✅ **Phase 0** — S3-compatible presets: AWS/R2/B2 + Wasabi, DO Spaces, MinIO,
+  Storj, Hetzner, Scaleway, Oracle OCI, IBM COS, Supabase, and a generic
+  self-hosted preset. No backend code. *Shipped.*
+- ✅ **Phase 1** — native GCS: `object_store` `gcp` feature + one builder, same
+  one-builder move that shipped Azure. *Shipped.*
+- ✅ **Phase 2** — WebDAV (Nextcloud/ownCloud/Storage Box/generic): new
+  `RemoteFs` impl, PROPFIND/GET/PUT/DELETE/MKCOL/MOVE, ETag change signal.
+  Verified against a live wsgidav server. *Shipped.*
 - ⬜ **Phase 3** — SMB/CIFS (NAS/Windows shares; Azure Files for free). Biggest
-  single gap. NFS as stretch.
+  single gap. **Blocked on the Windows dev box:** `pavao` links libsmbclient
+  (Samba C lib, no MSVC build) and the pure-Rust `smb` crate is still immature —
+  re-evaluate at build time, and it needs a live NAS to verify. NFS as stretch.
 - ⬜ **Phase 4** — read-only HTTP(S) source (autoindex browse + direct URL).
   Optional mini-phase.
 - ⬜ **Phase 5** — OAuth clouds, easiest API first: Dropbox → OneDrive → Drive →

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -28,6 +28,31 @@ one (`faro://` deep-link prefill; ServerKit does this).
 
 ---
 
+## Plan build order (the file numbers ARE the order)
+
+Read this instead of the roadmap if you just want "what's next." The plan files
+are numbered in the order to build them; the Track sections below are the
+thematic detail.
+
+| # | Plan file | Status | Why here |
+|---|-----------|--------|----------|
+| 1 | `1_faro-agent-pairing-and-distribution` | ✅ shipped | The agent — foundation everything else leans on. |
+| 2 | `2_continuous-folder-sync` | 🔄 Phases 1–2 + safety merged; runtime test left | The shipped sync engine. |
+| 3 | `3_scan-index-foundation` | ⬜ **next** | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
+| 4 | `4_disk-usage-explorer` | ⬜ | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
+| 5 | `5_additional-backends` | ⬜ | More `RemoteFs` impls (S3 presets → WebDAV → SMB → …). Independent; can slot anywhere. |
+| 6 | `6_directory-diff` | ⬜ | Reuses #3's scan engine (two trees) + `change_signal`/`etag`. |
+| 7 | `7_fleet-search` | ⬜ | Reuses #3's scan engine; later a `faro.db` filename index. |
+| 8 | `8_fleet-skills` | ⬜ | AI-authored fleet automations over the bridge. Independent. |
+| 9 | `9_on-demand-virtual-folders` | ⬜ | OneDrive-style placeholders (Plan 2 Phase 3). Large, per-OS, Windows-first. |
+| 10 | `10_iconify-brand-icons` | ⬜ | Additive brand/protocol logos. Independent polish; do whenever. |
+| 11 | `11_scoped-connection-sharing` | 🅿️ deferred | Blocked on a login/auth foundation. |
+
+Cross-project **Track D** (ServerKit ↔ Faro) has no plan file — it's a
+convergence effort tracked only in the Track section below.
+
+---
+
 ## Track A — Folder sync (Plan 2)
 
 Continuous "attach a local folder, keep it mirrored" for any backend.
@@ -35,16 +60,38 @@ Continuous "attach a local folder, keep it mirrored" for any backend.
 - ✅ **Phase 1–2** — continuous one-way sync (both directions), watcher + poll
   reconciler reusing `sync::plan` + `execute_sync_plan`, Additive/Mirror,
   Settings panel + status pill. *Merged.*
-- ⬜ **Safety hardening** *(next — small, high value)*: exclude patterns +
-  Mirror-delete guard. Makes the shipped feature safe to rely on.
+- ✅ **Safety hardening** — exclude patterns + Mirror-delete guard. *Merged
+  (`feat/foldersync-safety`).*
 - ⬜ **Runtime verification**: drive a live sync (easiest: to a paired phone
   agent). Currently compile/type-verified only.
-- ⬜ **Persistent state index + `change_signal` capability**: same-size-edit
-  detection, incremental scans, and the foundation for bidirectional.
-- ⬜ **Phase 3 → Plan 4** (on-demand placeholders) — see Track C.
-- ⬜ **Bidirectional + conflict resolution** — needs the index; own effort.
+- ⬜ **Bidirectional + conflict resolution** — needs the state index (Track A2);
+  own effort.
+- ⬜ **Phase 3 → Plan 9** (on-demand placeholders) — see Track C.
 
-## Track B — More connection backends (Plan 3)
+The persistent state index + `change_signal` were **cut out of Plan 2 into
+[Plan 3](3_scan-index-foundation.md) (Track A2)** — they're shared with disk
+usage, diff, and search, not sync-private.
+
+## Track A2 — Shared scan + index foundation (Plan 3)
+
+The primitives Plans 2, 6, 7, and 8 all quietly need, extracted so they're built
+**once**: a reusable **scan engine** (bounded-concurrency `RemoteFs` walk with
+progress/cancel + generic / exec-fast-path / object-flat strategy selection) and
+a shared **`faro.db`** (SQLite via `rusqlite` bundled, in `AppState`, tables
+per-feature). Plus `Capabilities.change_signal` + `DirEntry.etag`. The first
+consumer is the folder-sync **state index** (`sync_state`) — same-size-edit
+detection, remote-delete vs never-existed, resume-without-re-upload, and the
+prerequisite for bidirectional.
+
+- ⬜ **Phase 1** — `faro.db` + migrations in `AppState`.
+- ⬜ **Phase 2** — extract `sync.rs::walk` → `scan.rs` (the poller switches to it).
+- ⬜ **Phase 3** — `change_signal` + `etag` across all backends.
+- ⬜ **Phase 4** — state index live in the reconciler.
+
+Disk Usage (Track F), Diff (Track G), and Search (Track H) build on this — the
+scan engine and `faro.db` become additive callers + tables, not new subsystems.
+
+## Track B — More connection backends (Plan 5)
 
 Widen the connection list; each is one `RemoteFs` impl and inherits browse /
 transfer / sync for free.
@@ -58,7 +105,7 @@ transfer / sync for free.
 - ⬜ **Phase 3** — native GCS (Azure already works).
 - ⬜ **Phase 4** — OAuth clouds (Drive/OneDrive/Dropbox). Hardest (OAuth + ID-vs-path).
 
-## Track C — On-demand virtual folders (Plan 4)
+## Track C — On-demand virtual folders (Plan 9)
 
 OneDrive-style placeholders: files show in the folder, download on open, free-up-
 space to evict. Native, per-OS, **Windows-first** (Cloud Filter API).
@@ -66,7 +113,7 @@ space to evict. Native, per-OS, **Windows-first** (Cloud Filter API).
 - ⬜ Windows provider (Cloud Filter API via the `windows` crate) — its own
   feature-flagged effort; reuses the Track A engine for listing + hydration.
 - ⬜ macOS File Provider extension, ⬜ Linux FUSE, or the WinFsp/FUSE virtual-mount
-  fallback. *Designed in Plan 4; not built.*
+  fallback. *Designed in Plan 9; not built.*
 
 ## Track D — ServerKit ↔ Faro convergence (cross-project, greenfield)
 
@@ -93,7 +140,7 @@ surface for those agents).
 
 ---
 
-## Track E — Brand & protocol logos (Plan 5)
+## Track E — Brand & protocol logos (Plan 10)
 
 Additive icon layer for recognizable brand marks (S3/Azure/SSH/WordPress) via
 Iconify, bundled offline. Deliberately does **not** touch the file-type icons
@@ -106,7 +153,7 @@ UI icons.
 - ⬜ Phase 3 — tech badges elsewhere. ⬜ Phase 4 — (deferred) evaluate
   consolidating lucide UI icons onto Iconify.
 
-## Track F — Disk Usage Explorer (Plan 6)
+## Track F — Disk Usage Explorer (Plan 4)
 
 A WinDirStat/WizTree-style treemap + size-ranked tree, but over **any** backend
 (SFTP/S3/FTP/Agent/local) — opens as a workspace tab like the SSH terminal. The
@@ -114,24 +161,33 @@ differentiator vs the desktop tools: it works on **remote servers and buckets**,
 with a shell `du` fast path (SSH/Agent) and object-store flat listing so it's
 actually fast at scale.
 
-- ⬜ **Phase 1–2** — cross-backend scan engine (RemoteFs walk, progress/cancel)
-  + the Canvas treemap tab and size list. ⬜ Phase 3 — `du`/`find` + flat-listing
-  fast paths. ⬜ Phase 4 — delete/reveal actions + polish.
+- ⬜ **Phase 1–2** — the Canvas treemap tab and size list on top of the
+  **Track A2 scan engine** (the walk + `du`/flat-listing strategies live there).
+  ⬜ Phase 3 — wire the exec `du`/`find` + object flat-listing fast paths.
+  ⬜ Phase 4 — delete/reveal actions + `faro.db` "remember last scan per
+  connection" + polish.
 
-## Track G — Directory Diff (Plan 7)
+**Built on Track A2** (scan engine + `faro.db`). This is the first *visible*
+consumer of the foundation and it's read-only, so it's the lowest-risk way to
+prove the walk / exec / object-flat strategies on real backends.
+
+## Track G — Directory Diff (Plan 6)
 Meld/Beyond Compare for any two backends (incl. remote↔remote), surfaced in the
-**GUI, `faro-cli`, and as an MCP `faro_diff` tool**. Reuses `sync.rs`'s diff. ⬜
+**GUI, `faro-cli`, and as an MCP `faro_diff` tool**. Reuses `sync.rs`'s diff +
+the **Track A2** scan engine (walks two trees) and its `change_signal`/`etag`
+for `--hash` mode. ⬜
 
-## Track H — Fleet Search (Plan 8)
+## Track H — Fleet Search (Plan 7)
 Name + content search across any connection; exec `rg`/`grep` fast path on
-SSH/agent, walk fallback. GUI + CLI + `faro_search` MCP tool. ⬜
+SSH/agent, walk fallback. Reuses the **Track A2** scan engine (and, later, a
+`faro.db` filename index). GUI + CLI + `faro_search` MCP tool. ⬜
 
-## Track I — Fleet Skills (Plan 9)
+## Track I — Fleet Skills (Plan 8)
 Reusable, parameterized, **AI-authorable** automations over the fleet, MCP-native
 (the AI composes/saves Skills, then runs them across servers). Builds on the
 bridge's existing saved-commands + `faro_exec` + approvals. Safety-gated. ⬜
 
-## Track J — Scoped connection sharing (Plan 10) — DEFERRED
+## Track J — Scoped connection sharing (Plan 11) — DEFERRED
 Share a box read-only / path-jailed / time-boxed. **Parked until a login/auth
 foundation exists** — the real use case (remote employee, link-based) needs auth
 regardless, so we hold the whole track rather than ship the LAN-only half. The
@@ -149,14 +205,32 @@ scoped-grant model remains the permission backbone once login lands. 🅿️
 
 ## Recommended global sequence
 
-1. **Track A safety hardening + runtime test** — finish making the shipped sync
-   trustworthy. (Small.)
-2. **Track B Phase 0/1/2** — S3 presets + WebDAV + SMB. Biggest coverage gain,
-   no OAuth, all fit the trait.
-3. **Track A state index** — robustness + unlocks bidirectional.
-4. **Track D option (b)** — ServerKit installs `faro-agentd` as a managed
-   service; cheap, high leverage, and every server becomes syncable via Track A.
-5. **Track C Windows on-demand** and **Track B Phase 4 OAuth clouds** — the two
+The plan **file numbers now follow this execution order** (see the build-order
+index at the top). The Track sections above are a *thematic* map — their letters
+are stable labels, so a Track's `(Plan N)` no longer matches its position in the
+alphabet. This list is the order to actually build in; the numbered files are its
+mirror.
+
+1. **Track A — runtime test.** Safety hardening is merged; drive a live sync
+   (paired phone agent) so the shipped feature is trustworthy. (Small.)
+2. **Track A2 — scan engine + `faro.db`.** Build the shared foundation: extract
+   the walk into `scan.rs`, stand up SQLite in `AppState`, add
+   `change_signal`/`etag`. Nothing user-facing yet — it's the substrate for the
+   next three.
+3. **Track F — Disk Usage (Plan 4).** The first *visible* consumer of the scan
+   engine + DB, and read-only (zero risk to shipped sync). Proves the walk /
+   exec / object-flat strategies on real backends before the sync engine takes a
+   hard dependency on them. Best payoff-to-risk win on the board.
+4. **Track A2 — state index live.** Now layer the `sync_state` index into the
+   folder-sync reconciler on the foundation Disk Usage already exercised.
+   Robustness + unlocks bidirectional.
+5. **Track B Phase 0/1/2** — S3 presets + WebDAV + SMB. Biggest coverage gain,
+   no OAuth, all fit the trait. Independent of the DB — can interleave anywhere.
+6. **Tracks G + H — Diff + Search.** Same scan engine, new surfaces (GUI + CLI +
+   MCP `faro_diff` / `faro_search`).
+7. **Track D option (b)** — ServerKit installs `faro-agentd` as a managed
+   service; every server becomes syncable via Track A.
+8. **Track C Windows on-demand** and **Track B Phase 4 OAuth clouds** — the two
    large, later efforts.
 
 To execute any of these tracks end-to-end in a fresh session, use the local

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -93,6 +93,19 @@ surface for those agents).
 
 ---
 
+## Track E — Brand & protocol logos (Plan 5)
+
+Additive icon layer for recognizable brand marks (S3/Azure/SSH/WordPress) via
+Iconify, bundled offline. Deliberately does **not** touch the file-type icons
+(Material Icon Theme — more complete + has the extension mapping) or the lucide
+UI icons.
+
+- ✅ Files already use Material Icon Theme; UI uses lucide. *(shipped/present)*
+- ⬜ **Phase 1–2** — Iconify offline foundation + protocol logos on the rail,
+  connection list, and New-Connection picker (logo *plus* the colour monogram).
+- ⬜ Phase 3 — tech badges elsewhere. ⬜ Phase 4 — (deferred) evaluate
+  consolidating lucide UI icons onto Iconify.
+
 ## Recommended global sequence
 
 1. **Track A safety hardening + runtime test** — finish making the shipped sync

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -40,7 +40,7 @@ thematic detail.
 | 2 | `2_continuous-folder-sync` | 🔄 Phases 1–2 + safety merged; runtime test left | The shipped sync engine. |
 | 3 | `3_scan-index-foundation` | ✅ built (runtime test on a live backend left) | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
 | 4 | `4_disk-usage-explorer` | ✅ built (GUI click-through on a live backend left) | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
-| 5 | `5_additional-backends` | 🔄 Phases 0–2 shipped (S3 presets, GCS, WebDAV) | More `RemoteFs` impls. Remaining: SMB (blocked on MSVC/libsmbclient), read-only HTTP, OAuth clouds. |
+| 5 | `5_additional-backends` | 🔄 Phases 0–2 + 4 shipped (S3 presets, GCS, WebDAV, HTTP) | More `RemoteFs` impls. Remaining: SMB (blocked on MSVC/libsmbclient), OAuth clouds. |
 | 6 | `6_directory-diff` | ⬜ | Reuses #3's scan engine (two trees) + `change_signal`/`etag`. |
 | 7 | `7_fleet-search` | ⬜ | Reuses #3's scan engine; later a `faro.db` filename index. |
 | 8 | `8_fleet-skills` | ⬜ | AI-authored fleet automations over the bridge. Independent. |
@@ -115,8 +115,9 @@ transfer / sync for free.
   single gap. **Blocked on the Windows dev box:** `pavao` links libsmbclient
   (Samba C lib, no MSVC build) and the pure-Rust `smb` crate is still immature —
   re-evaluate at build time, and it needs a live NAS to verify. NFS as stretch.
-- ⬜ **Phase 4** — read-only HTTP(S) source (autoindex browse + direct URL).
-  Optional mini-phase.
+- ✅ **Phase 4** — read-only HTTP(S) source: nginx/Apache autoindex browse +
+  nginx JSON + direct-URL mode, streaming GET reads, mutations refused. Verified
+  against `python -m http.server`. *Shipped.*
 - ⬜ **Phase 5** — OAuth clouds, easiest API first: Dropbox → OneDrive → Drive →
   Box. Hardest (OAuth + ID-vs-path for Drive/Box).
 

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -106,6 +106,18 @@ UI icons.
 - ⬜ Phase 3 — tech badges elsewhere. ⬜ Phase 4 — (deferred) evaluate
   consolidating lucide UI icons onto Iconify.
 
+## Track F — Disk Usage Explorer (Plan 6)
+
+A WinDirStat/WizTree-style treemap + size-ranked tree, but over **any** backend
+(SFTP/S3/FTP/Agent/local) — opens as a workspace tab like the SSH terminal. The
+differentiator vs the desktop tools: it works on **remote servers and buckets**,
+with a shell `du` fast path (SSH/Agent) and object-store flat listing so it's
+actually fast at scale.
+
+- ⬜ **Phase 1–2** — cross-backend scan engine (RemoteFs walk, progress/cancel)
+  + the Canvas treemap tab and size list. ⬜ Phase 3 — `du`/`find` + flat-listing
+  fast paths. ⬜ Phase 4 — delete/reveal actions + polish.
+
 ## Recommended global sequence
 
 1. **Track A safety hardening + runtime test** — finish making the shipped sync

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -131,10 +131,11 @@ Reusable, parameterized, **AI-authorable** automations over the fleet, MCP-nativ
 (the AI composes/saves Skills, then runs them across servers). Builds on the
 bridge's existing saved-commands + `faro_exec` + approvals. Safety-gated. ⬜
 
-## Track J — Scoped connection sharing (Plan 10)
-Share a box read-only / path-jailed / time-boxed **without a login system**, by
-extending the agent's pairing + policy + revocation with scope + expiry. A
-browser-served Faro (code-server-style) is the deferred, login-requiring 10b. ⬜
+## Track J — Scoped connection sharing (Plan 10) — DEFERRED
+Share a box read-only / path-jailed / time-boxed. **Parked until a login/auth
+foundation exists** — the real use case (remote employee, link-based) needs auth
+regardless, so we hold the whole track rather than ship the LAN-only half. The
+scoped-grant model remains the permission backbone once login lands. 🅿️
 
 ## Near-term quick wins (small, high-value)
 - **Editable permissions dialog** — today Properties *shows* mode read-only; add

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -40,7 +40,7 @@ thematic detail.
 | 2 | `2_continuous-folder-sync` | 🔄 Phases 1–2 + safety merged; runtime test left | The shipped sync engine. |
 | 3 | `3_scan-index-foundation` | ✅ built (runtime test on a live backend left) | Shared scan engine + `faro.db`. Substrate for 4/6/7 and the sync state index. |
 | 4 | `4_disk-usage-explorer` | ⬜ **next** | First *visible*, read-only consumer of #3 — proves the foundation at low risk. |
-| 5 | `5_additional-backends` | ⬜ | More `RemoteFs` impls (S3 presets → WebDAV → SMB → …). Independent; can slot anywhere. |
+| 5 | `5_additional-backends` | ⬜ | More `RemoteFs` impls (S3 presets → GCS → WebDAV → SMB → OAuth clouds). Independent; can slot anywhere. |
 | 6 | `6_directory-diff` | ⬜ | Reuses #3's scan engine (two trees) + `change_signal`/`etag`. |
 | 7 | `7_fleet-search` | ⬜ | Reuses #3's scan engine; later a `faro.db` filename index. |
 | 8 | `8_fleet-skills` | ⬜ | AI-authored fleet automations over the bridge. Independent. |
@@ -103,12 +103,18 @@ transfer / sync for free.
 
 - ✅ Already present (pre-existing): SFTP, FTP/FTPS, S3, **Azure Blob** (via
   `object_store`), Faro Agent, local.
-- ⬜ **Phase 0** — S3-compatible presets (R2/B2/Wasabi/MinIO/Spaces): UI presets,
-  ~no backend code. *Cheapest win.*
-- ⬜ **Phase 1** — WebDAV (Nextcloud/ownCloud/generic). Low effort, high coverage.
-- ⬜ **Phase 2** — SMB/CIFS (NAS/Windows shares). Biggest single gap.
-- ⬜ **Phase 3** — native GCS (Azure already works).
-- ⬜ **Phase 4** — OAuth clouds (Drive/OneDrive/Dropbox). Hardest (OAuth + ID-vs-path).
+- 🔄 **Phase 0** — S3-compatible presets: AWS/R2/B2 shipped; Wasabi, MinIO,
+  Spaces, Storj, Hetzner + long tail remain. ~No backend code. *Cheapest win.*
+- ⬜ **Phase 1** — native GCS: `object_store` `gcp` feature, same one-builder
+  move that shipped Azure. Nearly free.
+- ⬜ **Phase 2** — WebDAV (Nextcloud/ownCloud/Storage Box/generic). Low effort,
+  high coverage.
+- ⬜ **Phase 3** — SMB/CIFS (NAS/Windows shares; Azure Files for free). Biggest
+  single gap. NFS as stretch.
+- ⬜ **Phase 4** — read-only HTTP(S) source (autoindex browse + direct URL).
+  Optional mini-phase.
+- ⬜ **Phase 5** — OAuth clouds, easiest API first: Dropbox → OneDrive → Drive →
+  Box. Hardest (OAuth + ID-vs-path for Drive/Box).
 
 ## Track C — On-demand virtual folders (Plan 9)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@xterm/xterm": "^5.5.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.456.0",
+        "material-icon-theme": "5.36.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.5.4",
@@ -2014,6 +2015,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chroma-js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
     "node_modules/chromium-bidi": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
@@ -2342,6 +2349,12 @@
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -2730,6 +2743,22 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/material-icon-theme": {
+      "version": "5.36.1",
+      "resolved": "https://registry.npmjs.org/material-icon-theme/-/material-icon-theme-5.36.1.tgz",
+      "integrity": "sha512-m61BOQlbzno5KrDMuSb2Z+SxPYXWrVSRZRo6YtmoboZjFdP+HMMAzl6fGlKZUkX7dDBV++eDXYOx5hAsr7derA==",
+      "license": "MIT",
+      "dependencies": {
+        "chroma-js": "^3.2.0",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "engines": {
+        "vscode": "^1.55.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/material-extensions"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@xterm/xterm": "^5.5.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.456.0",
+    "material-icon-theme": "5.36.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.4",

--- a/packages/file-ui/package.json
+++ b/packages/file-ui/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "lucide-react": "^0.456.0",
+    "material-icon-theme": "5.36.1",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {

--- a/packages/file-ui/src/components/FilePane.tsx
+++ b/packages/file-ui/src/components/FilePane.tsx
@@ -577,8 +577,9 @@ export function FilePane({
           label: "Analyze disk usage",
           icon: <PieChart size={12} />,
           onClick: () =>
+            sessionId &&
             fs
-              .analyzeDiskUsage!(sessionId!, single.path)
+              .analyzeDiskUsage!(sessionId, single.path)
               .catch((e) => setError(String(e))),
         });
       }

--- a/packages/file-ui/src/components/FilePane.tsx
+++ b/packages/file-ui/src/components/FilePane.tsx
@@ -14,6 +14,7 @@ import {
   ExternalLink,
   FileArchive,
   TerminalSquare,
+  PieChart,
   Info,
   Search,
   X,
@@ -569,6 +570,18 @@ export function FilePane({
               .catch((e) => setError(String(e))),
         });
       }
+      // Analyze disk usage under this folder (treemap + size breakdown). Works
+      // on every backend — no shell needed, the scan falls back to a walk.
+      if (single.kind === "directory" && fs.analyzeDiskUsage) {
+        items.push({
+          label: "Analyze disk usage",
+          icon: <PieChart size={12} />,
+          onClick: () =>
+            fs
+              .analyzeDiskUsage!(sessionId!, single.path)
+              .catch((e) => setError(String(e))),
+        });
+      }
       // Duplicate needs a server-side copy (cp over SSH) or local fs copy; object
       // stores / FTP can't, so hide it there.
       if (fs.duplicate && (sessionId === LOCAL_SESSION || caps?.hasShell)) {
@@ -813,6 +826,21 @@ export function FilePane({
             title="Upload files or a folder to this directory"
           >
             <Upload size={11} /> Upload
+          </button>
+        )}
+        {fs.analyzeDiskUsage && (
+          <button
+            onClick={() =>
+              sessionId &&
+              fs
+                .analyzeDiskUsage!(sessionId, path)
+                .catch((e) => setError(String(e)))
+            }
+            disabled={!sessionId}
+            className="rounded p-1 text-text-muted hover:bg-bg-hover hover:text-text disabled:opacity-40"
+            title="Analyze disk usage in this folder"
+          >
+            <PieChart size={13} />
           </button>
         )}
         {caps?.hasDirectories !== false && (

--- a/packages/file-ui/src/components/FilePane.tsx
+++ b/packages/file-ui/src/components/FilePane.tsx
@@ -43,6 +43,7 @@ import { usePathHistory } from "../hooks/usePathHistory";
 import { cn } from "../lib/cn";
 import { fmtSize, fmtMtime, formatMode } from "../lib/format";
 import { isImage, type FileIconSpec } from "../lib/fileIcons";
+import { materialIconUrl } from "../lib/materialIcons";
 import { ContextMenu, type MenuItem } from "./ContextMenu";
 import { PromptModal } from "./PromptModal";
 import { ConfirmModal } from "./ConfirmModal";
@@ -1256,12 +1257,28 @@ function Row({
     entry.kind === "file"
       ? "Double-click to transfer • Right-click for more"
       : "Double-click to open • Right-click for more";
-  const iconEl = <Icon size={13} className={cn("shrink-0", iconColor)} />;
+  // Prefer a Material Icon Theme SVG for known file types; fall back to the
+  // lucide glyph for folders, symlinks, and unmatched files.
+  const matUrl = entry.kind === "file" ? materialIconUrl(entry.name) : undefined;
+  const glyph = (size: number) =>
+    matUrl ? (
+      <img
+        src={matUrl}
+        width={size}
+        height={size}
+        alt=""
+        draggable={false}
+        className="shrink-0 select-none"
+      />
+    ) : (
+      <Icon size={size} className={cn("shrink-0", iconColor)} />
+    );
+  const iconEl = glyph(13);
   // Show a real image preview in the grid when the adapter can supply bytes.
   const canThumb = !!loadThumb && !!sessionId && isImage(entry);
 
   if (viewMode === "grid") {
-    const bigIcon = <Icon size={30} className={cn("shrink-0", iconColor)} />;
+    const bigIcon = glyph(30);
     return (
       <div
         data-idx={index}

--- a/packages/file-ui/src/context.tsx
+++ b/packages/file-ui/src/context.tsx
@@ -62,6 +62,12 @@ export interface FileSystemAdapter {
    * and the pane doesn't offer "Open terminal here". Remote sessions only.
    */
   openTerminal?(sessionId: SessionId, path: string): Promise<void>;
+  /**
+   * Optional: analyze disk usage under `path` (a WinDirStat-style treemap +
+   * size-ranked breakdown). Omit it and the pane doesn't offer the "Analyze
+   * disk usage" action.
+   */
+  analyzeDiskUsage?(sessionId: SessionId, path: string): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/file-ui/src/index.ts
+++ b/packages/file-ui/src/index.ts
@@ -31,6 +31,9 @@ export {
   type FileIconSpec,
 } from "./lib/fileIcons";
 
+// A Material Icon Theme SVG URL for a filename (folders/unknown → undefined).
+export { materialIconUrl } from "./lib/materialIcons";
+
 // Hooks + utils.
 export { usePathHistory } from "./hooks/usePathHistory";
 export { useDialog } from "./hooks/useDialog";

--- a/packages/file-ui/src/lib/fileIcons.tsx
+++ b/packages/file-ui/src/lib/fileIcons.tsx
@@ -12,6 +12,11 @@ import {
   FileType,
   Folder,
   Link2,
+  PenTool,
+  Layers,
+  Box,
+  Figma,
+  Frame,
   type LucideIcon,
 } from "lucide-react";
 import type { DirEntry } from "../types";
@@ -48,6 +53,12 @@ add(
 add(["html", "htm"], { Icon: FileCode, className: "text-orange-400" });
 add(["css", "scss", "sass", "less"], { Icon: FileCode, className: "text-blue-400" });
 add(["sql"], { Icon: FileCode, className: "text-fuchsia-400" });
+add(["hs", "clj", "cljs", "jl", "pl", "pm", "nim", "zig", "elm", "erl"], {
+  Icon: FileCode,
+  className: "text-teal-400",
+});
+add(["tf", "tfvars", "hcl"], { Icon: FileCode, className: "text-violet-400" }); // Terraform
+add(["gradle", "cmake", "make", "mk"], { Icon: FileCog, className: "text-text-dim" });
 
 // Shell / scripts
 add(["sh", "bash", "zsh", "fish", "ps1", "bat", "cmd"], {
@@ -69,6 +80,26 @@ const IMAGE_EXTS = [
 ];
 add(IMAGE_EXTS, { Icon: FileImage, className: "text-green-400" });
 const IMAGE_SET = new Set(IMAGE_EXTS);
+
+// Design / creative — distinct glyphs + brand-ish colours so a PSD doesn't look
+// like a JPG. Raster editors → Layers; vector/illustration → PenTool.
+add(["psd", "psb"], { Icon: Layers, className: "text-blue-400" }); // Photoshop
+add(["ai"], { Icon: PenTool, className: "text-orange-400" }); // Illustrator
+add(["eps", "ps"], { Icon: PenTool, className: "text-orange-300" });
+add(["indd", "idml"], { Icon: FileText, className: "text-rose-400" }); // InDesign
+add(["fig"], { Icon: Figma, className: "text-pink-400" }); // Figma
+add(["xd"], { Icon: Frame, className: "text-fuchsia-400" }); // Adobe XD
+add(["sketch"], { Icon: PenTool, className: "text-yellow-400" });
+add(["afphoto"], { Icon: Layers, className: "text-sky-400" }); // Affinity Photo
+add(["afdesign"], { Icon: PenTool, className: "text-violet-400" }); // Affinity Designer
+add(["cdr"], { Icon: PenTool, className: "text-lime-400" }); // CorelDRAW
+
+// 3D / CAD
+add(["blend"], { Icon: Box, className: "text-orange-400" }); // Blender
+add(["obj", "fbx", "gltf", "glb", "stl", "3ds", "dae", "usdz"], {
+  Icon: Box,
+  className: "text-cyan-400",
+});
 
 // Video
 add(["mp4", "mov", "mkv", "avi", "webm", "flv", "wmv", "m4v"], {

--- a/packages/file-ui/src/lib/materialIcons.ts
+++ b/packages/file-ui/src/lib/materialIcons.ts
@@ -1,0 +1,48 @@
+// Material Icon Theme integration — real per-file-type icons (the Photoshop
+// mark on a .psd, the Python logo on a .py, etc.), the same set VS Code file
+// managers use. MIT licensed (github.com/material-extensions/vscode-material-icon-theme).
+//
+// We import the prebuilt manifest for the extension/name → icon-name mapping and
+// bundle the SVGs as hashed asset URLs (built into the app — no network). Files
+// only; folders and symlinks keep the lucide glyphs so the tree still reads with
+// the accent colour. Anything unmatched falls back to the lucide map in
+// `fileIcons.tsx`.
+
+import manifest from "material-icon-theme/dist/material-icons.json";
+
+// Vite bundles each matched SVG and hands back its hashed URL. Absolute path
+// from the Vite root (repo root, where node_modules lives).
+const svgUrls = import.meta.glob(
+  "/node_modules/material-icon-theme/icons/*.svg",
+  { query: "?url", import: "default", eager: true }
+) as Record<string, string>;
+
+type StrMap = Record<string, string>;
+const fileNames = (manifest.fileNames ?? {}) as StrMap;
+const fileExtensions = (manifest.fileExtensions ?? {}) as StrMap;
+
+function urlForIconName(name: string | undefined): string | undefined {
+  if (!name) return undefined;
+  return svgUrls[`/node_modules/material-icon-theme/icons/${name}.svg`];
+}
+
+/**
+ * A bundled Material Icon Theme SVG URL for a file, or `undefined` to fall back
+ * to the lucide icon. Matches by exact filename first (e.g. `dockerfile`,
+ * `package.json`), then by the longest extension suffix (so `app.d.ts` beats
+ * `ts`), mirroring VS Code's resolution.
+ */
+export function materialIconUrl(name: string): string | undefined {
+  const lower = name.toLowerCase();
+
+  const byName = fileNames[lower];
+  if (byName) return urlForIconName(byName);
+
+  const parts = lower.split(".");
+  for (let i = 1; i < parts.length; i++) {
+    const ext = parts.slice(i).join(".");
+    const icon = fileExtensions[ext];
+    if (icon) return urlForIconName(icon);
+  }
+  return undefined;
+}

--- a/packages/file-ui/src/types.ts
+++ b/packages/file-ui/src/types.ts
@@ -11,6 +11,9 @@ export interface DirEntry {
   size: number;
   modified?: number; // unix seconds
   mode?: number; // posix mode bits when applicable
+  /** Backend's opaque change token (object stores expose an ETag). Absent for
+   *  backends that rely on mtime+size. A change *token*, not a content hash. */
+  etag?: string;
 }
 
 export interface Capabilities {
@@ -22,6 +25,9 @@ export interface Capabilities {
    *  terminal here". Optional so older adapters that omit it just don't get
    *  those actions. */
   hasShell?: boolean;
+  /** How this backend reports change — drives the sync index's staleness check.
+   *  Optional so older adapters that omit it default to mtime+size behaviour. */
+  changeSignal?: "mtimeSize" | "etag" | "hash";
 }
 
 // A session handle is opaque to the UI — it's whatever your adapter understands

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -44,6 +44,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,8 +1433,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "faro"
-version = "1.3.18"
+version = "1.3.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1437,6 +1461,7 @@ dependencies = [
  "object_store",
  "quick-xml 0.36.2",
  "reqwest 0.12.28",
+ "rusqlite",
  "russh",
  "russh-keys",
  "russh-sftp",
@@ -1460,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "faro-agent-proto"
-version = "1.3.18"
+version = "1.3.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1475,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "faro-agentd"
-version = "1.3.18"
+version = "1.3.19"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1493,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "faro-cli"
-version = "1.3.18"
+version = "1.3.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2138,6 +2163,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2153,6 +2181,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2836,6 +2873,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4335,6 +4383,20 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
  "mdns-sd",
  "notify",
  "object_store",
+ "percent-encoding",
  "quick-xml 0.36.2",
  "reqwest 0.12.28",
  "rusqlite",
@@ -1476,6 +1477,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3427,6 +3429,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest 0.12.28",
  "ring",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "snafu",
@@ -4585,6 +4588,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3018,6 +3018,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,6 +4296,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -6301,6 +6312,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1456,6 +1456,7 @@ dependencies = [
  "faro-agent-proto",
  "faro-agentd",
  "futures",
+ "keyring",
  "mdns-sd",
  "notify",
  "object_store",
@@ -2756,6 +2757,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +2902,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -3057,7 +3083,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4587,7 +4613,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -4739,6 +4765,19 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,9 +57,9 @@ mdns-sd = "0.11"
 # FTP / FTPS — sync API, driven from tokio via spawn_blocking.
 suppaftp = { version = "6", features = ["native-tls"] }
 
-# S3 / R2 / B2 — Apache Arrow's polymorphic object_store crate. v0.6 will reuse
-# this with the `azure` feature for Azure Blob.
-object_store = { version = "0.11", features = ["aws", "azure"] }
+# S3 / R2 / B2 — Apache Arrow's polymorphic object_store crate. The same crate
+# backs Azure Blob (`azure` feature) and native Google Cloud Storage (`gcp`).
+object_store = { version = "0.11", features = ["aws", "azure", "gcp"] }
 bytes = "1"
 
 # Importers — quick-xml for FileZilla's sitemanager.xml.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,12 @@ bytes = "1"
 # Importers — quick-xml for FileZilla's sitemanager.xml.
 quick-xml = "0.36"
 
+# Shared connection index (faro.db). The `bundled` feature compiles SQLite from
+# source so there's no system-SQLite dependency. One DB under app_data_dir holds
+# per-feature tables (sync_state today; scan_cache / search_index / diff_hash
+# later). See docs/plans/3_scan-index-foundation.md.
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # Misc
 anyhow = "1"
 thiserror = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -92,6 +92,11 @@ percent-encoding = "2"
 # uploads it back on every save.
 notify = "6"
 
+# OS keychain for OAuth tokens (Dropbox et al., Plan 5 Phase 5). Native backends
+# only (Windows Credential Manager / macOS Keychain / Linux keyutils) so there's
+# no dbus/secret-service build dependency.
+keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
+
 # Windows-only: registry access for the PuTTY sessions importer.
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -80,7 +80,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dirs = "5"
 sha2 = "0.10"
 base64 = "0.22"
-reqwest = { version = "0.12", features = ["json"] }
+# `stream` powers ranged/streamed WebDAV GET+PUT bodies (remotefs/webdav.rs).
+reqwest = { version = "0.12", features = ["json", "stream"] }
+# Wraps a tokio File as a Stream for streaming WebDAV PUT uploads.
+tokio-util = { version = "0.7", features = ["io"] }
+# Decode percent-encoded WebDAV PROPFIND href paths back into file names.
+percent-encoding = "2"
 
 # Filesystem watcher — powers the right-click "Edit with…" flow that
 # downloads a remote file to a tempfile, opens it in the user's editor, and

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -80,8 +80,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dirs = "5"
 sha2 = "0.10"
 base64 = "0.22"
-# `stream` powers ranged/streamed WebDAV GET+PUT bodies (remotefs/webdav.rs).
-reqwest = { version = "0.12", features = ["json", "stream"] }
+# `stream` powers ranged/streamed WebDAV GET+PUT bodies; `multipart` powers Box's
+# multipart/form-data uploads and Google Drive multipart create.
+reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }
 # Wraps a tokio File as a Stream for streaming WebDAV PUT uploads.
 tokio-util = { version = "0.7", features = ["io"] }
 # Decode percent-encoded WebDAV PROPFIND href paths back into file names.

--- a/src-tauri/faro-cli/src/main.rs
+++ b/src-tauri/faro-cli/src/main.rs
@@ -377,6 +377,12 @@ fn fs_for(session: &Session) -> Box<dyn RemoteFs> {
         Session::Object(obj) => {
             Box::new(faro_lib::remotefs::object::ObjectFs::new(obj.clone()))
         }
+        Session::Webdav(dav) => Box::new(faro_lib::remotefs::webdav::WebdavFs::new(dav.clone())),
+        Session::Http(http) => Box::new(faro_lib::remotefs::http::HttpFs::new(http.clone())),
+        Session::Dropbox(dbx) => Box::new(faro_lib::remotefs::dropbox::DropboxFs::new(dbx.clone())),
+        Session::OneDrive(od) => Box::new(faro_lib::remotefs::onedrive::OneDriveFs::new(od.clone())),
+        Session::GDrive(gd) => Box::new(faro_lib::remotefs::gdrive::GDriveFs::new(gd.clone())),
+        Session::Box(bx) => Box::new(faro_lib::remotefs::boxdrive::BoxFs::new(bx.clone())),
         Session::Agent(agent) => Box::new(faro_lib::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }
@@ -1292,6 +1298,14 @@ async fn upload_file(
         Session::Object(obj) => {
             upload_object(obj.clone(), local_path, &remote_path, &bar).await?
         }
+        Session::Webdav(_)
+        | Session::Http(_)
+        | Session::Dropbox(_)
+        | Session::OneDrive(_)
+        | Session::GDrive(_)
+        | Session::Box(_) => {
+            anyhow::bail!("uploads to this connection type are not yet supported in the CLI")
+        }
         Session::Agent(_) => anyhow::bail!("faro-agent connections are not supported in the CLI"),
     }
 
@@ -1415,6 +1429,14 @@ async fn download_file(session: &Session, remote_path: &str, local_dir: &str) ->
             }
             file.flush().await?;
         }
+        Session::Webdav(_)
+        | Session::Http(_)
+        | Session::Dropbox(_)
+        | Session::OneDrive(_)
+        | Session::GDrive(_)
+        | Session::Box(_) => {
+            anyhow::bail!("downloads from this connection type are not yet supported in the CLI")
+        }
         Session::Agent(_) => anyhow::bail!("faro-agent connections are not supported in the CLI"),
     }
 
@@ -1473,6 +1495,7 @@ fn reason_label(r: &faro_lib::sync::SyncReason) -> &'static str {
         faro_lib::sync::SyncReason::Missing => "new   ",
         faro_lib::sync::SyncReason::Newer => "newer ",
         faro_lib::sync::SyncReason::SizeChanged => "size  ",
+        faro_lib::sync::SyncReason::Edited => "edited",
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -63,6 +63,7 @@ pub async fn delete_profile(
             "gdrive" => {
                 crate::oauth::delete_tokens(crate::session::gdrive::GDRIVE_SERVICE, &id)
             }
+            "box" => crate::oauth::delete_tokens(crate::session::boxdrive::BOX_SERVICE, &id),
             _ => {}
         }
     }
@@ -292,6 +293,40 @@ pub async fn gdrive_authorize(profile_id: String) -> Result<DropboxAuthResult, S
         sort_order: None,
     };
     let account_label = match crate::session::gdrive_connect(&probe).await {
+        Ok(session) => session.account_label().await.unwrap_or_default(),
+        Err(_) => String::new(),
+    };
+    Ok(DropboxAuthResult { account_label })
+}
+
+/// Run the interactive Box OAuth flow, store tokens, return the label.
+#[tauri::command]
+pub async fn box_authorize(profile_id: String) -> Result<DropboxAuthResult, String> {
+    let config = crate::session::boxdrive::box_config();
+    let (tokens, _raw) = crate::oauth::authorize_loopback(&config).await.map_err(err)?;
+    crate::oauth::store_tokens(crate::session::boxdrive::BOX_SERVICE, &profile_id, &tokens)
+        .map_err(err)?;
+
+    let probe = ConnectionProfile {
+        id: profile_id.clone(),
+        name: String::new(),
+        protocol: "box".into(),
+        host: "box.com".into(),
+        port: 443,
+        username: String::new(),
+        auth: AuthMethod::Password { password: String::new() },
+        default_remote_path: None,
+        color: None,
+        auto_connect: None,
+        bucket: None,
+        region: None,
+        endpoint: None,
+        account: None,
+        agent_key: None,
+        group: None,
+        sort_order: None,
+    };
+    let account_label = match crate::session::box_connect(&probe).await {
         Ok(session) => session.account_label().await.unwrap_or_default(),
         Err(_) => String::new(),
     };
@@ -634,6 +669,7 @@ pub fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
         Session::Dropbox(dbx) => Box::new(crate::remotefs::dropbox::DropboxFs::new(dbx.clone())),
         Session::OneDrive(od) => Box::new(crate::remotefs::onedrive::OneDriveFs::new(od.clone())),
         Session::GDrive(gd) => Box::new(crate::remotefs::gdrive::GDriveFs::new(gd.clone())),
+        Session::Box(bx) => Box::new(crate::remotefs::boxdrive::BoxFs::new(bx.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -60,6 +60,9 @@ pub async fn delete_profile(
             "onedrive" => {
                 crate::oauth::delete_tokens(crate::session::onedrive::ONEDRIVE_SERVICE, &id)
             }
+            "gdrive" => {
+                crate::oauth::delete_tokens(crate::session::gdrive::GDRIVE_SERVICE, &id)
+            }
             _ => {}
         }
     }
@@ -255,6 +258,40 @@ pub async fn onedrive_authorize(profile_id: String) -> Result<DropboxAuthResult,
         sort_order: None,
     };
     let account_label = match crate::session::onedrive_connect(&probe).await {
+        Ok(session) => session.account_label().await.unwrap_or_default(),
+        Err(_) => String::new(),
+    };
+    Ok(DropboxAuthResult { account_label })
+}
+
+/// Run the interactive Google Drive OAuth flow, store tokens, return the label.
+#[tauri::command]
+pub async fn gdrive_authorize(profile_id: String) -> Result<DropboxAuthResult, String> {
+    let config = crate::session::gdrive::gdrive_config();
+    let (tokens, _raw) = crate::oauth::authorize_loopback(&config).await.map_err(err)?;
+    crate::oauth::store_tokens(crate::session::gdrive::GDRIVE_SERVICE, &profile_id, &tokens)
+        .map_err(err)?;
+
+    let probe = ConnectionProfile {
+        id: profile_id.clone(),
+        name: String::new(),
+        protocol: "gdrive".into(),
+        host: "drive.google.com".into(),
+        port: 443,
+        username: String::new(),
+        auth: AuthMethod::Password { password: String::new() },
+        default_remote_path: None,
+        color: None,
+        auto_connect: None,
+        bucket: None,
+        region: None,
+        endpoint: None,
+        account: None,
+        agent_key: None,
+        group: None,
+        sort_order: None,
+    };
+    let account_label = match crate::session::gdrive_connect(&probe).await {
         Ok(session) => session.account_label().await.unwrap_or_default(),
         Err(_) => String::new(),
     };
@@ -596,6 +633,7 @@ pub fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
         Session::Http(http) => Box::new(crate::remotefs::http::HttpFs::new(http.clone())),
         Session::Dropbox(dbx) => Box::new(crate::remotefs::dropbox::DropboxFs::new(dbx.clone())),
         Session::OneDrive(od) => Box::new(crate::remotefs::onedrive::OneDriveFs::new(od.clone())),
+        Session::GDrive(gd) => Box::new(crate::remotefs::gdrive::GDriveFs::new(gd.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -53,8 +53,14 @@ pub async fn delete_profile(
 ) -> Result<(), String> {
     // Clean up any keychain-stored OAuth tokens for this profile.
     if let Ok(Some(p)) = state.profiles.get(&id).await {
-        if p.protocol == "dropbox" {
-            crate::oauth::delete_tokens(crate::session::dropbox::DROPBOX_SERVICE, &id);
+        match p.protocol.as_str() {
+            "dropbox" => {
+                crate::oauth::delete_tokens(crate::session::dropbox::DROPBOX_SERVICE, &id)
+            }
+            "onedrive" => {
+                crate::oauth::delete_tokens(crate::session::onedrive::ONEDRIVE_SERVICE, &id)
+            }
+            _ => {}
         }
     }
     state.profiles.delete(&id).await.map_err(err)
@@ -210,6 +216,45 @@ pub async fn dropbox_authorize(profile_id: String) -> Result<DropboxAuthResult, 
         sort_order: None,
     };
     let account_label = match crate::session::dropbox_connect(&probe).await {
+        Ok(session) => session.account_label().await.unwrap_or_default(),
+        Err(_) => String::new(),
+    };
+    Ok(DropboxAuthResult { account_label })
+}
+
+/// Run the interactive OneDrive OAuth flow, store tokens in the keychain keyed by
+/// `profile_id`, and return the account label. Same shape as `dropbox_authorize`.
+#[tauri::command]
+pub async fn onedrive_authorize(profile_id: String) -> Result<DropboxAuthResult, String> {
+    let config = crate::session::onedrive::onedrive_config();
+    let (tokens, _raw) = crate::oauth::authorize_loopback(&config).await.map_err(err)?;
+    crate::oauth::store_tokens(
+        crate::session::onedrive::ONEDRIVE_SERVICE,
+        &profile_id,
+        &tokens,
+    )
+    .map_err(err)?;
+
+    let probe = ConnectionProfile {
+        id: profile_id.clone(),
+        name: String::new(),
+        protocol: "onedrive".into(),
+        host: "onedrive.com".into(),
+        port: 443,
+        username: String::new(),
+        auth: AuthMethod::Password { password: String::new() },
+        default_remote_path: None,
+        color: None,
+        auto_connect: None,
+        bucket: None,
+        region: None,
+        endpoint: None,
+        account: None,
+        agent_key: None,
+        group: None,
+        sort_order: None,
+    };
+    let account_label = match crate::session::onedrive_connect(&probe).await {
         Ok(session) => session.account_label().await.unwrap_or_default(),
         Err(_) => String::new(),
     };
@@ -550,6 +595,7 @@ pub fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
         Session::Webdav(dav) => Box::new(crate::remotefs::webdav::WebdavFs::new(dav.clone())),
         Session::Http(http) => Box::new(crate::remotefs::http::HttpFs::new(http.clone())),
         Session::Dropbox(dbx) => Box::new(crate::remotefs::dropbox::DropboxFs::new(dbx.clone())),
+        Session::OneDrive(od) => Box::new(crate::remotefs::onedrive::OneDriveFs::new(od.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -491,6 +491,7 @@ pub fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
             Box::new(crate::remotefs::object::ObjectFs::new(obj.clone()))
         }
         Session::Webdav(dav) => Box::new(crate::remotefs::webdav::WebdavFs::new(dav.clone())),
+        Session::Http(http) => Box::new(crate::remotefs::http::HttpFs::new(http.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::agent::ChatRequest;
-use crate::profiles::ConnectionProfile;
+use crate::profiles::{AuthMethod, ConnectionProfile};
 use crate::remotefs::{Capabilities, DirEntry, RemoteFs};
 use crate::session::{HostDecision, JobHandle, Session, SshSession};
 use crate::transfer::{OverwritePolicy, Transfer, TransferStatus};
@@ -51,6 +51,12 @@ pub async fn delete_profile(
     id: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
+    // Clean up any keychain-stored OAuth tokens for this profile.
+    if let Ok(Some(p)) = state.profiles.get(&id).await {
+        if p.protocol == "dropbox" {
+            crate::oauth::delete_tokens(crate::session::dropbox::DROPBOX_SERVICE, &id);
+        }
+    }
     state.profiles.delete(&id).await.map_err(err)
 }
 
@@ -157,6 +163,57 @@ pub async fn pair_agent(host: String, port: u16, code: String) -> Result<AgentPa
         hostname: outcome.system_info.hostname,
         os: outcome.system_info.os,
     })
+}
+
+// ---------- Dropbox (OAuth cloud) ----------
+
+/// Result of a Dropbox authorization, shown to the user to confirm the account.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DropboxAuthResult {
+    pub account_label: String,
+}
+
+/// Run the interactive Dropbox OAuth flow (opens the browser, catches the
+/// loopback redirect), store the tokens in the OS keychain keyed by `profile_id`,
+/// and return the account label. Mirrors agent pairing: the editor persists the
+/// profile once this succeeds, so a cancelled flow leaves no saved connection.
+#[tauri::command]
+pub async fn dropbox_authorize(profile_id: String) -> Result<DropboxAuthResult, String> {
+    let config = crate::session::dropbox::dropbox_config();
+    let (tokens, _raw) = crate::oauth::authorize_loopback(&config).await.map_err(err)?;
+    crate::oauth::store_tokens(
+        crate::session::dropbox::DROPBOX_SERVICE,
+        &profile_id,
+        &tokens,
+    )
+    .map_err(err)?;
+
+    // Fetch the account label with a throwaway session over the fresh tokens.
+    let probe = ConnectionProfile {
+        id: profile_id.clone(),
+        name: String::new(),
+        protocol: "dropbox".into(),
+        host: "dropbox.com".into(),
+        port: 443,
+        username: String::new(),
+        auth: AuthMethod::Password { password: String::new() },
+        default_remote_path: None,
+        color: None,
+        auto_connect: None,
+        bucket: None,
+        region: None,
+        endpoint: None,
+        account: None,
+        agent_key: None,
+        group: None,
+        sort_order: None,
+    };
+    let account_label = match crate::session::dropbox_connect(&probe).await {
+        Ok(session) => session.account_label().await.unwrap_or_default(),
+        Err(_) => String::new(),
+    };
+    Ok(DropboxAuthResult { account_label })
 }
 
 /// List the in-flight tracked commands (agent/bridge `exec`s, tails) running on a

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -474,6 +474,15 @@ async fn fs_for(
     Ok(fs_for_session(&session))
 }
 
+/// `fs_for` for other subsystems (e.g. the disk-usage scanner) that resolve a
+/// `RemoteFs` from a session id — same `local`-aware dispatch, exported.
+pub async fn fs_for_public(
+    session_id: &str,
+    state: &AppState,
+) -> Result<Box<dyn RemoteFs>, String> {
+    fs_for(session_id, state).await
+}
+
 pub fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
     match &**session {
         Session::Ssh(ssh) => Box::new(crate::remotefs::sftp::SftpFs::new(ssh.clone())),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -490,6 +490,7 @@ pub fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
         Session::Object(obj) => {
             Box::new(crate::remotefs::object::ObjectFs::new(obj.clone()))
         }
+        Session::Webdav(dav) => Box::new(crate::remotefs::webdav::WebdavFs::new(dav.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -492,6 +492,7 @@ pub fn fs_for_session(session: &Arc<Session>) -> Box<dyn RemoteFs> {
         }
         Session::Webdav(dav) => Box::new(crate::remotefs::webdav::WebdavFs::new(dav.clone())),
         Session::Http(http) => Box::new(crate::remotefs::http::HttpFs::new(http.clone())),
+        Session::Dropbox(dbx) => Box::new(crate::remotefs::dropbox::DropboxFs::new(dbx.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,0 +1,212 @@
+//! `faro.db` — one shared SQLite database for every subsystem that needs a
+//! persisted per-connection index (see `docs/plans/3_scan-index-foundation.md`).
+//!
+//! The win is deliberately modest: **one** connection + **one** migration runner,
+//! with **per-feature tables** in the same file. No grand unified schema. This
+//! plan lands the `sync_state` table (folder-sync's per-file memory); Plans 6/7/8
+//! add `scan_cache` / `search_index` / `diff_hash` as *additive* migrations —
+//! never a rewrite.
+//!
+//! Migrations are forward-only and versioned via SQLite's `user_version` pragma:
+//! append a statement to [`MIGRATIONS`] and bump nothing else. `rusqlite`'s
+//! `bundled` feature compiles SQLite from source, so there's no system dependency.
+//!
+//! The connection is guarded by a `std::sync::Mutex`. Every query runs to
+//! completion under the lock and returns owned data — the guard is never held
+//! across an `.await`, so callers stay `Send`.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+
+/// Forward-only schema migrations. Index = target `user_version - 1`; appending
+/// a statement is the *only* supported schema change. Never edit or reorder an
+/// existing entry — a shipped `faro.db` has already run it.
+const MIGRATIONS: &[&str] = &[
+    // v1 — folder-sync per-file index. Keyed by (pair_id, rel_path). `size`/
+    // `mtime` are the *source-side* values captured at last sync; `remote_signal`
+    // is the backend's opaque change token (ETag/hash) when it has one, else NULL.
+    "CREATE TABLE sync_state (
+        pair_id        TEXT    NOT NULL,
+        rel_path       TEXT    NOT NULL,
+        size           INTEGER NOT NULL,
+        mtime          INTEGER NOT NULL,
+        remote_signal  TEXT,
+        last_synced_ms INTEGER NOT NULL,
+        state          TEXT    NOT NULL DEFAULT 'synced',
+        PRIMARY KEY (pair_id, rel_path)
+    ) WITHOUT ROWID;",
+];
+
+/// A persisted per-file sync record — what the source looked like the last time
+/// this pair synced it. The reconciler diffs the *current* source against this to
+/// catch same-size edits the live size+mtime comparison would miss.
+#[derive(Debug, Clone)]
+pub struct SyncStateRow {
+    pub size: u64,
+    pub mtime: i64,
+    pub remote_signal: Option<String>,
+    pub last_synced_ms: i64,
+}
+
+pub struct Db {
+    conn: Mutex<Connection>,
+}
+
+impl Db {
+    /// Open (creating if absent) `faro.db` at `path` and run pending migrations.
+    pub fn open(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path)
+            .with_context(|| format!("open faro.db at {}", path.display()))?;
+        // WAL keeps readers from blocking the single writer — this is a desktop
+        // app with occasional background writes, not a hot OLTP path.
+        conn.pragma_update(None, "journal_mode", "WAL").ok();
+        conn.pragma_update(None, "foreign_keys", "ON").ok();
+        migrate(&conn).context("running faro.db migrations")?;
+        Ok(Self { conn: Mutex::new(conn) })
+    }
+
+    /// Open an in-memory database (tests).
+    #[cfg(test)]
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        migrate(&conn)?;
+        Ok(Self { conn: Mutex::new(conn) })
+    }
+
+    /// Load every remembered file for a pair, keyed by relative path.
+    pub fn load_sync_state(&self, pair_id: &str) -> Result<HashMap<String, SyncStateRow>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT rel_path, size, mtime, remote_signal, last_synced_ms
+               FROM sync_state WHERE pair_id = ?1",
+        )?;
+        let rows = stmt.query_map([pair_id], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                SyncStateRow {
+                    size: r.get::<_, i64>(1)? as u64,
+                    mtime: r.get(2)?,
+                    remote_signal: r.get(3)?,
+                    last_synced_ms: r.get(4)?,
+                },
+            ))
+        })?;
+        let mut out = HashMap::new();
+        for row in rows {
+            let (k, v) = row?;
+            out.insert(k, v);
+        }
+        Ok(out)
+    }
+
+    /// Record (insert or replace) one file's synced state.
+    pub fn upsert_sync_state(
+        &self,
+        pair_id: &str,
+        rel_path: &str,
+        size: u64,
+        mtime: i64,
+        remote_signal: Option<&str>,
+        last_synced_ms: i64,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO sync_state
+                 (pair_id, rel_path, size, mtime, remote_signal, last_synced_ms, state)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'synced')
+             ON CONFLICT(pair_id, rel_path) DO UPDATE SET
+                 size = excluded.size,
+                 mtime = excluded.mtime,
+                 remote_signal = excluded.remote_signal,
+                 last_synced_ms = excluded.last_synced_ms,
+                 state = 'synced'",
+            rusqlite::params![pair_id, rel_path, size as i64, mtime, remote_signal, last_synced_ms],
+        )?;
+        Ok(())
+    }
+
+    /// Forget one file (it's gone from the source and has been mirrored away).
+    pub fn delete_sync_state(&self, pair_id: &str, rel_path: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM sync_state WHERE pair_id = ?1 AND rel_path = ?2",
+            rusqlite::params![pair_id, rel_path],
+        )?;
+        Ok(())
+    }
+
+    /// Drop a pair's entire index (the pair was deleted).
+    pub fn clear_pair(&self, pair_id: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM sync_state WHERE pair_id = ?1", [pair_id])?;
+        Ok(())
+    }
+}
+
+/// Apply every migration whose index is `>= user_version`, bumping the pragma in
+/// lockstep so a half-applied run resumes cleanly on the next open.
+fn migrate(conn: &Connection) -> Result<()> {
+    let version: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0))?;
+    for (i, sql) in MIGRATIONS.iter().enumerate().skip(version as usize) {
+        conn.execute_batch(sql)
+            .with_context(|| format!("apply migration v{}", i + 1))?;
+        // `user_version` can't be a bound parameter — the value is our own index.
+        conn.pragma_update(None, "user_version", (i + 1) as i64)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrates_and_round_trips_sync_state() {
+        let db = Db::open_in_memory().unwrap();
+        assert!(db.load_sync_state("p1").unwrap().is_empty());
+
+        db.upsert_sync_state("p1", "a/b.txt", 42, 1000, Some("etag-1"), 5000)
+            .unwrap();
+        db.upsert_sync_state("p1", "c.txt", 7, 2000, None, 5001).unwrap();
+        db.upsert_sync_state("p2", "a/b.txt", 99, 3000, None, 5002)
+            .unwrap();
+
+        let p1 = db.load_sync_state("p1").unwrap();
+        assert_eq!(p1.len(), 2);
+        let row = &p1["a/b.txt"];
+        assert_eq!(row.size, 42);
+        assert_eq!(row.mtime, 1000);
+        assert_eq!(row.remote_signal.as_deref(), Some("etag-1"));
+        assert_eq!(row.last_synced_ms, 5000);
+
+        // upsert replaces in place
+        db.upsert_sync_state("p1", "a/b.txt", 43, 1500, None, 6000)
+            .unwrap();
+        let p1 = db.load_sync_state("p1").unwrap();
+        assert_eq!(p1.len(), 2);
+        assert_eq!(p1["a/b.txt"].size, 43);
+        assert_eq!(p1["a/b.txt"].remote_signal, None);
+
+        db.delete_sync_state("p1", "a/b.txt").unwrap();
+        assert_eq!(db.load_sync_state("p1").unwrap().len(), 1);
+
+        // p2 is untouched by p1 operations
+        assert_eq!(db.load_sync_state("p2").unwrap().len(), 1);
+        db.clear_pair("p2").unwrap();
+        assert!(db.load_sync_state("p2").unwrap().is_empty());
+    }
+
+    #[test]
+    fn migrate_is_idempotent_across_opens() {
+        // Running migrate twice on the same connection must not error or duplicate.
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+        migrate(&conn).unwrap();
+        let v: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0)).unwrap();
+        assert_eq!(v as usize, MIGRATIONS.len());
+    }
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -201,6 +201,32 @@ mod tests {
     }
 
     #[test]
+    fn open_creates_file_and_persists_across_reopen() {
+        // Exercises the exact code path startup uses: Db::open on a real path,
+        // WAL pragma, migrations, and durability across a reopen.
+        let mut path = std::env::temp_dir();
+        path.push(format!("faro_db_open_test_{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        {
+            let db = Db::open(&path).unwrap();
+            db.upsert_sync_state("p", "f.txt", 1, 2, None, 3).unwrap();
+        }
+        assert!(path.exists(), "Db::open must create the file");
+
+        // Reopen: migrations don't re-run destructively and data survives.
+        let db = Db::open(&path).unwrap();
+        let rows = db.load_sync_state("p").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows["f.txt"].size, 1);
+
+        drop(db);
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("db-wal"));
+        let _ = std::fs::remove_file(path.with_extension("db-shm"));
+    }
+
+    #[test]
     fn migrate_is_idempotent_across_opens() {
         // Running migrate twice on the same connection must not error or duplicate.
         let conn = Connection::open_in_memory().unwrap();

--- a/src-tauri/src/diskscan.rs
+++ b/src-tauri/src/diskscan.rs
@@ -1,0 +1,464 @@
+//! Disk Usage Explorer scan engine (see `docs/plans/4_disk-usage-explorer.md`).
+//!
+//! A WinDirStat/WizTree-style "what's eating the disk?" analysis, but over **any**
+//! backend — because every `RemoteFs` already knows how to walk. A [`ScanManager`]
+//! (shaped like `TransferManager` / `agent_host`: an `Arc` in `AppState`, running
+//! scans in a `Mutex<HashMap<scanId, …>>`) recursively sizes a directory and
+//! aggregates the totals into a tree the frontend renders as a treemap + a
+//! size-ranked list.
+//!
+//! Phase 1 is the **generic walk** — [`crate::scan::walk`], the one shared scan
+//! engine, summed up the tree. It works on every backend and is the fallback for
+//! the protocol fast paths (shell `du` for SSH/agent, object-store flat listing)
+//! that layer on in Phase 3 via [`ScanStrategy`].
+//!
+//! Progress streams over `diskscan://…` events (mirrors `transfer://…`); cancel
+//! flips a shared [`CancelToken`]. The aggregated tree is fetched once, on
+//! completion, via `diskscan_tree`.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::remotefs::{FileKind, RemoteFs};
+use crate::scan::{self, CancelToken, ScanOptions, ScanProgress};
+
+/// Which strategy produced a scan. Phase 1 only ever reports `Generic`; the
+/// exec (`Shell`) and object-store (`ObjectFlat`) fast paths land in Phase 3 and
+/// set this so the UI can show which path fired (and why the generic fallback,
+/// if exec was denied).
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ScanStrategy {
+    /// Recursive `RemoteFs::list_dir` walk — always available.
+    Generic,
+    /// One `du -ab` / `find -printf` over the SSH exec channel or a Faro Agent.
+    Shell,
+    /// A single flat object listing under the prefix (S3/Azure).
+    ObjectFlat,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ScanState {
+    Scanning,
+    Done,
+    Error,
+    Canceled,
+}
+
+/// One node in the aggregated size tree. `size` is the *total* bytes under this
+/// node (own bytes for a file; sum of descendants for a directory). Directories
+/// carry `children`; files have none. Children are sorted largest-first so the
+/// treemap and ranked list render the "biggest offenders" without re-sorting.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DuNode {
+    pub name: String,
+    pub path: String,
+    pub kind: FileKind,
+    pub size: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<DuNode>,
+}
+
+/// A snapshot of a scan for the frontend: live progress while `Scanning`, the
+/// aggregated `tree` once `Done`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanSnapshot {
+    pub id: String,
+    pub session_id: String,
+    pub root: String,
+    pub state: ScanState,
+    pub strategy: ScanStrategy,
+    pub dirs_scanned: usize,
+    pub files_found: usize,
+    pub total_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tree: Option<DuNode>,
+    pub started_at: i64,
+}
+
+/// The lightweight progress event body streamed over `diskscan://progress`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProgressEvent {
+    id: String,
+    dirs_scanned: usize,
+    files_found: usize,
+    total_bytes: u64,
+    strategy: ScanStrategy,
+}
+
+/// Shared live state for one scan. The task mutates the atomics as it walks; the
+/// query commands read them — no lock is held across the walk.
+struct ScanInfo {
+    id: String,
+    session_id: String,
+    root: String,
+    strategy: StdMutex<ScanStrategy>,
+    cancel: CancelToken,
+    dirs: AtomicUsize,
+    files: AtomicUsize,
+    bytes: AtomicU64,
+    started_at: i64,
+    /// The terminal result — `None` until the scan settles.
+    result: StdMutex<RunResult>,
+}
+
+enum RunResult {
+    Running,
+    Done(DuNode),
+    Error(String),
+    Canceled,
+}
+
+impl ScanInfo {
+    fn snapshot(&self) -> ScanSnapshot {
+        let strategy = *self.strategy.lock().unwrap();
+        let (state, error, tree) = match &*self.result.lock().unwrap() {
+            RunResult::Running => (ScanState::Scanning, None, None),
+            RunResult::Done(tree) => (ScanState::Done, None, Some(tree.clone())),
+            RunResult::Error(e) => (ScanState::Error, Some(e.clone()), None),
+            RunResult::Canceled => (ScanState::Canceled, None, None),
+        };
+        ScanSnapshot {
+            id: self.id.clone(),
+            session_id: self.session_id.clone(),
+            root: self.root.clone(),
+            state,
+            strategy,
+            dirs_scanned: self.dirs.load(Ordering::Relaxed),
+            files_found: self.files.load(Ordering::Relaxed),
+            total_bytes: self.bytes.load(Ordering::Relaxed),
+            error,
+            tree,
+            started_at: self.started_at,
+        }
+    }
+}
+
+struct ScanHandle {
+    info: Arc<ScanInfo>,
+    task: tauri::async_runtime::JoinHandle<()>,
+}
+
+pub struct ScanManager {
+    scans: Mutex<HashMap<String, ScanHandle>>,
+}
+
+fn now_ts() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+impl ScanManager {
+    pub fn new() -> Self {
+        Self { scans: Mutex::new(HashMap::new()) }
+    }
+
+    /// Kick off a scan of `root` on `fs`. Returns the scan id immediately; the
+    /// walk runs in a spawned task streaming `diskscan://progress` and, on
+    /// settle, one of `diskscan://done` / `diskscan://error` / `diskscan://canceled`.
+    pub async fn start(
+        self: &Arc<Self>,
+        session_id: String,
+        root: String,
+        fs: Box<dyn RemoteFs>,
+        app: AppHandle,
+    ) -> String {
+        let id = Uuid::new_v4().to_string();
+        let info = Arc::new(ScanInfo {
+            id: id.clone(),
+            session_id,
+            root: root.clone(),
+            strategy: StdMutex::new(ScanStrategy::Generic),
+            cancel: CancelToken::new(),
+            dirs: AtomicUsize::new(0),
+            files: AtomicUsize::new(0),
+            bytes: AtomicU64::new(0),
+            started_at: now_ts(),
+            result: StdMutex::new(RunResult::Running),
+        });
+
+        let task_info = Arc::clone(&info);
+        let mgr = Arc::clone(self);
+        let task = tauri::async_runtime::spawn(async move {
+            run_scan(task_info, root, fs, app).await;
+            // Leave the handle in the map so `diskscan_tree`/`_status` can fetch
+            // the settled result; the frontend evicts it when the tab closes.
+            let _ = mgr;
+        });
+
+        self.scans
+            .lock()
+            .await
+            .insert(id.clone(), ScanHandle { info, task });
+        id
+    }
+
+    pub async fn snapshot(&self, id: &str) -> Option<ScanSnapshot> {
+        self.scans.lock().await.get(id).map(|h| h.info.snapshot())
+    }
+
+    /// Flip the cancel flag; the walk stops at its next tick and reports Canceled.
+    pub async fn cancel(&self, id: &str) {
+        if let Some(h) = self.scans.lock().await.get(id) {
+            h.info.cancel.cancel();
+        }
+    }
+
+    /// Drop a finished (or abandoned) scan — the tab was closed. Aborts the task
+    /// if it's somehow still running.
+    pub async fn forget(&self, id: &str) {
+        if let Some(h) = self.scans.lock().await.remove(id) {
+            h.info.cancel.cancel();
+            h.task.abort();
+        }
+    }
+}
+
+/// The generic-walk scan body. Streams progress, builds the aggregated tree, and
+/// records the terminal result on `info`.
+async fn run_scan(info: Arc<ScanInfo>, root: String, fs: Box<dyn RemoteFs>, app: AppHandle) {
+    let opts = ScanOptions { concurrency: scan::DEFAULT_CONCURRENCY, cancel: info.cancel.clone() };
+
+    // Throttle progress events to ~10/s so a fast local walk doesn't flood the
+    // IPC channel. The atomics are always current for the query commands.
+    let mut last_emit = Instant::now();
+    let ev_info = Arc::clone(&info);
+    let ev_app = app.clone();
+    let on_progress = move |p: ScanProgress| {
+        ev_info.dirs.store(p.dirs_scanned, Ordering::Relaxed);
+        ev_info.files.store(p.files_found, Ordering::Relaxed);
+        ev_info.bytes.store(p.bytes_found, Ordering::Relaxed);
+        if last_emit.elapsed() >= Duration::from_millis(100) {
+            let _ = ev_app.emit(
+                "diskscan://progress",
+                ProgressEvent {
+                    id: ev_info.id.clone(),
+                    dirs_scanned: p.dirs_scanned,
+                    files_found: p.files_found,
+                    total_bytes: p.bytes_found,
+                    strategy: *ev_info.strategy.lock().unwrap(),
+                },
+            );
+            last_emit = Instant::now();
+        }
+    };
+
+    let walked = scan::walk(fs.as_ref(), &root, &opts, on_progress).await;
+
+    // Cancellation wins even if the walk returned an (empty/partial) Ok tree.
+    if info.cancel.is_cancelled() {
+        *info.result.lock().unwrap() = RunResult::Canceled;
+        let _ = app.emit("diskscan://canceled", info.snapshot());
+        return;
+    }
+
+    match walked {
+        Ok(tree) => {
+            let node = build_tree(&root, &tree);
+            info.bytes.store(node.size, Ordering::Relaxed);
+            *info.result.lock().unwrap() = RunResult::Done(node);
+            let _ = app.emit("diskscan://done", info.snapshot());
+        }
+        Err(e) => {
+            *info.result.lock().unwrap() = RunResult::Error(format!("{e:#}"));
+            let _ = app.emit("diskscan://error", info.snapshot());
+        }
+    }
+}
+
+/// The basename of a POSIX-ish path, tolerating a trailing slash. Empty → "/".
+fn basename(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return "/".to_string();
+    }
+    trimmed
+        .rsplit(|c| c == '/' || c == '\\')
+        .next()
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
+/// Intermediate builder: a directory-or-file with children keyed by segment name
+/// and a running aggregate `size`. Converted to a sorted [`DuNode`] at the end.
+#[derive(Default)]
+struct Build {
+    size: u64,
+    is_dir: bool,
+    children: HashMap<String, Build>,
+}
+
+/// Fold the flat file list into a nested, size-aggregated tree.
+fn build_tree(root: &str, tree: &scan::ScanTree) -> DuNode {
+    let mut builder = Build { is_dir: true, ..Default::default() };
+    for (rel, entry) in &tree.files {
+        let segments: Vec<&str> = rel.split('/').filter(|s| !s.is_empty()).collect();
+        if segments.is_empty() {
+            continue;
+        }
+        builder.size += entry.size;
+        insert_path(&mut builder, &segments, entry.size);
+    }
+    let root_path = root.trim_end_matches('/');
+    let root_path = if root_path.is_empty() { "/" } else { root_path };
+    convert(basename(root), root_path.to_string(), FileKind::Directory, builder)
+}
+
+fn insert_path(node: &mut Build, segments: &[&str], size: u64) {
+    let (first, rest) = segments.split_first().expect("non-empty segments");
+    let child = node.children.entry((*first).to_string()).or_default();
+    child.size += size;
+    if rest.is_empty() {
+        // Leaf file (unless a directory of the same name already claimed it).
+    } else {
+        child.is_dir = true;
+        insert_path(child, rest, size);
+    }
+}
+
+fn convert(name: String, path: String, kind: FileKind, build: Build) -> DuNode {
+    let mut children: Vec<DuNode> = build
+        .children
+        .into_iter()
+        .map(|(seg, child)| {
+            let child_path = if path == "/" {
+                format!("/{seg}")
+            } else {
+                format!("{path}/{seg}")
+            };
+            let child_kind = if child.is_dir { FileKind::Directory } else { FileKind::File };
+            convert(seg, child_path, child_kind, child)
+        })
+        .collect();
+    // Largest-first: the biggest offenders lead in both the treemap and the list.
+    children.sort_by(|a, b| b.size.cmp(&a.size).then_with(|| a.name.cmp(&b.name)));
+    DuNode { name, path, kind, size: build.size, children }
+}
+
+// ---------- Tauri commands ----------
+
+use tauri::State;
+
+/// Start a disk-usage scan of `path` on `session_id`. Returns the scan id; the
+/// frontend then listens for `diskscan://…` and fetches the tree on `done`.
+#[tauri::command]
+pub async fn diskscan_start(
+    session_id: String,
+    path: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let fs = crate::commands::fs_for_public(&session_id, &state).await?;
+    let mgr = Arc::clone(&state.diskscan);
+    Ok(mgr.start(session_id, path, fs, app).await)
+}
+
+#[tauri::command]
+pub async fn diskscan_status(
+    scan_id: String,
+    state: State<'_, AppState>,
+) -> Result<ScanSnapshot, String> {
+    state
+        .diskscan
+        .snapshot(&scan_id)
+        .await
+        .ok_or_else(|| format!("scan {scan_id} not found"))
+}
+
+/// Full snapshot including the aggregated `tree` (present once the scan is done).
+#[tauri::command]
+pub async fn diskscan_tree(
+    scan_id: String,
+    state: State<'_, AppState>,
+) -> Result<ScanSnapshot, String> {
+    state
+        .diskscan
+        .snapshot(&scan_id)
+        .await
+        .ok_or_else(|| format!("scan {scan_id} not found"))
+}
+
+#[tauri::command]
+pub async fn diskscan_cancel(scan_id: String, state: State<'_, AppState>) -> Result<(), String> {
+    state.diskscan.cancel(&scan_id).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn diskscan_forget(scan_id: String, state: State<'_, AppState>) -> Result<(), String> {
+    state.diskscan.forget(&scan_id).await;
+    Ok(())
+}
+
+use crate::AppState;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::{ScanEntry, ScanTree};
+
+    fn entry(size: u64) -> ScanEntry {
+        ScanEntry { absolute: String::new(), size, modified: 0, etag: None }
+    }
+
+    #[test]
+    fn aggregates_sizes_up_the_tree() {
+        let mut tree = ScanTree::default();
+        tree.files.insert("a/b.txt".into(), entry(10));
+        tree.files.insert("a/c.txt".into(), entry(20));
+        tree.files.insert("d.txt".into(), entry(5));
+
+        let root = build_tree("/data", &tree);
+        assert_eq!(root.size, 35);
+        assert_eq!(root.path, "/data");
+        // Children sorted largest-first: dir `a` (30) before file `d.txt` (5).
+        assert_eq!(root.children.len(), 2);
+        assert_eq!(root.children[0].name, "a");
+        assert_eq!(root.children[0].size, 30);
+        assert_eq!(root.children[0].kind, FileKind::Directory);
+        assert_eq!(root.children[0].path, "/data/a");
+        assert_eq!(root.children[1].name, "d.txt");
+        assert_eq!(root.children[1].size, 5);
+        assert_eq!(root.children[1].kind, FileKind::File);
+
+        // The dir's own children are sorted too: c.txt (20) before b.txt (10).
+        let a = &root.children[0];
+        assert_eq!(a.children[0].name, "c.txt");
+        assert_eq!(a.children[0].size, 20);
+        assert_eq!(a.children[1].name, "b.txt");
+    }
+
+    #[test]
+    fn empty_tree_yields_empty_root() {
+        let tree = ScanTree::default();
+        let root = build_tree("/x/", &tree);
+        assert_eq!(root.size, 0);
+        assert!(root.children.is_empty());
+        assert_eq!(root.path, "/x");
+    }
+
+    #[test]
+    fn root_slash_child_paths() {
+        let mut tree = ScanTree::default();
+        tree.files.insert("etc/hosts".into(), entry(1));
+        let root = build_tree("/", &tree);
+        assert_eq!(root.path, "/");
+        assert_eq!(root.children[0].path, "/etc");
+        assert_eq!(root.children[0].children[0].path, "/etc/hosts");
+    }
+}

--- a/src-tauri/src/diskscan.rs
+++ b/src-tauri/src/diskscan.rs
@@ -558,6 +558,24 @@ struct Build {
     children: HashMap<String, Build>,
 }
 
+/// The scan root as a uniformly forward-slashed path. Child segments are already
+/// POSIX-normalised (`scan::relative_of` replaces `\`), so normalising the root
+/// prefix here makes *every* DuNode path below it fully `/`-separated instead of
+/// the mixed `C:\Users\x/GitHub` the raw local path would produce. A trailing
+/// separator is trimmed except on a bare root — POSIX `/` or a Windows drive root
+/// `C:/` — which must keep it (a bare `C:` is the drive's CWD, not its root).
+fn normalize_root(root: &str) -> String {
+    let trimmed = root.replace('\\', "/");
+    let trimmed = trimmed.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else if trimmed.ends_with(':') {
+        format!("{trimmed}/")
+    } else {
+        trimmed.to_string()
+    }
+}
+
 /// Fold the flat file list into a nested, size-aggregated tree.
 fn build_tree(root: &str, tree: &scan::ScanTree) -> DuNode {
     let mut builder = Build { is_dir: true, ..Default::default() };
@@ -569,9 +587,7 @@ fn build_tree(root: &str, tree: &scan::ScanTree) -> DuNode {
         builder.size += entry.size;
         insert_path(&mut builder, &segments, entry.size);
     }
-    let root_path = root.trim_end_matches('/');
-    let root_path = if root_path.is_empty() { "/" } else { root_path };
-    convert(basename(root), root_path.to_string(), FileKind::Directory, builder)
+    convert(basename(root), normalize_root(root), FileKind::Directory, builder)
 }
 
 fn insert_path(node: &mut Build, segments: &[&str], size: u64) {
@@ -591,8 +607,10 @@ fn convert(name: String, path: String, kind: FileKind, build: Build) -> DuNode {
         .children
         .into_iter()
         .map(|(seg, child)| {
-            let child_path = if path == "/" {
-                format!("/{seg}")
+            // Roots already end in their separator (POSIX `/`, drive root `C:/`);
+            // everything else needs one inserted before the segment.
+            let child_path = if path.ends_with('/') {
+                format!("{path}{seg}")
             } else {
                 format!("{path}/{seg}")
             };
@@ -728,6 +746,32 @@ mod tests {
         assert_eq!(root.path, "/");
         assert_eq!(root.children[0].path, "/etc");
         assert_eq!(root.children[0].children[0].path, "/etc/hosts");
+    }
+
+    #[test]
+    fn normalizes_windows_root_prefix_to_forward_slashes() {
+        let mut tree = ScanTree::default();
+        // `scan::relative_of` already hands us `/`-separated relatives; only the
+        // root prefix (as the local Windows backend reports it) has backslashes.
+        tree.files.insert("GitHub/Faro/x.txt".into(), entry(3));
+        let root = build_tree("C:\\Users\\Juan\\Documents", &tree);
+        assert_eq!(root.path, "C:/Users/Juan/Documents");
+        assert_eq!(root.children[0].path, "C:/Users/Juan/Documents/GitHub");
+        assert_eq!(
+            root.children[0].children[0].children[0].path,
+            "C:/Users/Juan/Documents/GitHub/Faro/x.txt"
+        );
+    }
+
+    #[test]
+    fn windows_drive_root_stays_listable() {
+        let mut tree = ScanTree::default();
+        tree.files.insert("Windows/notepad.exe".into(), entry(1));
+        // A bare `C:` is the drive's working dir, not its root — keep the slash.
+        let root = build_tree("C:\\", &tree);
+        assert_eq!(root.path, "C:/");
+        assert_eq!(root.children[0].path, "C:/Windows");
+        assert_eq!(root.children[0].children[0].path, "C:/Windows/notepad.exe");
     }
 
     #[test]

--- a/src-tauri/src/diskscan.rs
+++ b/src-tauri/src/diskscan.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use anyhow::{Context, Result};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
@@ -28,6 +29,7 @@ use uuid::Uuid;
 
 use crate::remotefs::{FileKind, RemoteFs};
 use crate::scan::{self, CancelToken, ScanOptions, ScanProgress};
+use crate::session::{AgentSession, ObjectSession, Session, SshSession};
 
 /// Which strategy produced a scan. Phase 1 only ever reports `Generic`; the
 /// exec (`Shell`) and object-store (`ObjectFlat`) fast paths land in Phase 3 and
@@ -83,6 +85,10 @@ pub struct ScanSnapshot {
     pub total_bytes: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// A short explanation shown next to the strategy badge — e.g. why the fast
+    /// path fell back to the generic walk ("exec disabled — used walk").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tree: Option<DuNode>,
     pub started_at: i64,
@@ -106,6 +112,7 @@ struct ScanInfo {
     session_id: String,
     root: String,
     strategy: StdMutex<ScanStrategy>,
+    note: StdMutex<Option<String>>,
     cancel: CancelToken,
     dirs: AtomicUsize,
     files: AtomicUsize,
@@ -125,6 +132,7 @@ enum RunResult {
 impl ScanInfo {
     fn snapshot(&self) -> ScanSnapshot {
         let strategy = *self.strategy.lock().unwrap();
+        let note = self.note.lock().unwrap().clone();
         let (state, error, tree) = match &*self.result.lock().unwrap() {
             RunResult::Running => (ScanState::Scanning, None, None),
             RunResult::Done(tree) => (ScanState::Done, None, Some(tree.clone())),
@@ -141,9 +149,18 @@ impl ScanInfo {
             files_found: self.files.load(Ordering::Relaxed),
             total_bytes: self.bytes.load(Ordering::Relaxed),
             error,
+            note,
             tree,
             started_at: self.started_at,
         }
+    }
+
+    fn set_strategy(&self, s: ScanStrategy) {
+        *self.strategy.lock().unwrap() = s;
+    }
+
+    fn set_note(&self, n: impl Into<String>) {
+        *self.note.lock().unwrap() = Some(n.into());
     }
 }
 
@@ -168,13 +185,16 @@ impl ScanManager {
         Self { scans: Mutex::new(HashMap::new()) }
     }
 
-    /// Kick off a scan of `root` on `fs`. Returns the scan id immediately; the
-    /// walk runs in a spawned task streaming `diskscan://progress` and, on
-    /// settle, one of `diskscan://done` / `diskscan://error` / `diskscan://canceled`.
+    /// Kick off a scan of `root` on `fs`. `session` (absent for the local FS)
+    /// enables the protocol fast paths — a shell `find` over SSH/agent, or a flat
+    /// object listing. Returns the scan id immediately; the work runs in a spawned
+    /// task streaming `diskscan://progress` and, on settle, one of
+    /// `diskscan://done` / `diskscan://error` / `diskscan://canceled`.
     pub async fn start(
         self: &Arc<Self>,
         session_id: String,
         root: String,
+        session: Option<Arc<Session>>,
         fs: Box<dyn RemoteFs>,
         app: AppHandle,
     ) -> String {
@@ -184,6 +204,7 @@ impl ScanManager {
             session_id,
             root: root.clone(),
             strategy: StdMutex::new(ScanStrategy::Generic),
+            note: StdMutex::new(None),
             cancel: CancelToken::new(),
             dirs: AtomicUsize::new(0),
             files: AtomicUsize::new(0),
@@ -195,7 +216,7 @@ impl ScanManager {
         let task_info = Arc::clone(&info);
         let mgr = Arc::clone(self);
         let task = tauri::async_runtime::spawn(async move {
-            run_scan(task_info, root, fs, app).await;
+            run_scan(task_info, root, session, fs, app).await;
             // Leave the handle in the map so `diskscan_tree`/`_status` can fetch
             // the settled result; the frontend evicts it when the tab closes.
             let _ = mgr;
@@ -229,48 +250,58 @@ impl ScanManager {
     }
 }
 
-/// The generic-walk scan body. Streams progress, builds the aggregated tree, and
-/// records the terminal result on `info`.
-async fn run_scan(info: Arc<ScanInfo>, root: String, fs: Box<dyn RemoteFs>, app: AppHandle) {
-    let opts = ScanOptions { concurrency: scan::DEFAULT_CONCURRENCY, cancel: info.cancel.clone() };
-
-    // Throttle progress events to ~10/s so a fast local walk doesn't flood the
-    // IPC channel. The atomics are always current for the query commands.
-    let mut last_emit = Instant::now();
-    let ev_info = Arc::clone(&info);
-    let ev_app = app.clone();
-    let on_progress = move |p: ScanProgress| {
-        ev_info.dirs.store(p.dirs_scanned, Ordering::Relaxed);
-        ev_info.files.store(p.files_found, Ordering::Relaxed);
-        ev_info.bytes.store(p.bytes_found, Ordering::Relaxed);
-        if last_emit.elapsed() >= Duration::from_millis(100) {
-            let _ = ev_app.emit(
-                "diskscan://progress",
-                ProgressEvent {
-                    id: ev_info.id.clone(),
-                    dirs_scanned: p.dirs_scanned,
-                    files_found: p.files_found,
-                    total_bytes: p.bytes_found,
-                    strategy: *ev_info.strategy.lock().unwrap(),
-                },
-            );
-            last_emit = Instant::now();
+/// Scan body: pick the fastest available strategy, produce a flat file tree, then
+/// aggregate + record the result. The fast paths (shell `find`, object listing)
+/// fall back to the generic walk on any failure so a scan never hard-fails on a
+/// missing tool or a denied exec.
+async fn run_scan(
+    info: Arc<ScanInfo>,
+    root: String,
+    session: Option<Arc<Session>>,
+    fs: Box<dyn RemoteFs>,
+    app: AppHandle,
+) {
+    let flat: Result<scan::ScanTree, anyhow::Error> = match session.as_deref() {
+        // Object stores: one flat listing under the prefix returns every key + size.
+        Some(Session::Object(obj)) => {
+            info.set_strategy(ScanStrategy::ObjectFlat);
+            emit_progress(&info, &app);
+            scan_object(obj, &root, &info, &app).await
         }
+        // SSH: a single `find … -printf` beats thousands of SFTP round-trips.
+        Some(Session::Ssh(ssh)) => {
+            info.set_strategy(ScanStrategy::Shell);
+            emit_progress(&info, &app);
+            match scan_shell_ssh(ssh, &root, &info, &app).await {
+                Ok(t) => Ok(t),
+                Err(e) => fallback_walk(&info, &fs, &root, &app, &e).await,
+            }
+        }
+        // Faro Agent: same idea, gated by the daemon's allowExec policy.
+        Some(Session::Agent(agent)) => {
+            info.set_strategy(ScanStrategy::Shell);
+            emit_progress(&info, &app);
+            match scan_shell_agent(agent, &root, &info, &app).await {
+                Ok(t) => Ok(t),
+                Err(e) => fallback_walk(&info, &fs, &root, &app, &e).await,
+            }
+        }
+        // Local FS, FTP, or no shell: the generic walk is the only option.
+        _ => generic_walk(&info, &fs, &root, &app).await,
     };
 
-    let walked = scan::walk(fs.as_ref(), &root, &opts, on_progress).await;
-
-    // Cancellation wins even if the walk returned an (empty/partial) Ok tree.
+    // Cancellation wins even if a strategy returned a partial Ok tree.
     if info.cancel.is_cancelled() {
         *info.result.lock().unwrap() = RunResult::Canceled;
         let _ = app.emit("diskscan://canceled", info.snapshot());
         return;
     }
 
-    match walked {
+    match flat {
         Ok(tree) => {
             let node = build_tree(&root, &tree);
             info.bytes.store(node.size, Ordering::Relaxed);
+            info.files.store(tree.files.len(), Ordering::Relaxed);
             *info.result.lock().unwrap() = RunResult::Done(node);
             let _ = app.emit("diskscan://done", info.snapshot());
         }
@@ -279,6 +310,230 @@ async fn run_scan(info: Arc<ScanInfo>, root: String, fs: Box<dyn RemoteFs>, app:
             let _ = app.emit("diskscan://error", info.snapshot());
         }
     }
+}
+
+fn emit_progress(info: &ScanInfo, app: &AppHandle) {
+    let _ = app.emit(
+        "diskscan://progress",
+        ProgressEvent {
+            id: info.id.clone(),
+            dirs_scanned: info.dirs.load(Ordering::Relaxed),
+            files_found: info.files.load(Ordering::Relaxed),
+            total_bytes: info.bytes.load(Ordering::Relaxed),
+            strategy: *info.strategy.lock().unwrap(),
+        },
+    );
+}
+
+/// The generic bounded-concurrency `RemoteFs` walk, streaming progress counts.
+async fn generic_walk(
+    info: &Arc<ScanInfo>,
+    fs: &Box<dyn RemoteFs>,
+    root: &str,
+    app: &AppHandle,
+) -> Result<scan::ScanTree, anyhow::Error> {
+    let opts = ScanOptions { concurrency: scan::DEFAULT_CONCURRENCY, cancel: info.cancel.clone() };
+    let mut last_emit = Instant::now();
+    let ev_info = Arc::clone(info);
+    let ev_app = app.clone();
+    let on_progress = move |p: ScanProgress| {
+        ev_info.dirs.store(p.dirs_scanned, Ordering::Relaxed);
+        ev_info.files.store(p.files_found, Ordering::Relaxed);
+        ev_info.bytes.store(p.bytes_found, Ordering::Relaxed);
+        if last_emit.elapsed() >= Duration::from_millis(100) {
+            emit_progress(&ev_info, &ev_app);
+            last_emit = Instant::now();
+        }
+    };
+    scan::walk(fs.as_ref(), root, &opts, on_progress).await
+}
+
+/// Reset to the generic walk after a fast path failed, recording why.
+async fn fallback_walk(
+    info: &Arc<ScanInfo>,
+    fs: &Box<dyn RemoteFs>,
+    root: &str,
+    app: &AppHandle,
+    reason: &anyhow::Error,
+) -> Result<scan::ScanTree, anyhow::Error> {
+    let msg = reason.to_string();
+    let short = msg.lines().next().unwrap_or(&msg);
+    let note = if short.contains("denied") {
+        "exec disabled — used walk".to_string()
+    } else {
+        format!("fast path unavailable — used walk ({short})")
+    };
+    tracing::info!("disk-usage fast path fell back: {msg}");
+    info.set_strategy(ScanStrategy::Generic);
+    info.set_note(note);
+    emit_progress(info, app);
+    generic_walk(info, fs, root, app).await
+}
+
+// ---------- Protocol fast paths ----------
+
+/// POSIX single-quote a path so `find` survives spaces / shell metacharacters.
+fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// `find <root> -type f -printf '%s\t%p\n'` — one line per regular file, its
+/// byte size and absolute path, tab-separated. Symlinks aren't `-type f`, so
+/// they're skipped exactly as the generic walk skips them.
+fn find_command(root: &str) -> String {
+    format!("find {} -type f -printf '%s\\t%p\\n'", sh_quote(root))
+}
+
+/// Parse `find -printf '%s\t%p\n'` output into a flat file tree.
+fn parse_find(root: &str, out: &str) -> scan::ScanTree {
+    let normalized_root = root.trim_end_matches('/');
+    let mut tree = scan::ScanTree::default();
+    for line in out.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            continue;
+        }
+        let Some((size_str, path)) = line.split_once('\t') else {
+            continue;
+        };
+        let Ok(size) = size_str.trim().parse::<u64>() else {
+            continue;
+        };
+        let rel = scan::relative_of(normalized_root, path);
+        if rel.is_empty() {
+            continue;
+        }
+        tree.files.insert(
+            rel,
+            scan::ScanEntry { absolute: path.to_string(), size, modified: 0, etag: None },
+        );
+    }
+    tree
+}
+
+/// Sum the flat file sizes into `info` and emit a progress tick.
+fn record_flat(info: &ScanInfo, tree: &scan::ScanTree, app: &AppHandle) {
+    let bytes: u64 = tree.files.values().map(|e| e.size).sum();
+    info.files.store(tree.files.len(), Ordering::Relaxed);
+    info.bytes.store(bytes, Ordering::Relaxed);
+    emit_progress(info, app);
+}
+
+async fn scan_shell_ssh(
+    ssh: &Arc<SshSession>,
+    root: &str,
+    info: &ScanInfo,
+    app: &AppHandle,
+) -> Result<scan::ScanTree> {
+    let out = ssh.exec(&find_command(root)).await.context("run find over SSH")?;
+    let tree = parse_find(root, &out.stdout);
+    // `find` exits non-zero when *some* subdir was unreadable, yet still lists the
+    // rest — accept a non-empty result. Only a truly empty non-zero run is a real
+    // failure (e.g. `find` missing), which falls back to the walk.
+    if tree.files.is_empty() && out.exit_code != Some(0) {
+        let err = out.stderr.trim();
+        anyhow::bail!(
+            "find failed (exit {:?}): {}",
+            out.exit_code,
+            if err.is_empty() { "no output" } else { err }
+        );
+    }
+    record_flat(info, &tree, app);
+    Ok(tree)
+}
+
+async fn scan_shell_agent(
+    agent: &Arc<AgentSession>,
+    root: &str,
+    info: &ScanInfo,
+    app: &AppHandle,
+) -> Result<scan::ScanTree> {
+    // Cap the captured output; if `find` overruns it the tree would be partial,
+    // so we bail to the (correct) generic walk instead.
+    const MAX: usize = 64 * 1024 * 1024;
+    let out = agent.exec(&find_command(root), MAX, 120_000).await?;
+    if out.timed_out {
+        anyhow::bail!("find timed out");
+    }
+    if out.truncated {
+        anyhow::bail!("find output exceeded the cap");
+    }
+    let tree = parse_find(root, &out.stdout);
+    if tree.files.is_empty() && out.exit_code != Some(0) {
+        let err = out.stderr.trim();
+        anyhow::bail!(
+            "find failed (exit {:?}): {}",
+            out.exit_code,
+            if err.is_empty() { "no output" } else { err }
+        );
+    }
+    record_flat(info, &tree, app);
+    Ok(tree)
+}
+
+async fn scan_object(
+    obj: &Arc<ObjectSession>,
+    root: &str,
+    info: &ScanInfo,
+    app: &AppHandle,
+) -> Result<scan::ScanTree> {
+    use futures::StreamExt;
+    use object_store::path::Path as ObjPath;
+    use object_store::ObjectStore;
+
+    let prefix_raw = root.trim().trim_matches('/');
+    let prefix = if prefix_raw.is_empty() || prefix_raw == "." {
+        String::new()
+    } else {
+        prefix_raw.to_string()
+    };
+    let prefix_path = if prefix.is_empty() {
+        None
+    } else {
+        Some(ObjPath::from(prefix.as_str()))
+    };
+
+    let mut stream = obj.store.list(prefix_path.as_ref());
+    let mut tree = scan::ScanTree::default();
+    let mut bytes = 0u64;
+    let mut last_emit = Instant::now();
+    while let Some(meta) = stream.next().await {
+        if info.cancel.is_cancelled() {
+            break;
+        }
+        let meta = meta.context("list objects")?;
+        let key = meta.location.as_ref().to_string();
+        let rel = if prefix.is_empty() {
+            key.clone()
+        } else {
+            key.strip_prefix(&prefix)
+                .unwrap_or(&key)
+                .trim_start_matches('/')
+                .to_string()
+        };
+        if rel.is_empty() {
+            continue; // a marker object for the prefix itself
+        }
+        let size = meta.size as u64;
+        bytes += size;
+        tree.files.insert(
+            rel,
+            scan::ScanEntry {
+                absolute: format!("/{key}"),
+                size,
+                modified: meta.last_modified.timestamp(),
+                etag: meta.e_tag.clone(),
+            },
+        );
+        info.files.store(tree.files.len(), Ordering::Relaxed);
+        info.bytes.store(bytes, Ordering::Relaxed);
+        if last_emit.elapsed() >= Duration::from_millis(100) {
+            emit_progress(info, app);
+            last_emit = Instant::now();
+        }
+    }
+    emit_progress(info, app);
+    Ok(tree)
 }
 
 /// The basename of a POSIX-ish path, tolerating a trailing slash. Empty → "/".
@@ -363,9 +618,22 @@ pub async fn diskscan_start(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
+    // The live Session (absent for the local FS) unlocks the protocol fast paths;
+    // `fs` is always the generic-walk fallback.
+    let session = if session_id == crate::commands::LOCAL_SESSION {
+        None
+    } else {
+        Some(
+            state
+                .sessions
+                .get(&session_id)
+                .await
+                .ok_or_else(|| format!("session {session_id} not found"))?,
+        )
+    };
     let fs = crate::commands::fs_for_public(&session_id, &state).await?;
     let mgr = Arc::clone(&state.diskscan);
-    Ok(mgr.start(session_id, path, fs, app).await)
+    Ok(mgr.start(session_id, path, session, fs, app).await)
 }
 
 #[tauri::command]

--- a/src-tauri/src/diskscan.rs
+++ b/src-tauri/src/diskscan.rs
@@ -729,4 +729,52 @@ mod tests {
         assert_eq!(root.children[0].path, "/etc");
         assert_eq!(root.children[0].children[0].path, "/etc/hosts");
     }
+
+    #[test]
+    fn parse_find_output_matches_the_walk_shape() {
+        // What `find <root> -type f -printf '%s\t%p\n'` prints — including a
+        // non-zero-noise CRLF line and an unparseable line that must be skipped.
+        let out = "10\t/data/a/b.txt\r\n20\t/data/a/c.txt\n5\t/data/d.txt\ngarbage line\n";
+        let tree = parse_find("/data", out);
+        assert_eq!(tree.files.len(), 3);
+        assert_eq!(tree.files["a/b.txt"].size, 10);
+        assert_eq!(tree.files["a/c.txt"].size, 20);
+        assert_eq!(tree.files["d.txt"].size, 5);
+        // Aggregates identically to the generic walk.
+        let root = build_tree("/data", &tree);
+        assert_eq!(root.size, 35);
+        assert_eq!(root.children[0].name, "a");
+        assert_eq!(root.children[0].size, 30);
+    }
+
+    // A real end-to-end run of the "always works" generic strategy: walk an
+    // actual temp directory over LocalFs and fold it into the size tree. This is
+    // the runtime observation the whole feature leans on (every backend falls
+    // back to it), exercised without the Tauri/event plumbing.
+    #[tokio::test]
+    async fn walks_a_real_directory_into_a_size_tree() {
+        use crate::remotefs::local::LocalFs;
+        let base = std::env::temp_dir()
+            .join(format!("faro_diskscan_walk_{}", std::process::id()));
+        let sub = base.join("sub");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(base.join("top.bin"), vec![0u8; 100]).unwrap();
+        std::fs::write(sub.join("inner.bin"), vec![0u8; 250]).unwrap();
+
+        let root_str = base.to_string_lossy().to_string();
+        let tree = crate::scan::walk_tree(&LocalFs, &root_str).await.unwrap();
+        let node = build_tree(&root_str, &tree);
+
+        assert_eq!(node.size, 350);
+        assert_eq!(node.kind, FileKind::Directory);
+        // Largest-first: the 250-byte "sub" dir leads the 100-byte file.
+        assert_eq!(node.children[0].name, "sub");
+        assert_eq!(node.children[0].size, 250);
+        assert_eq!(node.children[0].kind, FileKind::Directory);
+        assert_eq!(node.children[1].name, "top.bin");
+        assert_eq!(node.children[1].size, 100);
+
+        std::fs::remove_dir_all(&base).ok();
+    }
 }

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -452,6 +452,21 @@ async fn download_to(
             }
             file.flush().await?;
         }
+        Session::Box(bx) => {
+            use futures::StreamExt;
+            let (file_id, _) = bx
+                .resolve_item(remote_path)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("{remote_path}: not found"))?;
+            let resp = bx.get_stream(&format!("/files/{file_id}/content")).await?;
+            let mut file = tokio::fs::File::create(local_path).await?;
+            let mut stream = resp.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+                file.write_all(&chunk).await?;
+            }
+            file.flush().await?;
+        }
         Session::Agent(agent) => {
             use base64::Engine as _;
             use faro_agent_proto::msg::{Request, Response};
@@ -635,6 +650,31 @@ async fn upload_from(
                 let code = resp.status().as_u16();
                 let text = resp.text().await.unwrap_or_default();
                 return Err(anyhow::anyhow!("gdrive upload {remote_path} ({code}): {text}"));
+            }
+        }
+        Session::Box(bx) => {
+            // Edit-in-place uploads a new version of the existing file.
+            let (file_id, _) = bx
+                .resolve_item(remote_path)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("{remote_path}: not found"))?;
+            let token = bx.access_token().await?;
+            let bytes = tokio::fs::read(&local).await?;
+            let part = reqwest::multipart::Part::bytes(bytes)
+                .file_name(crate::session::boxdrive::basename(remote_path).to_string());
+            let form = reqwest::multipart::Form::new().part("file", part);
+            let resp = bx
+                .client
+                .post(format!("{}/files/{file_id}/content", bx.upload_base))
+                .bearer_auth(&token)
+                .multipart(form)
+                .send()
+                .await
+                .with_context(|| format!("box update {remote_path}"))?;
+            if !resp.status().is_success() {
+                let code = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!("box upload {remote_path} ({code}): {text}"));
             }
         }
         Session::Agent(agent) => {

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -409,6 +409,21 @@ async fn download_to(
             }
             file.flush().await?;
         }
+        Session::Dropbox(dbx) => {
+            use futures::StreamExt;
+            let arg = serde_json::json!({
+                "path": crate::remotefs::dropbox::dropbox_api_path(remote_path)
+            })
+            .to_string();
+            let resp = dbx.content_get("/2/files/download", &arg).await?;
+            let mut file = tokio::fs::File::create(local_path).await?;
+            let mut stream = resp.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+                file.write_all(&chunk).await?;
+            }
+            file.flush().await?;
+        }
         Session::Agent(agent) => {
             use base64::Engine as _;
             use faro_agent_proto::msg::{Request, Response};
@@ -520,6 +535,32 @@ async fn upload_from(
             return Err(anyhow::anyhow!(
                 "HTTP source is read-only — saving edits is not supported"
             ));
+        }
+        Session::Dropbox(dbx) => {
+            use tokio_util::io::ReaderStream;
+            let arg = serde_json::json!({
+                "path": crate::remotefs::dropbox::dropbox_api_path(remote_path),
+                "mode": "overwrite", "autorename": false, "mute": true
+            })
+            .to_string();
+            let token = dbx.access_token().await?;
+            let f = tokio::fs::File::open(&local).await?;
+            let body = reqwest::Body::wrap_stream(ReaderStream::new(f));
+            let resp = dbx
+                .client
+                .post(format!("{}/2/files/upload", dbx.content_base))
+                .bearer_auth(&token)
+                .header("Dropbox-API-Arg", &arg)
+                .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+                .body(body)
+                .send()
+                .await
+                .with_context(|| format!("dropbox upload {remote_path}"))?;
+            if !resp.status().is_success() {
+                let code = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!("dropbox upload {remote_path} ({code}): {text}"));
+            }
         }
         Session::Agent(agent) => {
             use base64::Engine as _;

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -365,6 +365,28 @@ async fn download_to(
             }
             file.flush().await?;
         }
+        Session::Webdav(dav) => {
+            use futures::StreamExt;
+            let url = dav.url_for(remote_path, false);
+            let resp = dav
+                .request(reqwest::Method::GET, url)
+                .send()
+                .await
+                .with_context(|| format!("webdav get {remote_path}"))?;
+            if !resp.status().is_success() {
+                return Err(anyhow::anyhow!(
+                    "webdav get {remote_path}: HTTP {}",
+                    resp.status().as_u16()
+                ));
+            }
+            let mut file = tokio::fs::File::create(local_path).await?;
+            let mut stream = resp.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+                file.write_all(&chunk).await?;
+            }
+            file.flush().await?;
+        }
         Session::Agent(agent) => {
             use base64::Engine as _;
             use faro_agent_proto::msg::{Request, Response};
@@ -452,6 +474,25 @@ async fn upload_from(
                 .put(&p, bytes::Bytes::from(buf).into())
                 .await
                 .with_context(|| format!("object put {key}"))?;
+        }
+        Session::Webdav(dav) => {
+            use tokio_util::io::ReaderStream;
+            let file = tokio::fs::File::open(&local).await?;
+            let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+            let url = dav.url_for(remote_path, false);
+            let resp = dav
+                .request(reqwest::Method::PUT, url)
+                .header(reqwest::header::CONTENT_LENGTH, size)
+                .body(body)
+                .send()
+                .await
+                .with_context(|| format!("webdav put {remote_path}"))?;
+            if !resp.status().is_success() {
+                return Err(anyhow::anyhow!(
+                    "webdav put {remote_path}: HTTP {}",
+                    resp.status().as_u16()
+                ));
+            }
         }
         Session::Agent(agent) => {
             use base64::Engine as _;

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -387,6 +387,28 @@ async fn download_to(
             }
             file.flush().await?;
         }
+        Session::Http(http) => {
+            use futures::StreamExt;
+            let url = http.url_for(remote_path, false);
+            let resp = http
+                .request(reqwest::Method::GET, url)
+                .send()
+                .await
+                .with_context(|| format!("http get {remote_path}"))?;
+            if !resp.status().is_success() {
+                return Err(anyhow::anyhow!(
+                    "http get {remote_path}: HTTP {}",
+                    resp.status().as_u16()
+                ));
+            }
+            let mut file = tokio::fs::File::create(local_path).await?;
+            let mut stream = resp.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+                file.write_all(&chunk).await?;
+            }
+            file.flush().await?;
+        }
         Session::Agent(agent) => {
             use base64::Engine as _;
             use faro_agent_proto::msg::{Request, Response};
@@ -493,6 +515,11 @@ async fn upload_from(
                     resp.status().as_u16()
                 ));
             }
+        }
+        Session::Http(_) => {
+            return Err(anyhow::anyhow!(
+                "HTTP source is read-only — saving edits is not supported"
+            ));
         }
         Session::Agent(agent) => {
             use base64::Engine as _;

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -437,6 +437,21 @@ async fn download_to(
             }
             file.flush().await?;
         }
+        Session::GDrive(gd) => {
+            use futures::StreamExt;
+            let (file_id, _) = gd
+                .resolve_item(remote_path)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("{remote_path}: not found"))?;
+            let resp = gd.get_stream(&format!("/files/{file_id}?alt=media")).await?;
+            let mut file = tokio::fs::File::create(local_path).await?;
+            let mut stream = resp.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+                file.write_all(&chunk).await?;
+            }
+            file.flush().await?;
+        }
         Session::Agent(agent) => {
             use base64::Engine as _;
             use faro_agent_proto::msg::{Request, Response};
@@ -597,6 +612,29 @@ async fn upload_from(
                 let code = resp.status().as_u16();
                 let text = resp.text().await.unwrap_or_default();
                 return Err(anyhow::anyhow!("onedrive upload {remote_path} ({code}): {text}"));
+            }
+        }
+        Session::GDrive(gd) => {
+            // Edit-in-place always targets an existing file: update its media.
+            let (file_id, _) = gd
+                .resolve_item(remote_path)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("{remote_path}: not found"))?;
+            let token = gd.access_token().await?;
+            let bytes = tokio::fs::read(&local).await?;
+            let resp = gd
+                .client
+                .patch(format!("{}/files/{file_id}?uploadType=media", gd.upload_base))
+                .bearer_auth(&token)
+                .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+                .body(bytes)
+                .send()
+                .await
+                .with_context(|| format!("gdrive update {remote_path}"))?;
+            if !resp.status().is_success() {
+                let code = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!("gdrive upload {remote_path} ({code}): {text}"));
             }
         }
         Session::Agent(agent) => {

--- a/src-tauri/src/editor.rs
+++ b/src-tauri/src/editor.rs
@@ -424,6 +424,19 @@ async fn download_to(
             }
             file.flush().await?;
         }
+        Session::OneDrive(od) => {
+            use futures::StreamExt;
+            let resp = od
+                .get_stream(&crate::remotefs::onedrive::content_ref(remote_path))
+                .await?;
+            let mut file = tokio::fs::File::create(local_path).await?;
+            let mut stream = resp.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+                file.write_all(&chunk).await?;
+            }
+            file.flush().await?;
+        }
         Session::Agent(agent) => {
             use base64::Engine as _;
             use faro_agent_proto::msg::{Request, Response};
@@ -560,6 +573,30 @@ async fn upload_from(
                 let code = resp.status().as_u16();
                 let text = resp.text().await.unwrap_or_default();
                 return Err(anyhow::anyhow!("dropbox upload {remote_path} ({code}): {text}"));
+            }
+        }
+        Session::OneDrive(od) => {
+            use tokio_util::io::ReaderStream;
+            let token = od.access_token().await?;
+            let f = tokio::fs::File::open(&local).await?;
+            let body = reqwest::Body::wrap_stream(ReaderStream::new(f));
+            let resp = od
+                .client
+                .put(format!(
+                    "{}{}",
+                    od.graph_base,
+                    crate::remotefs::onedrive::content_ref(remote_path)
+                ))
+                .bearer_auth(&token)
+                .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+                .body(body)
+                .send()
+                .await
+                .with_context(|| format!("onedrive upload {remote_path}"))?;
+            if !resp.status().is_success() {
+                let code = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!("onedrive upload {remote_path} ({code}): {text}"));
             }
         }
         Session::Agent(agent) => {

--- a/src-tauri/src/foldersync.rs
+++ b/src-tauri/src/foldersync.rs
@@ -417,13 +417,26 @@ async fn reconcile_inner(
         Box::new(crate::remotefs::local::LocalFs);
     let remote_fs = crate::commands::fs_for_session(&session);
 
-    let mut plan = crate::sync::plan(
+    // The index tracks the *source* side (authoritative for one-way sync); its
+    // change signal comes from that backend's capabilities.
+    let source_signal = match pair.direction {
+        SyncDirection::LocalToRemote => local_fs.capabilities().change_signal,
+        SyncDirection::RemoteToLocal => remote_fs.capabilities().change_signal,
+    };
+    let index = state.db.load_sync_state(&pair.id).unwrap_or_else(|e| {
+        tracing::warn!("folder sync '{}': reading sync_state: {e:#}", pair.name);
+        Default::default()
+    });
+
+    let (mut plan, source_tree) = crate::sync::plan_indexed(
         local_fs.as_ref(),
         remote_fs.as_ref(),
         &pair.local_root,
         &pair.remote_root,
         pair.direction,
         pair.strategy,
+        Some(&index),
+        source_signal,
     )
     .await
     .context("planning sync")?;
@@ -444,6 +457,10 @@ async fn reconcile_inner(
     let warning = apply_safety(&mut plan, pair, source_available);
 
     if plan.copies.is_empty() && plan.deletes.is_empty() {
+        // Nothing to transfer — but still snapshot the source so a first run
+        // seeds the index (later same-size edits become detectable) and a delete
+        // prunes its row.
+        snapshot_index(&state.db, &pair.id, &source_tree, &index);
         return Ok(warning);
     }
 
@@ -452,7 +469,37 @@ async fn reconcile_inner(
         .context("executing sync")?;
 
     wait_for_transfers(state, ids).await;
+
+    // Record what the source looks like now, so the next reconcile compares
+    // against reality rather than re-uploading (resume) and catches in-place
+    // edits the live size/mtime diff would miss.
+    snapshot_index(&state.db, &pair.id, &source_tree, &index);
     Ok(warning)
+}
+
+/// Persist the current source tree into `sync_state`: upsert a row per file and
+/// prune rows for files that have disappeared from the source. Best-effort — a
+/// DB hiccup here only costs the optimization, never correctness (the live diff
+/// still runs every reconcile).
+fn snapshot_index(
+    db: &crate::db::Db,
+    pair_id: &str,
+    source_tree: &crate::scan::ScanTree,
+    before: &std::collections::HashMap<String, crate::db::SyncStateRow>,
+) {
+    let now = now_ms();
+    for (rel, e) in &source_tree.files {
+        if let Err(err) =
+            db.upsert_sync_state(pair_id, rel, e.size, e.modified, e.etag.as_deref(), now)
+        {
+            tracing::warn!("folder sync: sync_state upsert '{rel}': {err:#}");
+        }
+    }
+    for rel in before.keys() {
+        if !source_tree.files.contains_key(rel) {
+            let _ = db.delete_sync_state(pair_id, rel);
+        }
+    }
 }
 
 /// Return a live `Arc<Session>` for the pair, reusing the cached session id when
@@ -817,6 +864,8 @@ pub async fn foldersync_remove(
     state: State<'_, AppState>,
 ) -> Result<Vec<PairView>, String> {
     state.foldersync.remove(&id).await.map_err(err)?;
+    // Drop the pair's index rows so a future pair reusing the id starts clean.
+    let _ = state.db.clear_pair(&id);
     Ok(state.foldersync.views().await)
 }
 

--- a/src-tauri/src/foldersync.rs
+++ b/src-tauri/src/foldersync.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::sync::{mpsc, Mutex};
 
-use crate::sync::{SyncDirection, SyncStrategy};
+use crate::sync::{SyncDirection, SyncPlan, SyncStrategy};
 use crate::transfer::TransferStatus;
 use crate::AppState;
 
@@ -69,10 +69,26 @@ pub struct SyncPair {
     pub enabled: bool,
     #[serde(default = "default_poll_secs")]
     pub poll_interval_secs: u64,
+    /// gitignore-style patterns; matching files are neither pushed nor (under
+    /// Mirror) deleted. See [`is_excluded`].
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    /// Safety cap on how many destination files a single Mirror reconcile may
+    /// delete. `0` disables the cap. Doesn't apply to Additive (no deletes).
+    #[serde(default = "default_mirror_delete_cap")]
+    pub mirror_delete_cap: u32,
 }
 
 fn default_poll_secs() -> u64 {
     DEFAULT_POLL_SECS
+}
+
+/// Default blast-radius cap for Mirror deletes — high enough for normal churn,
+/// low enough to catch "the source folder vanished, delete everything remote."
+const DEFAULT_MIRROR_DELETE_CAP: u32 = 100;
+
+fn default_mirror_delete_cap() -> u32 {
+    DEFAULT_MIRROR_DELETE_CAP
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -360,11 +376,14 @@ async fn reconcile(
 
     let result = reconcile_inner(app, &state, pair, session_id).await;
     match result {
-        Ok(()) => {
+        // `Some(warning)` = the reconcile completed, but the Mirror-delete guard
+        // held some deletes back. Uploads still happened, so we report success
+        // (Idle + last_synced) while surfacing the guard note in `last_error`.
+        Ok(warning) => {
             set_state(app, status, PairState::Idle, |s| {
                 s.in_flight = 0;
                 s.last_synced = Some(now_ms());
-                s.last_error = None;
+                s.last_error = warning;
             })
             .await;
         }
@@ -382,12 +401,15 @@ async fn reconcile(
     }
 }
 
+/// Runs one reconcile. `Ok(None)` = clean; `Ok(Some(msg))` = completed but the
+/// Mirror-delete guard withheld deletes (a warning, not a failure); `Err` = the
+/// reconcile failed outright.
 async fn reconcile_inner(
     app: &AppHandle,
     state: &AppState,
     pair: &SyncPair,
     session_id: &mut Option<String>,
-) -> Result<()> {
+) -> Result<Option<String>> {
     // Ensure a live session for this pair's connection.
     let session = ensure_session(app, state, pair, session_id).await?;
 
@@ -395,7 +417,7 @@ async fn reconcile_inner(
         Box::new(crate::remotefs::local::LocalFs);
     let remote_fs = crate::commands::fs_for_session(&session);
 
-    let plan = crate::sync::plan(
+    let mut plan = crate::sync::plan(
         local_fs.as_ref(),
         remote_fs.as_ref(),
         &pair.local_root,
@@ -406,8 +428,23 @@ async fn reconcile_inner(
     .await
     .context("planning sync")?;
 
+    // For Mirror, learn whether the source root currently has any entries
+    // *before* trusting the diff's delete set (see `apply_safety`). Skip the
+    // extra listing for Additive, which never deletes.
+    let source_available = if matches!(pair.strategy, SyncStrategy::Mirror) {
+        let (src_fs, src_root): (&dyn crate::remotefs::RemoteFs, &str) = match pair.direction {
+            SyncDirection::LocalToRemote => (local_fs.as_ref(), pair.local_root.as_str()),
+            SyncDirection::RemoteToLocal => (remote_fs.as_ref(), pair.remote_root.as_str()),
+        };
+        matches!(src_fs.list_dir(src_root).await, Ok(e) if !e.is_empty())
+    } else {
+        true
+    };
+
+    let warning = apply_safety(&mut plan, pair, source_available);
+
     if plan.copies.is_empty() && plan.deletes.is_empty() {
-        return Ok(());
+        return Ok(warning);
     }
 
     let ids = crate::commands::execute_sync_plan(session, plan, &state.transfers, app)
@@ -415,7 +452,7 @@ async fn reconcile_inner(
         .context("executing sync")?;
 
     wait_for_transfers(state, ids).await;
-    Ok(())
+    Ok(warning)
 }
 
 /// Return a live `Arc<Session>` for the pair, reusing the cached session id when
@@ -487,6 +524,270 @@ async fn set_state(
         mutate(&mut s);
     }
     let _ = app.emit("foldersync://changed", ());
+}
+
+// ---------- safety: exclude patterns + Mirror-delete guard ----------
+
+/// Apply exclude patterns and the Mirror-delete guard to a freshly-planned
+/// `SyncPlan`, in place. Returns `Some(warning)` when the guard withheld
+/// deletes (the uploads still stand — only the destructive half is gated).
+///
+/// `source_available` is whether the source root currently lists any entries.
+/// An empty or unreadable source is the classic footgun — an unmounted drive,
+/// a deleted folder, a typo'd path — where the diff sees "nothing on the
+/// source" and a naive Mirror would wipe the entire destination. We refuse.
+fn apply_safety(plan: &mut SyncPlan, pair: &SyncPair, source_available: bool) -> Option<String> {
+    // Excludes: drop matching files from BOTH copies and deletes, so an excluded
+    // path is neither uploaded nor (under Mirror) deleted on the far side.
+    if !pair.exclude.is_empty() {
+        plan.copies.retain(|c| !is_excluded(&c.relative, &pair.exclude));
+        plan.deletes.retain(|d| !is_excluded(&d.relative, &pair.exclude));
+        plan.total_bytes = plan.copies.iter().map(|c| c.size).sum();
+    }
+
+    if !matches!(pair.strategy, SyncStrategy::Mirror) || plan.deletes.is_empty() {
+        return None;
+    }
+
+    if !source_available {
+        let n = plan.deletes.len();
+        plan.deletes.clear();
+        return Some(format!(
+            "Mirror guard: skipped deleting {n} destination file(s) — the source folder is empty or unreadable (is it mounted?)."
+        ));
+    }
+
+    if pair.mirror_delete_cap != 0 && plan.deletes.len() as u32 > pair.mirror_delete_cap {
+        let n = plan.deletes.len();
+        plan.deletes.clear();
+        return Some(format!(
+            "Mirror guard: skipped deleting {n} destination file(s) — over the {}-file safety cap. Raise the cap if this is intended.",
+            pair.mirror_delete_cap
+        ));
+    }
+
+    None
+}
+
+// ---------- exclude patterns ----------
+
+/// gitignore-lite matcher. A relative path (POSIX, '/'-separated) is excluded
+/// when any pattern matches. Rules:
+/// - blank lines and `#` comments are ignored;
+/// - a trailing `/` is stripped (dir patterns match the same as file patterns);
+/// - a pattern with no `/` (e.g. `node_modules`, `*.log`, `.DS_Store`) matches
+///   any single path segment at any depth;
+/// - a pattern containing `/` (or a leading `/`) is matched against the whole
+///   relative path, anchored at the root, and also excludes everything beneath
+///   a matched directory.
+///
+/// Wildcards: `*` matches within a segment, `**` crosses `/`, `?` is one
+/// non-`/` char.
+fn is_excluded(rel: &str, patterns: &[String]) -> bool {
+    let rel = rel.trim_start_matches('/');
+    for raw in patterns {
+        let pat = raw.trim();
+        if pat.is_empty() || pat.starts_with('#') {
+            continue;
+        }
+        let anchored = pat.starts_with('/');
+        let pat = pat.trim_start_matches('/').trim_end_matches('/');
+        if pat.is_empty() {
+            continue;
+        }
+        if anchored || pat.contains('/') {
+            // Whole-path match, plus descendants of a matched directory.
+            if glob_match(pat, rel) || glob_match(&format!("{pat}/**"), rel) {
+                return true;
+            }
+        } else {
+            // Basename-style: match against any single path segment.
+            if rel.split('/').any(|seg| glob_match(pat, seg)) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Glob match with `*` (any run within a segment), `**` (any run incl. `/`),
+/// and `?` (one non-`/` char). Both sides are POSIX strings.
+fn glob_match(pattern: &str, text: &str) -> bool {
+    glob_rec(pattern.as_bytes(), text.as_bytes())
+}
+
+fn glob_rec(p: &[u8], t: &[u8]) -> bool {
+    if p.is_empty() {
+        return t.is_empty();
+    }
+    match p[0] {
+        b'*' if p.len() >= 2 && p[1] == b'*' => {
+            // `**` — optionally followed by `/`; matches any run including `/`.
+            let rest = if p.len() >= 3 && p[2] == b'/' { &p[3..] } else { &p[2..] };
+            if glob_rec(rest, t) {
+                return true;
+            }
+            (0..t.len()).any(|i| glob_rec(rest, &t[i + 1..]))
+        }
+        b'*' => {
+            // `*` — any run of non-`/` chars.
+            if glob_rec(&p[1..], t) {
+                return true;
+            }
+            let mut i = 0;
+            while i < t.len() && t[i] != b'/' {
+                if glob_rec(&p[1..], &t[i + 1..]) {
+                    return true;
+                }
+                i += 1;
+            }
+            false
+        }
+        b'?' => !t.is_empty() && t[0] != b'/' && glob_rec(&p[1..], &t[1..]),
+        c => !t.is_empty() && t[0] == c && glob_rec(&p[1..], &t[1..]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_safety, is_excluded, SyncPair};
+    use crate::sync::{self, SyncDirection, SyncStrategy};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn ex(rel: &str, pats: &[&str]) -> bool {
+        let pats: Vec<String> = pats.iter().map(|s| s.to_string()).collect();
+        is_excluded(rel, &pats)
+    }
+
+    #[test]
+    fn basename_patterns_match_at_any_depth() {
+        assert!(ex("node_modules/react/index.js", &["node_modules"]));
+        assert!(ex(".git/config", &[".git"]));
+        assert!(ex("a/b/c.log", &["*.log"]));
+        assert!(ex(".DS_Store", &[".DS_Store"]));
+        assert!(!ex("src/main.rs", &["*.log", "node_modules"]));
+    }
+
+    #[test]
+    fn path_patterns_are_anchored_and_cover_descendants() {
+        assert!(ex("dist/app.js", &["/dist"])); // anchored dir + descendants
+        assert!(ex("build/x/y.o", &["build/**"]));
+        assert!(ex("build/app.js", &["build"])); // path-anchored dir name
+        assert!(!ex("src/dist/app.js", &["/dist"])); // anchored, not any-depth
+        assert!(ex("a/b/temp.tmp", &["a/**/*.tmp"]));
+    }
+
+    #[test]
+    fn blanks_and_comments_are_ignored() {
+        assert!(!ex("src/main.rs", &["", "  ", "# a comment"]));
+    }
+
+    // ----- on-disk exercise of the real planner + guard -----
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn scratch(tag: &str) -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut d = std::env::temp_dir();
+        d.push(format!("faro_fs_test_{}_{tag}_{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn write(root: &PathBuf, rel: &str, body: &str) {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, body).unwrap();
+    }
+
+    fn pair(exclude: &[&str], cap: u32) -> SyncPair {
+        SyncPair {
+            id: "t".into(),
+            name: "t".into(),
+            local_root: String::new(),
+            profile_id: String::new(),
+            remote_root: String::new(),
+            direction: SyncDirection::LocalToRemote,
+            strategy: SyncStrategy::Mirror,
+            enabled: true,
+            poll_interval_secs: 60,
+            exclude: exclude.iter().map(|s| s.to_string()).collect(),
+            mirror_delete_cap: cap,
+        }
+    }
+
+    async fn plan_dirs(src: &PathBuf, dst: &PathBuf) -> sync::SyncPlan {
+        let fs = crate::remotefs::local::LocalFs;
+        sync::plan(
+            &fs,
+            &fs,
+            src.to_str().unwrap(),
+            dst.to_str().unwrap(),
+            SyncDirection::LocalToRemote,
+            SyncStrategy::Mirror,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[test]
+    fn excludes_and_guard_over_real_files() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let src = scratch("src");
+            let dst = scratch("dst");
+
+            // Source tree: a normal file, an excluded dir, an excluded ext,
+            // and a nested keeper.
+            write(&src, "keep.txt", "hi");
+            write(&src, "sub/b.txt", "b");
+            write(&src, "node_modules/pkg/index.js", "x");
+            write(&src, "debug.log", "log");
+
+            // Destination has extras (Mirror deletes) — including one under an
+            // excluded dir that must survive.
+            write(&dst, "extra1.txt", "1");
+            write(&dst, "extra2.txt", "2");
+            write(&dst, "node_modules/pkg/old.js", "old");
+
+            let excl = &["node_modules", "*.log"];
+
+            // 1) Excludes filter copies + protect excluded deletes.
+            let mut p = plan_dirs(&src, &dst).await;
+            let w = apply_safety(&mut p, &pair(excl, 100), true);
+            assert!(w.is_none(), "under cap, available source → no warning");
+            let copies: Vec<&str> = p.copies.iter().map(|c| c.relative.as_str()).collect();
+            assert!(copies.contains(&"sub/b.txt"));
+            assert!(!copies.iter().any(|r| r.contains("node_modules")));
+            assert!(!copies.iter().any(|r| r.ends_with(".log")));
+            let dels: Vec<&str> = p.deletes.iter().map(|d| d.relative.as_str()).collect();
+            assert!(dels.contains(&"extra1.txt") && dels.contains(&"extra2.txt"));
+            assert!(
+                !dels.iter().any(|r| r.contains("node_modules")),
+                "excluded destination files are never mirror-deleted"
+            );
+
+            // 2) Delete cap trips → deletes withheld, warning surfaced.
+            let mut p = plan_dirs(&src, &dst).await;
+            let w = apply_safety(&mut p, &pair(excl, 1), true);
+            assert!(w.unwrap().contains("safety cap"));
+            assert!(p.deletes.is_empty(), "over-cap deletes are withheld");
+            assert!(!p.copies.is_empty(), "uploads still proceed past the guard");
+
+            // 3) Empty/unreadable source → never wipe the destination.
+            let mut p = plan_dirs(&src, &dst).await;
+            let w = apply_safety(&mut p, &pair(excl, 100), false);
+            assert!(w.unwrap().contains("empty or unreadable"));
+            assert!(p.deletes.is_empty());
+
+            let _ = std::fs::remove_dir_all(&src);
+            let _ = std::fs::remove_dir_all(&dst);
+        });
+    }
 }
 
 // ---------- Tauri commands ----------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,11 +6,12 @@ use tauri::Manager;
 // secrets directly — credentials live in profiles::ConnectionProfile, which
 // the CLI deliberately redacts in `profiles show`.
 pub mod bridge;
-mod commands;
+pub mod commands;
 pub mod agent;
 mod agent_host;
 pub mod db;
 mod deeplink;
+mod diskscan;
 mod editor;
 mod foldersync;
 pub mod importers;
@@ -32,6 +33,8 @@ pub struct AppState {
     pub bridge: Arc<bridge::BridgeState>,
     pub agent_host: Arc<agent_host::AgentHost>,
     pub foldersync: Arc<foldersync::FolderSync>,
+    /// Running disk-usage scans (Plan 4). Ephemeral — not persisted.
+    pub diskscan: Arc<diskscan::ScanManager>,
     /// Shared `faro.db` — the per-connection index (sync_state today; scan/search
     /// caches later). See `db.rs`.
     pub db: Arc<db::Db>,
@@ -91,6 +94,7 @@ pub fn run() {
                     foldersync::FolderSync::load(&handle)
                         .expect("failed to initialise folder sync settings"),
                 ),
+                diskscan: Arc::new(diskscan::ScanManager::new()),
                 db,
             };
             app.manage(state);
@@ -161,6 +165,11 @@ pub fn run() {
             foldersync::foldersync_remove,
             foldersync::foldersync_set_enabled,
             foldersync::foldersync_sync_now,
+            diskscan::diskscan_start,
+            diskscan::diskscan_status,
+            diskscan::diskscan_tree,
+            diskscan::diskscan_cancel,
+            diskscan::diskscan_forget,
             commands::list_agent_jobs,
             commands::kill_agent_job,
             commands::respond_to_host_prompt,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -158,6 +158,7 @@ pub fn run() {
             commands::dropbox_authorize,
             commands::onedrive_authorize,
             commands::gdrive_authorize,
+            commands::box_authorize,
             agent_host::agent_host_status,
             agent_host::agent_host_set_enabled,
             agent_host::agent_host_open_pairing,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,6 +155,7 @@ pub fn run() {
             commands::discover_agents,
             commands::agent_public_key,
             commands::pair_agent,
+            commands::dropbox_authorize,
             agent_host::agent_host_status,
             agent_host::agent_host_set_enabled,
             agent_host::agent_host_open_pairing,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod importers;
 mod known_hosts;
 pub mod profiles;
 pub mod remotefs;
+pub mod scan;
 pub mod session;
 pub mod sync;
 mod terminal;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -156,6 +156,7 @@ pub fn run() {
             commands::agent_public_key,
             commands::pair_agent,
             commands::dropbox_authorize,
+            commands::onedrive_authorize,
             agent_host::agent_host_status,
             agent_host::agent_host_set_enabled,
             agent_host::agent_host_open_pairing,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod bridge;
 mod commands;
 pub mod agent;
 mod agent_host;
+pub mod db;
 mod deeplink;
 mod editor;
 mod foldersync;
@@ -30,6 +31,9 @@ pub struct AppState {
     pub bridge: Arc<bridge::BridgeState>,
     pub agent_host: Arc<agent_host::AgentHost>,
     pub foldersync: Arc<foldersync::FolderSync>,
+    /// Shared `faro.db` — the per-connection index (sync_state today; scan/search
+    /// caches later). See `db.rs`.
+    pub db: Arc<db::Db>,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -61,6 +65,14 @@ pub fn run() {
                 profiles::ProfileStore::load_or_create(&handle)
                     .expect("failed to initialise profile store"),
             );
+            let db = {
+                let dir = handle
+                    .path()
+                    .app_data_dir()
+                    .expect("resolving app_data_dir for faro.db");
+                std::fs::create_dir_all(&dir).ok();
+                Arc::new(db::Db::open(&dir.join("faro.db")).expect("failed to open faro.db"))
+            };
             let state = AppState {
                 sessions: Arc::new(session::SessionManager::new()),
                 ptys: Arc::new(terminal::PtyManager::new()),
@@ -78,6 +90,7 @@ pub fn run() {
                     foldersync::FolderSync::load(&handle)
                         .expect("failed to initialise folder sync settings"),
                 ),
+                db,
             };
             app.manage(state);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod editor;
 mod foldersync;
 pub mod importers;
 mod known_hosts;
+pub mod oauth;
 pub mod profiles;
 pub mod remotefs;
 pub mod scan;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,6 +157,7 @@ pub fn run() {
             commands::pair_agent,
             commands::dropbox_authorize,
             commands::onedrive_authorize,
+            commands::gdrive_authorize,
             agent_host::agent_host_status,
             agent_host::agent_host_set_enabled,
             agent_host::agent_host_open_pairing,

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1,0 +1,409 @@
+//! Shared OAuth 2.0 infrastructure for the consumer-cloud backends (Plan 5).
+//!
+//! Implements the loopback + PKCE authorization-code flow (RFC 8252 / 7636) with
+//! no external OAuth crate: a fixed-port local HTTP listener catches the redirect,
+//! the code is exchanged for tokens against a configurable token endpoint, and
+//! refresh is a second form POST. Dropbox is the first consumer; OneDrive / Drive
+//! / Box reuse the same helper by supplying a different `OAuthConfig`.
+//!
+//! Tokens live in the OS keychain (`keyring`), never in the plaintext profile
+//! JSON — refresh tokens are long-lived bearer credentials.
+
+use anyhow::{anyhow, Context, Result};
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use url::Url;
+
+/// Fixed loopback redirect port. Deterministic so the maintainer registers
+/// exactly `http://localhost:53682/` as the app's redirect URI (the same port
+/// rclone uses, for the same reason). See the provider app-setup notes.
+pub const REDIRECT_PORT: u16 = 53682;
+
+/// Everything provider-specific about an OAuth flow. Endpoints are fields (not
+/// constants) so tests can point them at a local mock.
+#[derive(Clone)]
+pub struct OAuthConfig {
+    pub client_id: String,
+    pub auth_url: String,
+    pub token_url: String,
+    pub scopes: Vec<String>,
+    /// Extra query params on the authorize URL (e.g. Dropbox's
+    /// `token_access_type=offline` to get a refresh token).
+    pub extra_auth_params: Vec<(String, String)>,
+}
+
+/// Tokens returned by an exchange/refresh. `expires_at` is an absolute Unix
+/// timestamp (seconds); 0 means "unknown, treat as expired".
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TokenSet {
+    pub access_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    pub expires_at: i64,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// A PKCE `code_verifier` (unreserved chars) and its S256 `code_challenge`.
+pub fn pkce_pair() -> (String, String) {
+    // 96 hex chars of CSPRNG entropy (uuid v4 is getrandom-backed) — well within
+    // the 43–128 unreserved-character verifier range.
+    let verifier = format!(
+        "{}{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    );
+    let challenge = pkce_challenge(&verifier);
+    (verifier, challenge)
+}
+
+/// S256 challenge: base64url-no-pad of SHA-256(verifier).
+pub fn pkce_challenge(verifier: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(verifier.as_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+}
+
+fn redirect_uri() -> String {
+    format!("http://localhost:{REDIRECT_PORT}/")
+}
+
+/// Build the provider authorize URL for a given challenge.
+pub fn authorize_url(config: &OAuthConfig, challenge: &str) -> Result<Url> {
+    let mut url = Url::parse(&config.auth_url).context("parse auth_url")?;
+    {
+        let mut q = url.query_pairs_mut();
+        q.append_pair("client_id", &config.client_id);
+        q.append_pair("response_type", "code");
+        q.append_pair("redirect_uri", &redirect_uri());
+        q.append_pair("code_challenge", challenge);
+        q.append_pair("code_challenge_method", "S256");
+        if !config.scopes.is_empty() {
+            q.append_pair("scope", &config.scopes.join(" "));
+        }
+        for (k, v) in &config.extra_auth_params {
+            q.append_pair(k, v);
+        }
+    }
+    Ok(url)
+}
+
+/// Run the full interactive flow: start the loopback listener, open the browser,
+/// wait for the redirect, and exchange the code. Returns the tokens plus the raw
+/// token-endpoint JSON (providers stash extras there, e.g. Dropbox `account_id`).
+pub async fn authorize_loopback(config: &OAuthConfig) -> Result<(TokenSet, serde_json::Value)> {
+    if config.client_id.is_empty() {
+        return Err(anyhow!(
+            "no OAuth client id configured — register the app and set its key \
+             (see the provider setup note)"
+        ));
+    }
+    let (verifier, challenge) = pkce_pair();
+    let auth_url = authorize_url(config, &challenge)?;
+
+    // Bind the fixed loopback port *before* opening the browser so the redirect
+    // can't race an unbound socket.
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", REDIRECT_PORT))
+        .await
+        .with_context(|| format!("bind loopback :{REDIRECT_PORT} for OAuth redirect"))?;
+
+    open_url(auth_url.as_str())?;
+
+    // Wait (bounded) for the browser redirect and pull the ?code= out of it.
+    let code = tokio::time::timeout(Duration::from_secs(300), accept_code(&listener))
+        .await
+        .map_err(|_| anyhow!("timed out waiting for the authorization redirect"))??;
+
+    let tokens_raw = exchange_code(config, &code, &verifier).await?;
+    let tokens = token_set_from(&tokens_raw)?;
+    Ok((tokens, tokens_raw))
+}
+
+/// Accept a single redirect request, answer with a friendly page, and return the
+/// `code` (or surface the `error`).
+async fn accept_code(listener: &tokio::net::TcpListener) -> Result<String> {
+    loop {
+        let (mut stream, _) = listener.accept().await.context("accept OAuth redirect")?;
+        let mut buf = [0u8; 4096];
+        let n = stream.read(&mut buf).await.unwrap_or(0);
+        let req = String::from_utf8_lossy(&buf[..n]);
+        // First line: `GET /?code=... HTTP/1.1`
+        let path = req
+            .lines()
+            .next()
+            .and_then(|l| l.split_whitespace().nth(1))
+            .unwrap_or("/");
+        let parsed = Url::parse(&format!("http://localhost{path}")).ok();
+        let (code, error) = parsed
+            .as_ref()
+            .map(|u| {
+                let mut code = None;
+                let mut error = None;
+                for (k, v) in u.query_pairs() {
+                    match k.as_ref() {
+                        "code" => code = Some(v.into_owned()),
+                        "error" => error = Some(v.into_owned()),
+                        _ => {}
+                    }
+                }
+                (code, error)
+            })
+            .unwrap_or((None, None));
+
+        // Ignore stray hits (favicon, etc.) that carry neither code nor error.
+        if code.is_none() && error.is_none() {
+            let _ = respond(&mut stream, "Waiting for authorization…").await;
+            continue;
+        }
+
+        let body = if error.is_some() {
+            "Authorization failed. You can close this window and return to Faro."
+        } else {
+            "Faro is now connected. You can close this window."
+        };
+        let _ = respond(&mut stream, body).await;
+
+        if let Some(e) = error {
+            return Err(anyhow!("authorization was denied: {e}"));
+        }
+        return code.ok_or_else(|| anyhow!("redirect carried no authorization code"));
+    }
+}
+
+async fn respond(stream: &mut tokio::net::TcpStream, body: &str) -> Result<()> {
+    let html = format!(
+        "<!doctype html><html><head><meta charset=utf-8><title>Faro</title></head>\
+         <body style=\"font-family:system-ui;padding:3rem;text-align:center\">\
+         <h2>{body}</h2></body></html>"
+    );
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\
+         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+        html.len(),
+        html
+    );
+    stream.write_all(resp.as_bytes()).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Exchange an authorization code + PKCE verifier for tokens. Returns the raw
+/// JSON so provider-specific fields survive.
+pub async fn exchange_code(
+    config: &OAuthConfig,
+    code: &str,
+    verifier: &str,
+) -> Result<serde_json::Value> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&config.token_url)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("code_verifier", verifier),
+            ("client_id", &config.client_id),
+            ("redirect_uri", &redirect_uri()),
+        ])
+        .send()
+        .await
+        .context("token exchange request")?;
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(anyhow!("token exchange failed ({}): {text}", status.as_u16()));
+    }
+    serde_json::from_str(&text).context("parse token response")
+}
+
+/// Refresh an access token from a refresh token. Providers usually return only a
+/// new access token, so the caller keeps the existing refresh token.
+pub async fn refresh(config: &OAuthConfig, refresh_token: &str) -> Result<TokenSet> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&config.token_url)
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+            ("client_id", &config.client_id),
+        ])
+        .send()
+        .await
+        .context("token refresh request")?;
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(anyhow!("token refresh failed ({}): {text}", status.as_u16()));
+    }
+    let raw: serde_json::Value = serde_json::from_str(&text).context("parse refresh response")?;
+    let mut set = token_set_from(&raw)?;
+    // Carry forward the refresh token if the response omitted one.
+    if set.refresh_token.is_none() {
+        set.refresh_token = Some(refresh_token.to_string());
+    }
+    Ok(set)
+}
+
+fn token_set_from(raw: &serde_json::Value) -> Result<TokenSet> {
+    let parsed: TokenResponse =
+        serde_json::from_value(raw.clone()).context("token response missing access_token")?;
+    let expires_at = parsed
+        .expires_in
+        .map(|s| now_secs() + s.max(0))
+        .unwrap_or(0);
+    Ok(TokenSet {
+        access_token: parsed.access_token,
+        refresh_token: parsed.refresh_token,
+        expires_at,
+    })
+}
+
+/// True when a token is expired or within 60s of it (or its expiry is unknown).
+pub fn is_expired(tokens: &TokenSet) -> bool {
+    tokens.expires_at == 0 || tokens.expires_at <= now_secs() + 60
+}
+
+fn open_url(url: &str) -> Result<()> {
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut c = std::process::Command::new("rundll32");
+        c.args(["url.dll,FileProtocolHandler", url]);
+        c
+    };
+    #[cfg(target_os = "macos")]
+    let mut cmd = {
+        let mut c = std::process::Command::new("open");
+        c.arg(url);
+        c
+    };
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let mut cmd = {
+        let mut c = std::process::Command::new("xdg-open");
+        c.arg(url);
+        c
+    };
+    cmd.spawn().context("open the system browser")?;
+    Ok(())
+}
+
+// ---- Token storage (OS keychain) ----
+
+/// Persist a provider's tokens for a profile in the OS keychain.
+pub fn store_tokens(service: &str, profile_id: &str, tokens: &TokenSet) -> Result<()> {
+    let entry = keyring::Entry::new(service, profile_id).context("open keychain entry")?;
+    let json = serde_json::to_string(tokens).context("serialize tokens")?;
+    entry.set_password(&json).context("write tokens to keychain")?;
+    Ok(())
+}
+
+/// Load a profile's tokens, or `None` if it was never authorized.
+pub fn load_tokens(service: &str, profile_id: &str) -> Result<Option<TokenSet>> {
+    let entry = keyring::Entry::new(service, profile_id).context("open keychain entry")?;
+    match entry.get_password() {
+        Ok(json) => Ok(Some(serde_json::from_str(&json).context("parse stored tokens")?)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(anyhow!("read tokens from keychain: {e}")),
+    }
+}
+
+/// Remove a profile's tokens (best-effort — a missing entry is not an error).
+pub fn delete_tokens(service: &str, profile_id: &str) {
+    if let Ok(entry) = keyring::Entry::new(service, profile_id) {
+        let _ = entry.delete_credential();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_challenge_is_s256_base64url() {
+        // RFC 7636 Appendix B reference vector.
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        assert_eq!(
+            pkce_challenge(verifier),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
+    }
+
+    #[test]
+    fn pkce_pair_lengths() {
+        let (v, c) = pkce_pair();
+        assert_eq!(v.len(), 96);
+        assert!(!c.is_empty());
+        assert_eq!(pkce_challenge(&v), c);
+    }
+
+    #[test]
+    fn authorize_url_has_pkce_and_redirect() {
+        let cfg = OAuthConfig {
+            client_id: "abc123".into(),
+            auth_url: "https://example.com/oauth2/authorize".into(),
+            token_url: "https://example.com/oauth2/token".into(),
+            scopes: vec!["files.read".into(), "files.write".into()],
+            extra_auth_params: vec![("token_access_type".into(), "offline".into())],
+        };
+        let url = authorize_url(&cfg, "CHAL").unwrap();
+        let q: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(q["client_id"], "abc123");
+        assert_eq!(q["response_type"], "code");
+        assert_eq!(q["code_challenge"], "CHAL");
+        assert_eq!(q["code_challenge_method"], "S256");
+        assert_eq!(q["scope"], "files.read files.write");
+        assert_eq!(q["token_access_type"], "offline");
+        assert_eq!(q["redirect_uri"], "http://localhost:53682/");
+    }
+
+    #[test]
+    fn token_set_computes_expiry() {
+        let raw = serde_json::json!({
+            "access_token": "at", "refresh_token": "rt", "expires_in": 3600
+        });
+        let set = token_set_from(&raw).unwrap();
+        assert_eq!(set.access_token, "at");
+        assert_eq!(set.refresh_token.as_deref(), Some("rt"));
+        assert!(set.expires_at > now_secs() + 3000);
+        assert!(!is_expired(&set));
+
+        let no_exp = token_set_from(&serde_json::json!({"access_token":"x"})).unwrap();
+        assert_eq!(no_exp.expires_at, 0);
+        assert!(is_expired(&no_exp)); // unknown expiry ⇒ treat as expired
+    }
+
+    /// Round-trips tokens through the real OS keychain. `#[ignore]`d because it
+    /// touches the credential store (unavailable on headless CI); run locally
+    /// with `cargo test -p faro -- --ignored keychain`.
+    #[test]
+    #[ignore = "touches the OS keychain"]
+    fn keychain_roundtrip() {
+        let svc = "faro-oauth-test";
+        let id = "roundtrip-profile";
+        let tokens = TokenSet {
+            access_token: "AT".into(),
+            refresh_token: Some("RT".into()),
+            expires_at: 1_234_567_890,
+        };
+        store_tokens(svc, id, &tokens).expect("store");
+        let loaded = load_tokens(svc, id).expect("load").expect("present");
+        assert_eq!(loaded, tokens);
+        delete_tokens(svc, id);
+        assert!(load_tokens(svc, id).expect("load after delete").is_none());
+    }
+}

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -329,6 +329,54 @@ pub fn delete_tokens(service: &str, profile_id: &str) {
     }
 }
 
+/// Shared token holder for the OAuth cloud backends: hands out a valid access
+/// token, refreshing (proactively on near-expiry, or on a forced 401 retry) and
+/// re-persisting to the keychain. Each provider session embeds one so the
+/// refresh logic lives in exactly one place.
+pub struct RefreshingToken {
+    service: String,
+    profile_id: String,
+    config: OAuthConfig,
+    tokens: tokio::sync::Mutex<TokenSet>,
+}
+
+impl RefreshingToken {
+    pub fn new(service: &str, profile_id: &str, config: OAuthConfig, tokens: TokenSet) -> Self {
+        Self {
+            service: service.to_string(),
+            profile_id: profile_id.to_string(),
+            config,
+            tokens: tokio::sync::Mutex::new(tokens),
+        }
+    }
+
+    /// A valid access token, refreshing + persisting first if it's near expiry.
+    pub async fn access_token(&self) -> Result<String> {
+        let mut guard = self.tokens.lock().await;
+        if is_expired(&guard) {
+            self.refresh_locked(&mut guard).await?;
+        }
+        Ok(guard.access_token.clone())
+    }
+
+    /// Force a refresh (used after a 401 on a token we thought was still valid).
+    pub async fn force_refresh(&self) -> Result<()> {
+        let mut guard = self.tokens.lock().await;
+        self.refresh_locked(&mut guard).await
+    }
+
+    async fn refresh_locked(&self, guard: &mut TokenSet) -> Result<()> {
+        let rt = guard
+            .refresh_token
+            .clone()
+            .ok_or_else(|| anyhow!("no refresh token — re-authorize this connection"))?;
+        let fresh = refresh(&self.config, &rt).await?;
+        *guard = fresh;
+        store_tokens(&self.service, &self.profile_id, guard)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/remotefs/agent.rs
+++ b/src-tauri/src/remotefs/agent.rs
@@ -3,7 +3,7 @@
 //! session's encrypted channel; the daemon enforces its own write policy, so a
 //! refusal surfaces here as an error the UI shows.
 
-use super::{Capabilities, DirEntry, FileKind, RemoteFs};
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
 use crate::session::AgentSession;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -38,6 +38,7 @@ fn convert(e: ProtoEntry) -> DirEntry {
         size: e.size,
         modified: e.modified,
         mode: e.mode,
+        etag: None,
     }
 }
 
@@ -116,6 +117,9 @@ impl RemoteFs for AgentFs {
             can_rename: true,
             has_directories: true,
             has_shell: false,
+            // A Faro daemon fronts a POSIX-ish filesystem (Android's emulated
+            // storage included) — mtime+size is the reliable change hint.
+            change_signal: ChangeSignal::MtimeSize,
         }
     }
 }

--- a/src-tauri/src/remotefs/boxdrive.rs
+++ b/src-tauri/src/remotefs/boxdrive.rs
@@ -1,0 +1,318 @@
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
+use crate::remotefs::dropbox::parse_iso8601;
+use crate::session::boxdrive::{basename, normalize, parent_of};
+use crate::session::BoxSession;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use reqwest::Method;
+use std::sync::Arc;
+
+/// RemoteFs over the Box API v2. Box is ID-addressed like Google Drive, so it
+/// reuses the same resolver pattern (path→id via listing). Real folders,
+/// rename/move via PUT, no chmod. `sha1` is the change token for files.
+pub struct BoxFs {
+    session: Arc<BoxSession>,
+}
+
+impl BoxFs {
+    pub fn new(session: Arc<BoxSession>) -> Self {
+        Self { session }
+    }
+}
+
+#[async_trait]
+impl RemoteFs for BoxFs {
+    async fn list_dir(&self, path: &str) -> Result<Vec<DirEntry>> {
+        let folder_id = self.session.folder_id(path).await?;
+        let items = self.session.folder_items(&folder_id).await?;
+        let mut out = Vec::with_capacity(items.len());
+        for item in &items {
+            if let Some((entry, id, is_dir)) = entry_from_json(item, path) {
+                if is_dir {
+                    self.session.cache_path(&entry.path, &id);
+                }
+                out.push(entry);
+            }
+        }
+        Ok(out)
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        let (id, is_folder) = self
+            .session
+            .resolve_item(from)
+            .await?
+            .with_context(|| format!("{from}: not found"))?;
+        let to_parent_id = self.session.folder_id(&parent_of(&normalize(to))).await?;
+        let new_name = basename(&normalize(to)).to_string();
+        let endpoint = if is_folder {
+            format!("/folders/{id}")
+        } else {
+            format!("/files/{id}")
+        };
+        let body = serde_json::json!({ "name": new_name, "parent": { "id": to_parent_id } });
+        self.session
+            .rpc(Method::PUT, &endpoint, Some(&body))
+            .await
+            .with_context(|| format!("move {from} -> {to}"))?;
+        self.session.clear_cache();
+        Ok(())
+    }
+
+    async fn delete(&self, path: &str, _recursive: bool) -> Result<()> {
+        let (id, is_folder) = self
+            .session
+            .resolve_item(path)
+            .await?
+            .with_context(|| format!("{path}: not found"))?;
+        let endpoint = if is_folder {
+            format!("/folders/{id}?recursive=true")
+        } else {
+            format!("/files/{id}")
+        };
+        self.session
+            .rpc(Method::DELETE, &endpoint, None)
+            .await
+            .with_context(|| format!("delete {path}"))?;
+        self.session.clear_cache();
+        Ok(())
+    }
+
+    async fn create_dir(&self, path: &str) -> Result<()> {
+        let parent_id = self.session.folder_id(&parent_of(&normalize(path))).await?;
+        let body = serde_json::json!({
+            "name": basename(&normalize(path)),
+            "parent": { "id": parent_id },
+        });
+        self.session
+            .rpc(Method::POST, "/folders", Some(&body))
+            .await
+            .with_context(|| format!("create dir {path}"))?;
+        self.session.clear_cache();
+        Ok(())
+    }
+
+    async fn chmod(&self, _path: &str, _mode: u32) -> Result<()> {
+        Err(anyhow::anyhow!("Box has no POSIX permissions"))
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            can_chmod: false,
+            can_symlink: false,
+            can_rename: true,
+            has_directories: true,
+            has_shell: false,
+            change_signal: ChangeSignal::Etag,
+        }
+    }
+}
+
+/// Parse a Box item into `(DirEntry, id, is_folder)`.
+fn entry_from_json(item: &serde_json::Value, request_path: &str) -> Option<(DirEntry, String, bool)> {
+    let id = item.get("id").and_then(|x| x.as_str())?.to_string();
+    let name = item.get("name").and_then(|x| x.as_str())?.to_string();
+    let is_folder = item.get("type").and_then(|t| t.as_str()) == Some("folder");
+    let size = item.get("size").and_then(|s| s.as_u64()).unwrap_or(0);
+    // Box `modified_at` is RFC3339 with an offset; take the first 19 chars
+    // (YYYY-MM-DDTHH:MM:SS) — the offset is dropped (minor display-mtime skew).
+    let modified = item
+        .get("modified_at")
+        .and_then(|m| m.as_str())
+        .map(|s| &s[..s.len().min(19)])
+        .and_then(parse_iso8601);
+    let etag = item
+        .get("sha1")
+        .and_then(|s| s.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let base = request_path.trim_matches('/');
+    let path = if base.is_empty() {
+        format!("/{name}")
+    } else {
+        format!("/{base}/{name}")
+    };
+    Some((
+        DirEntry {
+            name,
+            path,
+            kind: if is_folder {
+                FileKind::Directory
+            } else {
+                FileKind::File
+            },
+            size,
+            modified,
+            mode: None,
+            etag,
+        },
+        id,
+        is_folder,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_box_items() {
+        let items = serde_json::json!([
+            { "type": "folder", "id": "22222", "name": "Photos" },
+            { "type": "file", "id": "33333", "name": "report.pdf", "size": 2048,
+              "modified_at": "2024-07-15T09:30:00-07:00", "sha1": "deadbeef" }
+        ]);
+        let arr = items.as_array().unwrap();
+        let parsed: Vec<_> = arr.iter().filter_map(|i| entry_from_json(i, "/docs")).collect();
+        assert_eq!(parsed.len(), 2);
+
+        let (dir, id, is_dir) = parsed.iter().find(|(e, _, _)| e.name == "Photos").unwrap();
+        assert!(is_dir);
+        assert_eq!(id, "22222");
+        assert_eq!(dir.kind, FileKind::Directory);
+        assert_eq!(dir.path, "/docs/Photos");
+
+        let (file, _, _) = parsed.iter().find(|(e, _, _)| e.name == "report.pdf").unwrap();
+        assert_eq!(file.kind, FileKind::File);
+        assert_eq!(file.size, 2048);
+        assert_eq!(file.etag.as_deref(), Some("deadbeef"));
+        assert_eq!(file.modified, Some(1_721_035_800)); // offset dropped
+    }
+
+    /// End-to-end against the Box mock (`tests/box_mock.py`). Skipped unless
+    /// FARO_BOX_MOCK_URL is set; run with
+    /// `cargo test -p faro -- --ignored box_roundtrip` after starting it.
+    /// Exercises the ID resolver on a nested path plus token exchange, the
+    /// 401→refresh retry, and list/create/upload/download/move/delete.
+    #[tokio::test]
+    #[ignore = "requires the Box mock (FARO_BOX_MOCK_URL)"]
+    async fn live_box_roundtrip() {
+        use crate::oauth::{self, TokenSet};
+        use crate::profiles::{AuthMethod, ConnectionProfile};
+        use crate::session::boxdrive::{box_config, box_connect, BOX_SERVICE};
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let Ok(mock) = std::env::var("FARO_BOX_MOCK_URL") else {
+            eprintln!("skip: FARO_BOX_MOCK_URL unset");
+            return;
+        };
+        std::env::set_var("FARO_BOX_CLIENT_ID", "test-client");
+        std::env::set_var("FARO_BOX_TOKEN_URL", format!("{mock}/token"));
+        std::env::set_var("FARO_BOX_API_BASE", &mock);
+        std::env::set_var("FARO_BOX_UPLOAD_BASE", &mock);
+
+        let ex = oauth::exchange_code(&box_config(), "authcode", "verifier")
+            .await
+            .expect("exchange");
+        assert_eq!(ex["access_token"], "ACCESS1");
+
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let pid = "box-mock-test";
+        oauth::store_tokens(
+            BOX_SERVICE,
+            pid,
+            &TokenSet {
+                access_token: "STALE".into(),
+                refresh_token: Some("REFRESH1".into()),
+                expires_at: now + 99_999,
+            },
+        )
+        .expect("seed");
+
+        let profile = ConnectionProfile {
+            id: pid.into(),
+            name: "bx".into(),
+            protocol: "box".into(),
+            host: "box.com".into(),
+            port: 443,
+            username: String::new(),
+            auth: AuthMethod::Password { password: String::new() },
+            default_remote_path: None,
+            color: None,
+            auto_connect: None,
+            bucket: None,
+            region: None,
+            endpoint: None,
+            account: None,
+            agent_key: None,
+            group: None,
+            sort_order: None,
+        };
+        let session = Arc::new(box_connect(&profile).await.expect("connect"));
+
+        // First call uses STALE → 401 → refresh → succeeds.
+        assert_eq!(session.account_label().await.expect("account"), "tester@example.com");
+
+        let fs = BoxFs::new(session.clone());
+        fs.create_dir("/faro-test").await.expect("mkdir1");
+        fs.create_dir("/faro-test/sub").await.expect("mkdir2");
+
+        // Upload into the nested folder (multipart create, as the transfer path does).
+        let parent = session.folder_id("/faro-test/sub").await.expect("resolve parent");
+        let token = session.access_token().await.unwrap();
+        let attrs = serde_json::json!({ "name": "hello.txt", "parent": { "id": parent } });
+        let part = reqwest::multipart::Part::bytes(b"hi box".to_vec()).file_name("hello.txt");
+        let form = reqwest::multipart::Form::new()
+            .text("attributes", attrs.to_string())
+            .part("file", part);
+        let put = session
+            .client
+            .post(format!("{}/files/content", session.upload_base))
+            .bearer_auth(&token)
+            .multipart(form)
+            .send()
+            .await
+            .expect("upload");
+        assert!(put.status().is_success(), "upload {}", put.status());
+        session.clear_cache();
+
+        let entries = fs.list_dir("/faro-test/sub").await.expect("list");
+        let hello = entries.iter().find(|e| e.name == "hello.txt").expect("hello");
+        assert_eq!(hello.kind, FileKind::File);
+        assert_eq!(hello.size, 6);
+        assert!(hello.etag.is_some(), "sha1 change token");
+
+        // Download via resolver → id → /files/{id}/content.
+        let (fid, _) = session
+            .resolve_item("/faro-test/sub/hello.txt")
+            .await
+            .expect("resolve")
+            .expect("present");
+        let dl = session
+            .get_stream(&format!("/files/{fid}/content"))
+            .await
+            .expect("dl")
+            .text()
+            .await
+            .expect("body");
+        assert_eq!(dl, "hi box");
+
+        // Move across folders.
+        fs.rename("/faro-test/sub/hello.txt", "/faro-test/renamed.txt")
+            .await
+            .expect("move");
+        assert!(fs
+            .list_dir("/faro-test")
+            .await
+            .expect("l1")
+            .iter()
+            .any(|e| e.name == "renamed.txt"));
+        assert!(!fs
+            .list_dir("/faro-test/sub")
+            .await
+            .expect("l2")
+            .iter()
+            .any(|e| e.name == "hello.txt"));
+
+        fs.delete("/faro-test", true).await.expect("delete");
+        assert!(!fs
+            .list_dir("/")
+            .await
+            .expect("root")
+            .iter()
+            .any(|e| e.name == "faro-test"));
+
+        oauth::delete_tokens(BOX_SERVICE, pid);
+        eprintln!("live_box_roundtrip: OK");
+    }
+}

--- a/src-tauri/src/remotefs/dropbox.rs
+++ b/src-tauri/src/remotefs/dropbox.rs
@@ -167,8 +167,9 @@ fn entry_from_json(e: &serde_json::Value) -> Option<DirEntry> {
 }
 
 /// Parse a fixed-form ISO-8601 UTC timestamp (`2024-07-15T09:30:00Z`, as Dropbox
-/// emits) into a Unix timestamp. Dependency-free — the format is fixed.
-fn parse_iso8601(s: &str) -> Option<i64> {
+/// and Graph emit) into a Unix timestamp. Dependency-free — the format is fixed.
+/// Shared with the OneDrive backend.
+pub(crate) fn parse_iso8601(s: &str) -> Option<i64> {
     let s = s.trim();
     let (date, rest) = s.split_once('T')?;
     let time = rest.trim_end_matches('Z');

--- a/src-tauri/src/remotefs/dropbox.rs
+++ b/src-tauri/src/remotefs/dropbox.rs
@@ -1,0 +1,244 @@
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
+use crate::remotefs::webdav::days_from_civil;
+use crate::session::DropboxSession;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// RemoteFs over the Dropbox API v2. Dropbox is path-addressed, so it slots
+/// straight into the trait: real folders, rename via `move_v2`, no chmod. The
+/// per-file `rev` is a reliable change token (`ChangeSignal::Etag`).
+pub struct DropboxFs {
+    session: Arc<DropboxSession>,
+}
+
+impl DropboxFs {
+    pub fn new(session: Arc<DropboxSession>) -> Self {
+        Self { session }
+    }
+}
+
+/// Translate a Faro path (`/a/b`, or `/` for root) into a Dropbox API path
+/// (`""` for root, otherwise `/a/b`).
+pub fn dropbox_api_path(faro_path: &str) -> String {
+    let trimmed = faro_path.trim().trim_matches('/');
+    if trimmed.is_empty() || trimmed == "." {
+        String::new()
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+#[async_trait]
+impl RemoteFs for DropboxFs {
+    async fn list_dir(&self, path: &str) -> Result<Vec<DirEntry>> {
+        let dbx = dropbox_api_path(path);
+        let mut out = Vec::new();
+
+        let mut resp = self
+            .session
+            .rpc(
+                "/2/files/list_folder",
+                serde_json::json!({ "path": dbx, "recursive": false }),
+            )
+            .await?;
+
+        loop {
+            if let Some(entries) = resp.get("entries").and_then(|e| e.as_array()) {
+                for e in entries {
+                    if let Some(entry) = entry_from_json(e) {
+                        out.push(entry);
+                    }
+                }
+            }
+            let has_more = resp
+                .get("has_more")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !has_more {
+                break;
+            }
+            let cursor = resp
+                .get("cursor")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string();
+            resp = self
+                .session
+                .rpc(
+                    "/2/files/list_folder/continue",
+                    serde_json::json!({ "cursor": cursor }),
+                )
+                .await?;
+        }
+        Ok(out)
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        self.session
+            .rpc(
+                "/2/files/move_v2",
+                serde_json::json!({
+                    "from_path": dropbox_api_path(from),
+                    "to_path": dropbox_api_path(to),
+                    "autorename": false,
+                }),
+            )
+            .await
+            .with_context(|| format!("move {from} -> {to}"))?;
+        Ok(())
+    }
+
+    async fn delete(&self, path: &str, _recursive: bool) -> Result<()> {
+        // delete_v2 removes a folder and its contents; the flag needs no handling.
+        self.session
+            .rpc(
+                "/2/files/delete_v2",
+                serde_json::json!({ "path": dropbox_api_path(path) }),
+            )
+            .await
+            .with_context(|| format!("delete {path}"))?;
+        Ok(())
+    }
+
+    async fn create_dir(&self, path: &str) -> Result<()> {
+        self.session
+            .rpc(
+                "/2/files/create_folder_v2",
+                serde_json::json!({ "path": dropbox_api_path(path), "autorename": false }),
+            )
+            .await
+            .with_context(|| format!("create dir {path}"))?;
+        Ok(())
+    }
+
+    async fn chmod(&self, _path: &str, _mode: u32) -> Result<()> {
+        Err(anyhow::anyhow!("Dropbox has no POSIX permissions"))
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            can_chmod: false,
+            can_symlink: false,
+            can_rename: true,
+            has_directories: true,
+            has_shell: false,
+            // Dropbox's per-file `rev` changes on every edit — a reliable token.
+            change_signal: ChangeSignal::Etag,
+        }
+    }
+}
+
+/// Parse one `list_folder` entry into a DirEntry, or `None` for a shape we don't
+/// recognize (e.g. a deleted tombstone).
+fn entry_from_json(e: &serde_json::Value) -> Option<DirEntry> {
+    let tag = e.get(".tag").and_then(|t| t.as_str())?;
+    let kind = match tag {
+        "folder" => FileKind::Directory,
+        "file" => FileKind::File,
+        _ => return None, // "deleted" or unknown
+    };
+    let name = e.get("name").and_then(|n| n.as_str())?.to_string();
+    // path_display is the properly-cased server path; fall back to path_lower.
+    let path = e
+        .get("path_display")
+        .or_else(|| e.get("path_lower"))
+        .and_then(|p| p.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("/{name}"));
+    let size = e.get("size").and_then(|s| s.as_u64()).unwrap_or(0);
+    let modified = e
+        .get("server_modified")
+        .and_then(|m| m.as_str())
+        .and_then(parse_iso8601);
+    let etag = e
+        .get("rev")
+        .and_then(|r| r.as_str())
+        .map(|s| s.to_string());
+    Some(DirEntry {
+        name,
+        path,
+        kind,
+        size,
+        modified,
+        mode: None,
+        etag,
+    })
+}
+
+/// Parse a fixed-form ISO-8601 UTC timestamp (`2024-07-15T09:30:00Z`, as Dropbox
+/// emits) into a Unix timestamp. Dependency-free — the format is fixed.
+fn parse_iso8601(s: &str) -> Option<i64> {
+    let s = s.trim();
+    let (date, rest) = s.split_once('T')?;
+    let time = rest.trim_end_matches('Z');
+    let d: Vec<&str> = date.split('-').collect();
+    let t: Vec<&str> = time.split(':').collect();
+    if d.len() != 3 || t.len() != 3 {
+        return None;
+    }
+    let year: i64 = d[0].parse().ok()?;
+    let month: i64 = d[1].parse().ok()?;
+    let day: i64 = d[2].parse().ok()?;
+    let hh: i64 = t[0].parse().ok()?;
+    let mm: i64 = t[1].parse().ok()?;
+    // Seconds may carry a fractional part (…:30.5Z); take the integer part.
+    let ss: i64 = t[2].split('.').next()?.parse().ok()?;
+    Some(days_from_civil(year, month, day) * 86400 + hh * 3600 + mm * 60 + ss)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_path_mapping() {
+        assert_eq!(dropbox_api_path("/"), "");
+        assert_eq!(dropbox_api_path(""), "");
+        assert_eq!(dropbox_api_path("."), "");
+        assert_eq!(dropbox_api_path("/docs"), "/docs");
+        assert_eq!(dropbox_api_path("docs/sub/"), "/docs/sub");
+    }
+
+    #[test]
+    fn iso8601_epoch() {
+        assert_eq!(parse_iso8601("1970-01-01T00:00:00Z"), Some(0));
+        assert_eq!(parse_iso8601("2024-07-15T09:30:00Z"), Some(1_721_035_800));
+        assert_eq!(parse_iso8601("2024-07-15T09:30:00.5Z"), Some(1_721_035_800));
+        assert_eq!(parse_iso8601("nope"), None);
+    }
+
+    #[test]
+    fn parses_list_folder_entries() {
+        let listing = serde_json::json!({
+            "entries": [
+                { ".tag": "folder", "name": "Photos",
+                  "path_display": "/Photos", "path_lower": "/photos", "id": "id:1" },
+                { ".tag": "file", "name": "report.pdf", "path_display": "/report.pdf",
+                  "size": 2048, "server_modified": "2024-07-15T09:30:00Z",
+                  "rev": "0158abc", "id": "id:2" },
+                { ".tag": "deleted", "name": "gone.txt", "path_display": "/gone.txt" }
+            ],
+            "cursor": "AAA",
+            "has_more": false
+        });
+        let entries: Vec<DirEntry> = listing["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(entry_from_json)
+            .collect();
+        // The "deleted" tombstone is dropped.
+        assert_eq!(entries.len(), 2);
+
+        let dir = entries.iter().find(|e| e.name == "Photos").unwrap();
+        assert_eq!(dir.kind, FileKind::Directory);
+        assert_eq!(dir.path, "/Photos");
+
+        let file = entries.iter().find(|e| e.name == "report.pdf").unwrap();
+        assert_eq!(file.kind, FileKind::File);
+        assert_eq!(file.size, 2048);
+        assert_eq!(file.etag.as_deref(), Some("0158abc"));
+        assert_eq!(file.modified, Some(1_721_035_800));
+    }
+}

--- a/src-tauri/src/remotefs/dropbox.rs
+++ b/src-tauri/src/remotefs/dropbox.rs
@@ -241,4 +241,131 @@ mod tests {
         assert_eq!(file.etag.as_deref(), Some("0158abc"));
         assert_eq!(file.modified, Some(1_721_035_800));
     }
+
+    /// End-to-end against the Dropbox mock (`tests/dropbox_mock.py`). Skipped
+    /// unless FARO_DROPBOX_MOCK_URL is set; run with
+    /// `cargo test -p faro -- --ignored dropbox_roundtrip` after starting the
+    /// mock. Exercises the whole client path — the 401→refresh retry,
+    /// get_current_account, list/create/upload/download/move/delete — through
+    /// Faro's own DropboxSession/DropboxFs, no real account needed.
+    #[tokio::test]
+    #[ignore = "requires the Dropbox mock (FARO_DROPBOX_MOCK_URL)"]
+    async fn live_dropbox_roundtrip() {
+        use crate::oauth::{self, TokenSet};
+        use crate::profiles::{AuthMethod, ConnectionProfile};
+        use crate::session::dropbox::{dropbox_config, dropbox_connect, DROPBOX_SERVICE};
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let Ok(mock) = std::env::var("FARO_DROPBOX_MOCK_URL") else {
+            eprintln!("skip: FARO_DROPBOX_MOCK_URL unset");
+            return;
+        };
+        std::env::set_var("FARO_DROPBOX_APP_KEY", "test-app-key");
+        std::env::set_var("FARO_DROPBOX_TOKEN_URL", format!("{mock}/oauth2/token"));
+        std::env::set_var("FARO_DROPBOX_API_BASE", &mock);
+        std::env::set_var("FARO_DROPBOX_CONTENT_BASE", &mock);
+
+        // First: a real token exchange against the mock (the code path authorize
+        // uses after the browser redirect).
+        let exchanged = oauth::exchange_code(&dropbox_config(), "authcode", "verifier")
+            .await
+            .expect("exchange");
+        assert_eq!(exchanged["access_token"], "ACCESS1");
+        assert_eq!(exchanged["refresh_token"], "REFRESH1");
+
+        // Seed a deliberately-stale-but-unexpired access token so the very first
+        // API call 401s and drives the force-refresh retry path.
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let pid = "dropbox-mock-test";
+        oauth::store_tokens(
+            DROPBOX_SERVICE,
+            pid,
+            &TokenSet {
+                access_token: "STALE".into(),
+                refresh_token: Some("REFRESH1".into()),
+                expires_at: now + 99_999,
+            },
+        )
+        .expect("seed tokens");
+
+        let profile = ConnectionProfile {
+            id: pid.into(),
+            name: "dbx".into(),
+            protocol: "dropbox".into(),
+            host: "dropbox.com".into(),
+            port: 443,
+            username: String::new(),
+            auth: AuthMethod::Password { password: String::new() },
+            default_remote_path: None,
+            color: None,
+            auto_connect: None,
+            bucket: None,
+            region: None,
+            endpoint: None,
+            account: None,
+            agent_key: None,
+            group: None,
+            sort_order: None,
+        };
+        let session = Arc::new(dropbox_connect(&profile).await.expect("connect"));
+
+        // First API call uses the STALE token → 401 → force_refresh → succeeds.
+        let label = session.account_label().await.expect("account");
+        assert_eq!(label, "tester@example.com");
+
+        let fs = DropboxFs::new(session.clone());
+        fs.create_dir("/faro-test").await.expect("mkdir");
+
+        // Upload through the content endpoint (same call the transfer manager makes).
+        let token = session.access_token().await.unwrap();
+        let arg = serde_json::json!({
+            "path": "/faro-test/hello.txt", "mode": "overwrite"
+        })
+        .to_string();
+        let put = session
+            .client
+            .post(format!("{}/2/files/upload", session.content_base))
+            .bearer_auth(&token)
+            .header("Dropbox-API-Arg", &arg)
+            .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+            .body("hello dropbox")
+            .send()
+            .await
+            .expect("upload");
+        assert!(put.status().is_success());
+
+        // List sees it with the right size.
+        let entries = fs.list_dir("/faro-test").await.expect("list");
+        let hello = entries.iter().find(|e| e.name == "hello.txt").expect("hello");
+        assert_eq!(hello.kind, FileKind::File);
+        assert_eq!(hello.size, 13);
+
+        // Download round-trips the bytes.
+        let dl = session
+            .content_get(
+                "/2/files/download",
+                &serde_json::json!({"path": "/faro-test/hello.txt"}).to_string(),
+            )
+            .await
+            .expect("download")
+            .text()
+            .await
+            .expect("body");
+        assert_eq!(dl, "hello dropbox");
+
+        // Move, then delete.
+        fs.rename("/faro-test/hello.txt", "/faro-test/renamed.txt")
+            .await
+            .expect("move");
+        let entries = fs.list_dir("/faro-test").await.expect("list2");
+        assert!(entries.iter().any(|e| e.name == "renamed.txt"));
+        assert!(!entries.iter().any(|e| e.name == "hello.txt"));
+
+        fs.delete("/faro-test", true).await.expect("delete");
+        let root = fs.list_dir("/").await.expect("list root");
+        assert!(!root.iter().any(|e| e.name == "faro-test"));
+
+        oauth::delete_tokens(DROPBOX_SERVICE, pid);
+        eprintln!("live_dropbox_roundtrip: OK");
+    }
 }

--- a/src-tauri/src/remotefs/ftp.rs
+++ b/src-tauri/src/remotefs/ftp.rs
@@ -1,4 +1,4 @@
-use super::{Capabilities, DirEntry, FileKind, RemoteFs};
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
 use crate::session::FtpSession;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -55,6 +55,7 @@ fn entry_from_listing(parent: &str, line: &str) -> Option<DirEntry> {
         size: f.size() as u64,
         modified,
         mode: None,
+        etag: None,
     })
 }
 
@@ -153,6 +154,7 @@ impl RemoteFs for FtpFs {
             can_rename: true,
             has_directories: true,
             has_shell: false,
+            change_signal: ChangeSignal::MtimeSize,
         }
     }
 }

--- a/src-tauri/src/remotefs/gdrive.rs
+++ b/src-tauri/src/remotefs/gdrive.rs
@@ -1,0 +1,367 @@
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
+use crate::remotefs::dropbox::parse_iso8601;
+use crate::session::gdrive::{basename, folder_mime_is, normalize, parent_of};
+use crate::session::GDriveSession;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use reqwest::Method;
+use std::sync::Arc;
+
+/// RemoteFs over Google Drive v3. Drive is **ID-addressed**, so each op resolves
+/// the Faro path to a file id via the session's resolver first, then acts on the
+/// id. Real folders, rename/move via PATCH, no chmod. `md5Checksum` is the change
+/// token for binary files (absent for folders / Google-native docs → mtime+size).
+pub struct GDriveFs {
+    session: Arc<GDriveSession>,
+}
+
+impl GDriveFs {
+    pub fn new(session: Arc<GDriveSession>) -> Self {
+        Self { session }
+    }
+}
+
+fn urlenc(s: &str) -> String {
+    utf8_percent_encode(s, NON_ALPHANUMERIC).to_string()
+}
+
+#[async_trait]
+impl RemoteFs for GDriveFs {
+    async fn list_dir(&self, path: &str) -> Result<Vec<DirEntry>> {
+        let folder_id = self.session.folder_id(path).await?;
+        let q = format!("'{}' in parents and trashed = false", folder_id);
+        let mut out = Vec::new();
+        let mut page_token: Option<String> = None;
+        loop {
+            let mut url = format!(
+                "/files?q={}&fields=nextPageToken,files(id,name,mimeType,size,modifiedTime,md5Checksum)&pageSize=200",
+                urlenc(&q)
+            );
+            if let Some(tok) = &page_token {
+                url.push_str(&format!("&pageToken={}", urlenc(tok)));
+            }
+            let v = self.session.rpc(Method::GET, &url, None).await?;
+            if let Some(files) = v.get("files").and_then(|f| f.as_array()) {
+                for f in files {
+                    if let Some((entry, id, is_dir)) = entry_from_json(f, path) {
+                        // Warm the resolver cache for subfolders so navigating in
+                        // doesn't re-query.
+                        if is_dir {
+                            self.session.cache_path(&entry.path, &id);
+                        }
+                        out.push(entry);
+                    }
+                }
+            }
+            match v.get("nextPageToken").and_then(|t| t.as_str()) {
+                Some(tok) => page_token = Some(tok.to_string()),
+                None => break,
+            }
+        }
+        Ok(out)
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        let (id, _) = self
+            .session
+            .resolve_item(from)
+            .await?
+            .with_context(|| format!("{from}: not found"))?;
+        let from_parent = self.session.folder_id(&parent_of(&normalize(from))).await?;
+        let to_parent = self.session.folder_id(&parent_of(&normalize(to))).await?;
+        let new_name = basename(&normalize(to)).to_string();
+
+        let mut url = format!("/files/{id}?fields=id");
+        if from_parent != to_parent {
+            url.push_str(&format!(
+                "&addParents={}&removeParents={}",
+                urlenc(&to_parent),
+                urlenc(&from_parent)
+            ));
+        }
+        let body = serde_json::json!({ "name": new_name });
+        self.session
+            .rpc(Method::PATCH, &url, Some(&body))
+            .await
+            .with_context(|| format!("move {from} -> {to}"))?;
+        self.session.clear_cache();
+        Ok(())
+    }
+
+    async fn delete(&self, path: &str, _recursive: bool) -> Result<()> {
+        let (id, _) = self
+            .session
+            .resolve_item(path)
+            .await?
+            .with_context(|| format!("{path}: not found"))?;
+        // DELETE removes a folder and its contents permanently.
+        self.session
+            .rpc(Method::DELETE, &format!("/files/{id}"), None)
+            .await
+            .with_context(|| format!("delete {path}"))?;
+        self.session.clear_cache();
+        Ok(())
+    }
+
+    async fn create_dir(&self, path: &str) -> Result<()> {
+        let parent_id = self.session.folder_id(&parent_of(&normalize(path))).await?;
+        let body = serde_json::json!({
+            "name": basename(&normalize(path)),
+            "mimeType": crate::session::gdrive::FOLDER_MIME,
+            "parents": [parent_id],
+        });
+        self.session
+            .rpc(Method::POST, "/files?fields=id", Some(&body))
+            .await
+            .with_context(|| format!("create dir {path}"))?;
+        self.session.clear_cache();
+        Ok(())
+    }
+
+    async fn chmod(&self, _path: &str, _mode: u32) -> Result<()> {
+        Err(anyhow::anyhow!("Google Drive has no POSIX permissions"))
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            can_chmod: false,
+            can_symlink: false,
+            can_rename: true,
+            has_directories: true,
+            has_shell: false,
+            change_signal: ChangeSignal::Etag,
+        }
+    }
+}
+
+/// Parse a Drive file resource into `(DirEntry, id, is_folder)`.
+fn entry_from_json(f: &serde_json::Value, request_path: &str) -> Option<(DirEntry, String, bool)> {
+    let id = f.get("id").and_then(|x| x.as_str())?.to_string();
+    let name = f.get("name").and_then(|x| x.as_str())?.to_string();
+    let is_folder = folder_mime_is(f.get("mimeType").and_then(|m| m.as_str()).unwrap_or(""));
+    // Drive returns `size` as a decimal string, and only for binary files.
+    let size = f
+        .get("size")
+        .and_then(|s| s.as_str())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+    let modified = f
+        .get("modifiedTime")
+        .and_then(|m| m.as_str())
+        .and_then(parse_iso8601);
+    let etag = f
+        .get("md5Checksum")
+        .and_then(|m| m.as_str())
+        .map(|s| s.to_string());
+    let base = request_path.trim_matches('/');
+    let path = if base.is_empty() {
+        format!("/{name}")
+    } else {
+        format!("/{base}/{name}")
+    };
+    Some((
+        DirEntry {
+            name,
+            path,
+            kind: if is_folder {
+                FileKind::Directory
+            } else {
+                FileKind::File
+            },
+            size,
+            modified,
+            mode: None,
+            etag,
+        },
+        id,
+        is_folder,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::gdrive::escape_q;
+
+    #[test]
+    fn q_escaping() {
+        assert_eq!(escape_q("plain"), "plain");
+        assert_eq!(escape_q("O'Brien"), "O\\'Brien");
+        assert_eq!(escape_q("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn parses_drive_files() {
+        let files = serde_json::json!([
+            { "id": "f1", "name": "Photos", "mimeType": "application/vnd.google-apps.folder" },
+            { "id": "f2", "name": "report.pdf", "mimeType": "application/pdf",
+              "size": "2048", "modifiedTime": "2024-07-15T09:30:00Z", "md5Checksum": "abc123" }
+        ]);
+        let arr = files.as_array().unwrap();
+        let parsed: Vec<_> = arr
+            .iter()
+            .filter_map(|f| entry_from_json(f, "/docs"))
+            .collect();
+        assert_eq!(parsed.len(), 2);
+
+        let (dir, id, is_dir) = parsed.iter().find(|(e, _, _)| e.name == "Photos").unwrap();
+        assert!(is_dir);
+        assert_eq!(id, "f1");
+        assert_eq!(dir.kind, FileKind::Directory);
+        assert_eq!(dir.path, "/docs/Photos");
+
+        let (file, _, _) = parsed.iter().find(|(e, _, _)| e.name == "report.pdf").unwrap();
+        assert_eq!(file.kind, FileKind::File);
+        assert_eq!(file.size, 2048);
+        assert_eq!(file.etag.as_deref(), Some("abc123"));
+        assert_eq!(file.modified, Some(1_721_035_800));
+    }
+
+    /// End-to-end against the Drive mock (`tests/gdrive_mock.py`). Skipped unless
+    /// FARO_GDRIVE_MOCK_URL is set; run with
+    /// `cargo test -p faro -- --ignored gdrive_roundtrip` after starting it.
+    /// Exercises the ID resolver on a nested path plus token exchange, the
+    /// 401→refresh retry, and list/create/upload/download/move/delete.
+    #[tokio::test]
+    #[ignore = "requires the Google Drive mock (FARO_GDRIVE_MOCK_URL)"]
+    async fn live_gdrive_roundtrip() {
+        use crate::oauth::{self, TokenSet};
+        use crate::profiles::{AuthMethod, ConnectionProfile};
+        use crate::session::gdrive::{gdrive_config, gdrive_connect, GDRIVE_SERVICE};
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let Ok(mock) = std::env::var("FARO_GDRIVE_MOCK_URL") else {
+            eprintln!("skip: FARO_GDRIVE_MOCK_URL unset");
+            return;
+        };
+        std::env::set_var("FARO_GDRIVE_CLIENT_ID", "test-client");
+        std::env::set_var("FARO_GDRIVE_TOKEN_URL", format!("{mock}/token"));
+        std::env::set_var("FARO_GDRIVE_API_BASE", &mock);
+        std::env::set_var("FARO_GDRIVE_UPLOAD_BASE", &mock);
+
+        let ex = oauth::exchange_code(&gdrive_config(), "authcode", "verifier")
+            .await
+            .expect("exchange");
+        assert_eq!(ex["access_token"], "ACCESS1");
+
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let pid = "gdrive-mock-test";
+        oauth::store_tokens(
+            GDRIVE_SERVICE,
+            pid,
+            &TokenSet {
+                access_token: "STALE".into(),
+                refresh_token: Some("REFRESH1".into()),
+                expires_at: now + 99_999,
+            },
+        )
+        .expect("seed");
+
+        let profile = ConnectionProfile {
+            id: pid.into(),
+            name: "gd".into(),
+            protocol: "gdrive".into(),
+            host: "drive.google.com".into(),
+            port: 443,
+            username: String::new(),
+            auth: AuthMethod::Password { password: String::new() },
+            default_remote_path: None,
+            color: None,
+            auto_connect: None,
+            bucket: None,
+            region: None,
+            endpoint: None,
+            account: None,
+            agent_key: None,
+            group: None,
+            sort_order: None,
+        };
+        let session = Arc::new(gdrive_connect(&profile).await.expect("connect"));
+
+        // First call uses STALE → 401 → refresh → succeeds.
+        assert_eq!(session.account_label().await.expect("account"), "tester@example.com");
+
+        let fs = GDriveFs::new(session.clone());
+        // Nested folders exercise the resolver descending two levels.
+        fs.create_dir("/faro-test").await.expect("mkdir1");
+        fs.create_dir("/faro-test/sub").await.expect("mkdir2");
+
+        // Upload into the nested folder (multipart create, same as the transfer path).
+        let parent = session.folder_id("/faro-test/sub").await.expect("resolve parent");
+        let token = session.access_token().await.unwrap();
+        let boundary = "faroTESTboundary";
+        let metaj = serde_json::json!({ "name": "hello.txt", "parents": [parent] });
+        let mut body: Vec<u8> = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(b"Content-Type: application/json; charset=UTF-8\r\n\r\n");
+        body.extend_from_slice(metaj.to_string().as_bytes());
+        body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+        body.extend_from_slice(b"hi drive");
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        let put = session
+            .client
+            .post(format!("{}/files?uploadType=multipart", session.upload_base))
+            .bearer_auth(&token)
+            .header(
+                reqwest::header::CONTENT_TYPE,
+                format!("multipart/related; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .expect("upload");
+        assert!(put.status().is_success(), "upload {}", put.status());
+        session.clear_cache();
+
+        let entries = fs.list_dir("/faro-test/sub").await.expect("list");
+        let hello = entries.iter().find(|e| e.name == "hello.txt").expect("hello");
+        assert_eq!(hello.kind, FileKind::File);
+        assert_eq!(hello.size, 8);
+        assert!(hello.etag.is_some(), "md5 change token");
+
+        // Download via resolver → id → alt=media.
+        let (fid, _) = session
+            .resolve_item("/faro-test/sub/hello.txt")
+            .await
+            .expect("resolve")
+            .expect("present");
+        let dl = session
+            .get_stream(&format!("/files/{fid}?alt=media"))
+            .await
+            .expect("dl")
+            .text()
+            .await
+            .expect("body");
+        assert_eq!(dl, "hi drive");
+
+        // Move across folders (addParents/removeParents).
+        fs.rename("/faro-test/sub/hello.txt", "/faro-test/renamed.txt")
+            .await
+            .expect("move");
+        assert!(fs
+            .list_dir("/faro-test")
+            .await
+            .expect("l1")
+            .iter()
+            .any(|e| e.name == "renamed.txt"));
+        assert!(!fs
+            .list_dir("/faro-test/sub")
+            .await
+            .expect("l2")
+            .iter()
+            .any(|e| e.name == "hello.txt"));
+
+        fs.delete("/faro-test", true).await.expect("delete");
+        assert!(!fs
+            .list_dir("/")
+            .await
+            .expect("root")
+            .iter()
+            .any(|e| e.name == "faro-test"));
+
+        oauth::delete_tokens(GDRIVE_SERVICE, pid);
+        eprintln!("live_gdrive_roundtrip: OK");
+    }
+}

--- a/src-tauri/src/remotefs/http.rs
+++ b/src-tauri/src/remotefs/http.rs
@@ -1,0 +1,455 @@
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
+use crate::remotefs::webdav::parse_http_date;
+use crate::session::http::HttpMode;
+use crate::session::HttpSession;
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use percent_encoding::percent_decode_str;
+use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, LAST_MODIFIED};
+use reqwest::Method;
+use std::collections::HashSet;
+use std::sync::Arc;
+use url::Url;
+
+/// Read-only RemoteFs over a static HTTP(S) server. Lists via autoindex (nginx /
+/// Apache HTML, or nginx JSON) and reads via `GET`; every mutation errors. In
+/// single-file mode it surfaces one entry for a pasted direct URL. Change signal
+/// is the file's `ETag`/`Last-Modified` (populated on read/HEAD, not in a listing).
+pub struct HttpFs {
+    session: Arc<HttpSession>,
+}
+
+impl HttpFs {
+    pub fn new(session: Arc<HttpSession>) -> Self {
+        Self { session }
+    }
+
+    /// HEAD a file URL for its size / last-modified / etag. Best-effort — a
+    /// server that rejects HEAD just yields zeros.
+    async fn head_meta(&self, url: &Url) -> (u64, Option<i64>, Option<String>) {
+        match self.session.request(Method::HEAD, url.clone()).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                let h = resp.headers();
+                let size = h
+                    .get(CONTENT_LENGTH)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(0);
+                let modified = h
+                    .get(LAST_MODIFIED)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(parse_http_date);
+                let etag = h
+                    .get(ETAG)
+                    .and_then(|v| v.to_str().ok())
+                    .map(clean_etag)
+                    .filter(|s| !s.is_empty());
+                (size, modified, etag)
+            }
+            _ => (0, None, None),
+        }
+    }
+
+    fn read_only(op: &str) -> anyhow::Error {
+        anyhow!("HTTP source is read-only ({op} not supported)")
+    }
+}
+
+#[async_trait]
+impl RemoteFs for HttpFs {
+    async fn list_dir(&self, path: &str) -> Result<Vec<DirEntry>> {
+        if let HttpMode::DirectFile { name } = &self.session.mode {
+            // Single-file connection: one entry, HEAD for its size.
+            let url = self.session.url_for(path, false);
+            let (size, modified, etag) = self.head_meta(&url).await;
+            return Ok(vec![DirEntry {
+                name: name.clone(),
+                path: format!("/{name}"),
+                kind: FileKind::File,
+                size,
+                modified,
+                mode: None,
+                etag,
+            }]);
+        }
+
+        let url = self.session.url_for(path, true);
+        let resp = self
+            .session
+            .request(Method::GET, url)
+            .send()
+            .await
+            .with_context(|| format!("GET {path}"))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(anyhow!("{path}: not found"));
+        }
+        if !status.is_success() {
+            return Err(anyhow!("list {path} failed: HTTP {}", status.as_u16()));
+        }
+        let is_json = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_ascii_lowercase().contains("json"))
+            .unwrap_or(false);
+        let body = resp.text().await.context("read listing body")?;
+
+        let entries = if is_json || body.trim_start().starts_with('[') {
+            parse_nginx_json(&body, path)
+        } else {
+            parse_autoindex_html(&body, path)
+        };
+        Ok(entries)
+    }
+
+    async fn rename(&self, _from: &str, _to: &str) -> Result<()> {
+        Err(Self::read_only("rename"))
+    }
+
+    async fn delete(&self, _path: &str, _recursive: bool) -> Result<()> {
+        Err(Self::read_only("delete"))
+    }
+
+    async fn create_dir(&self, _path: &str) -> Result<()> {
+        Err(Self::read_only("create dir"))
+    }
+
+    async fn chmod(&self, _path: &str, _mode: u32) -> Result<()> {
+        Err(Self::read_only("chmod"))
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            can_chmod: false,
+            can_symlink: false,
+            can_rename: false,
+            // Autoindex exposes real subdirectories; direct-file mode just has one.
+            has_directories: true,
+            has_shell: false,
+            change_signal: ChangeSignal::Etag,
+        }
+    }
+}
+
+/// Build a child's Faro path from the directory being listed + a leaf name.
+fn child_path(request_path: &str, name: &str) -> String {
+    let base = request_path.trim_matches('/');
+    if base.is_empty() {
+        format!("/{name}")
+    } else {
+        format!("/{base}/{name}")
+    }
+}
+
+/// Strip the surrounding quotes and any weak-validator `W/` prefix off an ETag.
+fn clean_etag(raw: &str) -> String {
+    raw.trim()
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_string()
+}
+
+/// Parse an nginx/Apache autoindex HTML page into entries. Deliberately simple
+/// and anchor-based (one entry per line, as both servers emit) so it survives the
+/// `<pre>` and `<table>` variants; sizes are best-effort (real size comes from
+/// Content-Length on download).
+fn parse_autoindex_html(body: &str, request_path: &str) -> Vec<DirEntry> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for line in body.lines() {
+        if let Some((href, tail)) = first_href(line) {
+            if let Some(entry) = entry_from_href(&href, tail, request_path) {
+                if seen.insert(entry.path.clone()) {
+                    out.push(entry);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Find the first quoted `href="…"` on a line, returning the href and the text
+/// after the anchor's `</a>` (where nginx/Apache put the date + size columns).
+fn first_href(line: &str) -> Option<(String, &str)> {
+    let idx = line.find("href=")?;
+    let after = &line[idx + 5..];
+    let quote = match after.as_bytes().first()? {
+        b'"' => '"',
+        b'\'' => '\'',
+        _ => return None, // unquoted href — skip
+    };
+    let rest = &after[1..];
+    let end = rest.find(quote)?;
+    let href = rest[..end].to_string();
+    let after_href = &rest[end + 1..];
+    let tail = match after_href.find("</a>") {
+        Some(p) => &after_href[p + 4..],
+        None => after_href,
+    };
+    Some((href, tail))
+}
+
+fn entry_from_href(href: &str, tail: &str, request_path: &str) -> Option<DirEntry> {
+    // Drop query/fragment (Apache column-sort links become empty → skipped).
+    let href = href.split(['?', '#']).next().unwrap_or(href);
+    if href.is_empty() || href.contains("://") || href.starts_with('/') {
+        return None; // external, absolute, or nav link
+    }
+    let is_dir = href.ends_with('/');
+    let trimmed = href.trim_end_matches('/');
+    let seg = trimmed.rsplit('/').next().unwrap_or(trimmed);
+    if seg.is_empty() || seg == "." || seg == ".." {
+        return None;
+    }
+    let name = percent_decode_str(seg).decode_utf8_lossy().into_owned();
+    if name.eq_ignore_ascii_case("parent directory") {
+        return None;
+    }
+    let size = if is_dir { 0 } else { size_from_tail(tail) };
+    Some(DirEntry {
+        name: name.clone(),
+        path: child_path(request_path, &name),
+        kind: if is_dir {
+            FileKind::Directory
+        } else {
+            FileKind::File
+        },
+        size,
+        modified: None,
+        mode: None,
+        etag: None,
+    })
+}
+
+/// Best-effort size from the trailing column(s) of an autoindex row: the last
+/// token that parses as a byte count (plain integer, or Apache's `1.2K`/`3M`).
+fn size_from_tail(tail: &str) -> u64 {
+    let text = strip_tags(tail);
+    for tok in text.split_whitespace().rev() {
+        if tok == "-" {
+            return 0;
+        }
+        if let Some(n) = parse_size_token(tok) {
+            return n;
+        }
+    }
+    0
+}
+
+fn parse_size_token(tok: &str) -> Option<u64> {
+    if let Ok(n) = tok.parse::<u64>() {
+        return Some(n);
+    }
+    parse_human_size(tok)
+}
+
+/// Parse Apache's human-readable sizes (`1.2K`, `3.4M`, `12G`) into bytes.
+fn parse_human_size(tok: &str) -> Option<u64> {
+    let t = tok.trim();
+    let last = t.chars().last()?;
+    let mult: f64 = match last.to_ascii_uppercase() {
+        'K' => 1024.0,
+        'M' => 1024.0 * 1024.0,
+        'G' => 1024.0 * 1024.0 * 1024.0,
+        'T' => 1024.0f64.powi(4),
+        _ => return None,
+    };
+    let num: f64 = t[..t.len() - 1].trim().parse().ok()?;
+    Some((num * mult) as u64)
+}
+
+fn strip_tags(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_tag = false;
+    for c in s.chars() {
+        match c {
+            // Emit a space at each tag boundary so adjacent table cells
+            // (`…09:30</td><td>1.2K…`) don't fuse into one token.
+            '<' => {
+                in_tag = true;
+                out.push(' ');
+            }
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out
+}
+
+#[derive(serde::Deserialize)]
+struct JsonItem {
+    name: String,
+    #[serde(rename = "type")]
+    typ: Option<String>,
+    size: Option<u64>,
+    mtime: Option<String>,
+}
+
+/// Parse nginx's `autoindex_format json;` listing.
+fn parse_nginx_json(body: &str, request_path: &str) -> Vec<DirEntry> {
+    let items: Vec<JsonItem> = serde_json::from_str(body).unwrap_or_default();
+    items
+        .into_iter()
+        .filter_map(|it| {
+            if it.name.is_empty() || it.name == "." || it.name == ".." {
+                return None;
+            }
+            let is_dir = it.typ.as_deref() == Some("directory");
+            Some(DirEntry {
+                path: child_path(request_path, &it.name),
+                name: it.name,
+                kind: if is_dir {
+                    FileKind::Directory
+                } else {
+                    FileKind::File
+                },
+                size: it.size.unwrap_or(0),
+                modified: it.mtime.as_deref().and_then(parse_http_date),
+                mode: None,
+                etag: None,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NGINX_HTML: &str = r#"<html>
+<head><title>Index of /pub/</title></head>
+<body bgcolor="white">
+<h1>Index of /pub/</h1><hr><pre><a href="../">../</a>
+<a href="images/">images/</a>                                        14-Jul-2024 10:00       -
+<a href="notes.txt">notes.txt</a>                                    15-Jul-2024 09:30      42
+<a href="archive%20v2.zip">archive v2.zip</a>                        16-Jul-2024 12:00  1048576
+</pre><hr></body>
+</html>"#;
+
+    #[test]
+    fn parses_nginx_autoindex() {
+        let e = parse_autoindex_html(NGINX_HTML, "/pub");
+        assert_eq!(e.len(), 3, "got {e:?}");
+
+        let dir = e.iter().find(|x| x.name == "images").unwrap();
+        assert_eq!(dir.kind, FileKind::Directory);
+        assert_eq!(dir.path, "/pub/images");
+
+        let notes = e.iter().find(|x| x.name == "notes.txt").unwrap();
+        assert_eq!(notes.kind, FileKind::File);
+        assert_eq!(notes.size, 42);
+
+        let zip = e.iter().find(|x| x.name == "archive v2.zip").unwrap();
+        assert_eq!(zip.size, 1_048_576);
+        assert_eq!(zip.path, "/pub/archive v2.zip");
+    }
+
+    const APACHE_HTML: &str = r#"<html><body>
+<h1>Index of /files</h1>
+<table>
+<tr><th><a href="?C=N;O=D">Name</a></th><th>Last modified</th><th>Size</th></tr>
+<tr><td><a href="/files/">Parent Directory</a></td><td>&nbsp;</td><td>-</td></tr>
+<tr><td><a href="docs/">docs/</a></td><td>2024-07-14 10:00</td><td>-</td></tr>
+<tr><td><a href="readme.md">readme.md</a></td><td>2024-07-15 09:30</td><td>1.2K</td></tr>
+<tr><td><a href="big.iso">big.iso</a></td><td>2024-07-16 12:00</td><td>2.0G</td></tr>
+</table>
+</body></html>"#;
+
+    #[test]
+    fn parses_apache_autoindex() {
+        let e = parse_autoindex_html(APACHE_HTML, "/files");
+        // Sort link + Parent Directory dropped; docs + readme.md + big.iso remain.
+        assert_eq!(e.len(), 3, "got {e:?}");
+        assert!(e.iter().any(|x| x.name == "docs" && x.kind == FileKind::Directory));
+        let readme = e.iter().find(|x| x.name == "readme.md").unwrap();
+        assert_eq!(readme.size, (1.2 * 1024.0) as u64);
+        let iso = e.iter().find(|x| x.name == "big.iso").unwrap();
+        assert_eq!(iso.size, 2 * 1024 * 1024 * 1024);
+    }
+
+    const NGINX_JSON: &str = r#"[
+{ "name":"images", "type":"directory", "mtime":"Sun, 14 Jul 2024 10:00:00 GMT" },
+{ "name":"notes.txt", "type":"file", "mtime":"Mon, 15 Jul 2024 09:30:00 GMT", "size":42 },
+{ "name":".", "type":"directory" }
+]"#;
+
+    #[test]
+    fn parses_nginx_json() {
+        let e = parse_nginx_json(NGINX_JSON, "/pub");
+        assert_eq!(e.len(), 2); // "." dropped
+        let dir = e.iter().find(|x| x.name == "images").unwrap();
+        assert_eq!(dir.kind, FileKind::Directory);
+        assert!(dir.modified.is_some());
+        let notes = e.iter().find(|x| x.name == "notes.txt").unwrap();
+        assert_eq!(notes.size, 42);
+        assert_eq!(notes.path, "/pub/notes.txt");
+    }
+
+    #[test]
+    fn human_sizes() {
+        assert_eq!(parse_human_size("1.2K"), Some(1228));
+        assert_eq!(parse_human_size("3M"), Some(3 * 1024 * 1024));
+        assert_eq!(parse_size_token("512"), Some(512));
+        assert_eq!(parse_size_token("12:00"), None);
+    }
+
+    /// End-to-end against a real static file server (e.g. `python -m http.server`
+    /// autoindex). Skipped unless FARO_HTTP_URL is set; run with
+    /// `cargo test -p faro -- --ignored http_source`.
+    #[tokio::test]
+    #[ignore = "requires a live static HTTP server (FARO_HTTP_URL)"]
+    async fn live_http_source() {
+        use crate::profiles::{AuthMethod, ConnectionProfile};
+        use crate::session::http::http_connect;
+
+        let Ok(url) = std::env::var("FARO_HTTP_URL") else {
+            eprintln!("skip: FARO_HTTP_URL unset");
+            return;
+        };
+        let profile = ConnectionProfile {
+            id: "t".into(),
+            name: "http".into(),
+            protocol: "http".into(),
+            host: "127.0.0.1".into(),
+            port: 443,
+            username: String::new(),
+            auth: AuthMethod::Password { password: String::new() },
+            default_remote_path: None,
+            color: None,
+            auto_connect: None,
+            bucket: None,
+            region: None,
+            endpoint: Some(url),
+            account: None,
+            agent_key: None,
+            group: None,
+            sort_order: None,
+        };
+        let sess = Arc::new(http_connect(&profile).await.expect("connect"));
+        let fs = HttpFs::new(sess.clone());
+        let entries = fs.list_dir("/").await.expect("list root");
+        eprintln!("live_http_source: {} entries", entries.len());
+        assert!(!entries.is_empty());
+
+        // Mutations must be refused.
+        assert!(fs.delete("/anything", false).await.is_err());
+        assert!(fs.create_dir("/nope").await.is_err());
+
+        // GET a listed file back through the session (the transfer read path).
+        if let Some(file) = entries.iter().find(|e| e.kind == FileKind::File) {
+            let body = sess
+                .request(Method::GET, sess.url_for(&file.path, false))
+                .send()
+                .await
+                .expect("get send")
+                .text()
+                .await
+                .expect("get body");
+            eprintln!("fetched {} ({} bytes)", file.name, body.len());
+            assert!(!body.is_empty());
+        }
+        eprintln!("live_http_source: OK");
+    }
+}

--- a/src-tauri/src/remotefs/local.rs
+++ b/src-tauri/src/remotefs/local.rs
@@ -1,4 +1,4 @@
-use super::{Capabilities, DirEntry, FileKind, RemoteFs};
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use std::path::Path;
@@ -39,6 +39,7 @@ impl RemoteFs for LocalFs {
                 size: meta.len(),
                 modified,
                 mode: None,
+                etag: None,
             });
         }
         Ok(out)
@@ -98,6 +99,7 @@ impl RemoteFs for LocalFs {
             can_rename: true,
             has_directories: true,
             has_shell: false,
+            change_signal: ChangeSignal::MtimeSize,
         }
     }
 }

--- a/src-tauri/src/remotefs/mod.rs
+++ b/src-tauri/src/remotefs/mod.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 pub mod agent;
+pub mod boxdrive;
 pub mod dropbox;
 pub mod ftp;
 pub mod gdrive;

--- a/src-tauri/src/remotefs/mod.rs
+++ b/src-tauri/src/remotefs/mod.rs
@@ -7,6 +7,7 @@ pub mod ftp;
 pub mod http;
 pub mod local;
 pub mod object;
+pub mod onedrive;
 pub mod sftp;
 pub mod webdav;
 

--- a/src-tauri/src/remotefs/mod.rs
+++ b/src-tauri/src/remotefs/mod.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod agent;
 pub mod ftp;
+pub mod http;
 pub mod local;
 pub mod object;
 pub mod sftp;

--- a/src-tauri/src/remotefs/mod.rs
+++ b/src-tauri/src/remotefs/mod.rs
@@ -6,6 +6,7 @@ pub mod ftp;
 pub mod local;
 pub mod object;
 pub mod sftp;
+pub mod webdav;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/src-tauri/src/remotefs/mod.rs
+++ b/src-tauri/src/remotefs/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub mod agent;
 pub mod dropbox;
 pub mod ftp;
+pub mod gdrive;
 pub mod http;
 pub mod local;
 pub mod object;

--- a/src-tauri/src/remotefs/mod.rs
+++ b/src-tauri/src/remotefs/mod.rs
@@ -27,6 +27,27 @@ pub struct DirEntry {
     pub modified: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<u32>,
+    /// Backend-supplied opaque change token when it has one (object stores
+    /// expose an ETag). Treat it as a change *token*, not a content hash —
+    /// multipart-S3 ETags aren't MD5s. `None` for backends that rely on
+    /// mtime+size instead. See [`ChangeSignal`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub etag: Option<String>,
+}
+
+/// The cheapest reliable "did this file change" a backend can offer. Consumed by
+/// folder-sync's `sync_state` index (Plan 3), diff's `--hash` mode (Plan 6), and
+/// declared per-backend so callers stop guessing from mtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ChangeSignal {
+    /// POSIX-ish: compare size + mtime (SFTP, FTP, local, agent).
+    MtimeSize,
+    /// Object stores: compare the opaque ETag on `DirEntry.etag`.
+    Etag,
+    /// Neither is reliable; a content hash is required (no backend declares this
+    /// today — reserved so a future backend can opt in without a schema change).
+    Hash,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -39,6 +60,8 @@ pub struct Capabilities {
     /// Backend runs shell commands (gates server-side archive + "open terminal
     /// here"). True for SSH; false for local/FTP/object stores.
     pub has_shell: bool,
+    /// How this backend reports change — drives the sync index's staleness check.
+    pub change_signal: ChangeSignal,
 }
 
 /// Unified filesystem abstraction. Each backend (Local, SFTP, S3, FTP, ...)

--- a/src-tauri/src/remotefs/mod.rs
+++ b/src-tauri/src/remotefs/mod.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 pub mod agent;
+pub mod dropbox;
 pub mod ftp;
 pub mod http;
 pub mod local;

--- a/src-tauri/src/remotefs/object.rs
+++ b/src-tauri/src/remotefs/object.rs
@@ -1,4 +1,4 @@
-use super::{Capabilities, DirEntry, FileKind, RemoteFs};
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
 use crate::session::ObjectSession;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -29,7 +29,12 @@ fn normalize_prefix(raw: &str) -> String {
     }
 }
 
-fn entry_for_object(key: &str, size: u64, modified_secs: Option<i64>) -> DirEntry {
+fn entry_for_object(
+    key: &str,
+    size: u64,
+    modified_secs: Option<i64>,
+    etag: Option<String>,
+) -> DirEntry {
     let name = key.rsplit('/').next().unwrap_or(key).to_string();
     DirEntry {
         name,
@@ -38,6 +43,7 @@ fn entry_for_object(key: &str, size: u64, modified_secs: Option<i64>) -> DirEntr
         size,
         modified: modified_secs,
         mode: None,
+        etag,
     }
 }
 
@@ -51,6 +57,7 @@ fn entry_for_prefix(prefix: &str) -> DirEntry {
         size: 0,
         modified: None,
         mode: None,
+        etag: None,
     }
 }
 
@@ -82,6 +89,7 @@ impl RemoteFs for ObjectFs {
                 obj.location.as_ref(),
                 obj.size as u64,
                 Some(modified),
+                obj.e_tag.clone(),
             ));
         }
         Ok(out)
@@ -146,6 +154,9 @@ impl RemoteFs for ObjectFs {
             can_rename: true,
             has_directories: false,
             has_shell: false,
+            // Object stores expose an ETag per object — an opaque change token
+            // (not necessarily an MD5 for multipart uploads). See ChangeSignal.
+            change_signal: ChangeSignal::Etag,
         }
     }
 }

--- a/src-tauri/src/remotefs/onedrive.rs
+++ b/src-tauri/src/remotefs/onedrive.rs
@@ -1,0 +1,372 @@
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
+use crate::remotefs::dropbox::parse_iso8601;
+use crate::session::OneDriveSession;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use reqwest::Method;
+use std::sync::Arc;
+
+/// Characters to percent-encode in a path segment: controls, space, and the URL
+/// reserved/delimiter chars — but NOT the unreserved set (`. - _ ~`), so a normal
+/// filename like `report.pdf` passes through unchanged.
+const PATH_ENC: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'?')
+    .add(b'/')
+    .add(b'\\')
+    .add(b'<')
+    .add(b'>')
+    .add(b'{')
+    .add(b'}')
+    .add(b'|')
+    .add(b'^')
+    .add(b'`');
+
+/// RemoteFs over OneDrive via Microsoft Graph. Graph supports path addressing
+/// (`/me/drive/root:/path:`), so it slots into the trait like Dropbox: real
+/// folders, rename/move via PATCH, no chmod. The per-item `cTag` is the change
+/// token.
+pub struct OneDriveFs {
+    session: Arc<OneDriveSession>,
+}
+
+impl OneDriveFs {
+    pub fn new(session: Arc<OneDriveSession>) -> Self {
+        Self { session }
+    }
+}
+
+fn enc(seg: &str) -> String {
+    utf8_percent_encode(seg, PATH_ENC).to_string()
+}
+
+/// Percent-encode a Faro path's segments, keeping the slashes.
+fn enc_path(faro: &str) -> String {
+    faro.trim_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(enc)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn is_root(faro: &str) -> bool {
+    let p = faro.trim().trim_matches('/');
+    p.is_empty() || p == "."
+}
+
+/// Graph item reference for a path (addresses the item itself).
+pub fn item_ref(faro: &str) -> String {
+    if is_root(faro) {
+        "/me/drive/root".to_string()
+    } else {
+        format!("/me/drive/root:/{}:", enc_path(faro))
+    }
+}
+
+/// Graph children reference for a directory path.
+fn children_ref(faro: &str) -> String {
+    if is_root(faro) {
+        "/me/drive/root/children".to_string()
+    } else {
+        format!("/me/drive/root:/{}:/children", enc_path(faro))
+    }
+}
+
+/// Graph content reference for a file path (download/upload bytes).
+pub fn content_ref(faro: &str) -> String {
+    format!("/me/drive/root:/{}:/content", enc_path(faro))
+}
+
+fn basename(faro: &str) -> &str {
+    faro.trim_matches('/').rsplit('/').next().unwrap_or("")
+}
+
+fn parent_of(faro: &str) -> String {
+    let t = faro.trim_matches('/');
+    match t.rsplit_once('/') {
+        Some((p, _)) => p.to_string(),
+        None => String::new(),
+    }
+}
+
+/// Graph parentReference path for a Faro directory (`/drive/root:` at root).
+fn parent_path_ref(parent_faro: &str) -> String {
+    if is_root(parent_faro) {
+        "/drive/root:".to_string()
+    } else {
+        format!("/drive/root:/{}", enc_path(parent_faro))
+    }
+}
+
+#[async_trait]
+impl RemoteFs for OneDriveFs {
+    async fn list_dir(&self, path: &str) -> Result<Vec<DirEntry>> {
+        let mut out = Vec::new();
+        let mut next = children_ref(path);
+        loop {
+            let page = self.session.rpc(Method::GET, &next, None).await?;
+            if let Some(items) = page.get("value").and_then(|v| v.as_array()) {
+                for item in items {
+                    if let Some(e) = entry_from_json(item, path) {
+                        out.push(e);
+                    }
+                }
+            }
+            match page.get("@odata.nextLink").and_then(|v| v.as_str()) {
+                Some(url) => next = url.to_string(),
+                None => break,
+            }
+        }
+        Ok(out)
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        let body = serde_json::json!({
+            "name": basename(to),
+            "parentReference": { "path": parent_path_ref(&parent_of(to)) },
+        });
+        self.session
+            .rpc(Method::PATCH, &item_ref(from), Some(&body))
+            .await
+            .with_context(|| format!("move {from} -> {to}"))?;
+        Ok(())
+    }
+
+    async fn delete(&self, path: &str, _recursive: bool) -> Result<()> {
+        // Graph DELETE removes a folder and its contents.
+        self.session
+            .rpc(Method::DELETE, &item_ref(path), None)
+            .await
+            .with_context(|| format!("delete {path}"))?;
+        Ok(())
+    }
+
+    async fn create_dir(&self, path: &str) -> Result<()> {
+        let parent = parent_of(path);
+        let body = serde_json::json!({
+            "name": basename(path),
+            "folder": {},
+            "@microsoft.graph.conflictBehavior": "fail",
+        });
+        self.session
+            .rpc(Method::POST, &children_ref(&parent), Some(&body))
+            .await
+            .with_context(|| format!("create dir {path}"))?;
+        Ok(())
+    }
+
+    async fn chmod(&self, _path: &str, _mode: u32) -> Result<()> {
+        Err(anyhow::anyhow!("OneDrive has no POSIX permissions"))
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            can_chmod: false,
+            can_symlink: false,
+            can_rename: true,
+            has_directories: true,
+            has_shell: false,
+            change_signal: ChangeSignal::Etag,
+        }
+    }
+}
+
+/// Parse a Graph driveItem into a DirEntry (path built under `request_path`).
+fn entry_from_json(item: &serde_json::Value, request_path: &str) -> Option<DirEntry> {
+    let name = item.get("name").and_then(|n| n.as_str())?.to_string();
+    let kind = if item.get("folder").is_some() {
+        FileKind::Directory
+    } else {
+        FileKind::File
+    };
+    let size = item.get("size").and_then(|s| s.as_u64()).unwrap_or(0);
+    let modified = item
+        .get("lastModifiedDateTime")
+        .and_then(|m| m.as_str())
+        .and_then(parse_iso8601);
+    // cTag tracks content changes; fall back to eTag.
+    let etag = item
+        .get("cTag")
+        .or_else(|| item.get("eTag"))
+        .and_then(|t| t.as_str())
+        .map(|s| s.to_string());
+    let base = request_path.trim_matches('/');
+    let path = if base.is_empty() {
+        format!("/{name}")
+    } else {
+        format!("/{base}/{name}")
+    };
+    Some(DirEntry {
+        name,
+        path,
+        kind,
+        size,
+        modified,
+        mode: None,
+        etag,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graph_path_refs() {
+        assert_eq!(item_ref("/"), "/me/drive/root");
+        assert_eq!(item_ref("/a/b"), "/me/drive/root:/a/b:");
+        assert_eq!(children_ref("/"), "/me/drive/root/children");
+        assert_eq!(children_ref("/docs"), "/me/drive/root:/docs:/children");
+        assert_eq!(content_ref("/a/f.txt"), "/me/drive/root:/a/f.txt:/content");
+        // Spaces get percent-encoded.
+        assert_eq!(item_ref("/my docs"), "/me/drive/root:/my%20docs:");
+        assert_eq!(parent_path_ref(""), "/drive/root:");
+        assert_eq!(parent_path_ref("/a"), "/drive/root:/a");
+    }
+
+    #[test]
+    fn parses_graph_children() {
+        let page = serde_json::json!({
+            "value": [
+                { "name": "Photos", "folder": { "childCount": 3 }, "size": 0,
+                  "lastModifiedDateTime": "2024-07-14T10:00:00Z", "cTag": "ctag1", "id": "1" },
+                { "name": "report.pdf", "file": { "mimeType": "application/pdf" },
+                  "size": 2048, "lastModifiedDateTime": "2024-07-15T09:30:00Z",
+                  "cTag": "ctag2", "eTag": "etag2", "id": "2" }
+            ]
+        });
+        let items = page["value"].as_array().unwrap();
+        let entries: Vec<DirEntry> = items
+            .iter()
+            .filter_map(|i| entry_from_json(i, "/docs"))
+            .collect();
+        assert_eq!(entries.len(), 2);
+        let dir = entries.iter().find(|e| e.name == "Photos").unwrap();
+        assert_eq!(dir.kind, FileKind::Directory);
+        assert_eq!(dir.path, "/docs/Photos");
+        let file = entries.iter().find(|e| e.name == "report.pdf").unwrap();
+        assert_eq!(file.kind, FileKind::File);
+        assert_eq!(file.size, 2048);
+        assert_eq!(file.etag.as_deref(), Some("ctag2"));
+        assert_eq!(file.modified, Some(1_721_035_800));
+    }
+
+    /// End-to-end against the Graph mock (`tests/onedrive_mock.py`). Skipped
+    /// unless FARO_ONEDRIVE_MOCK_URL is set; run with
+    /// `cargo test -p faro -- --ignored onedrive_roundtrip` after starting it.
+    /// Drives the whole client path — token exchange, 401→refresh retry, /me,
+    /// list/create/upload/download/move/delete — through Faro's own code.
+    #[tokio::test]
+    #[ignore = "requires the OneDrive mock (FARO_ONEDRIVE_MOCK_URL)"]
+    async fn live_onedrive_roundtrip() {
+        use crate::oauth::{self, TokenSet};
+        use crate::profiles::{AuthMethod, ConnectionProfile};
+        use crate::session::onedrive::{onedrive_config, onedrive_connect, ONEDRIVE_SERVICE};
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let Ok(mock) = std::env::var("FARO_ONEDRIVE_MOCK_URL") else {
+            eprintln!("skip: FARO_ONEDRIVE_MOCK_URL unset");
+            return;
+        };
+        std::env::set_var("FARO_ONEDRIVE_CLIENT_ID", "test-client");
+        std::env::set_var("FARO_ONEDRIVE_TOKEN_URL", format!("{mock}/oauth2/token"));
+        std::env::set_var("FARO_ONEDRIVE_GRAPH_BASE", &mock);
+
+        // Real token exchange against the mock.
+        let ex = oauth::exchange_code(&onedrive_config(), "authcode", "verifier")
+            .await
+            .expect("exchange");
+        assert_eq!(ex["access_token"], "ACCESS1");
+
+        // Seed a stale-but-unexpired token so the first call 401s → force refresh.
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let pid = "onedrive-mock-test";
+        oauth::store_tokens(
+            ONEDRIVE_SERVICE,
+            pid,
+            &TokenSet {
+                access_token: "STALE".into(),
+                refresh_token: Some("REFRESH1".into()),
+                expires_at: now + 99_999,
+            },
+        )
+        .expect("seed");
+
+        let profile = ConnectionProfile {
+            id: pid.into(),
+            name: "od".into(),
+            protocol: "onedrive".into(),
+            host: "onedrive.com".into(),
+            port: 443,
+            username: String::new(),
+            auth: AuthMethod::Password { password: String::new() },
+            default_remote_path: None,
+            color: None,
+            auto_connect: None,
+            bucket: None,
+            region: None,
+            endpoint: None,
+            account: None,
+            agent_key: None,
+            group: None,
+            sort_order: None,
+        };
+        let session = Arc::new(onedrive_connect(&profile).await.expect("connect"));
+
+        // First API call uses STALE → 401 → force_refresh → succeeds.
+        assert_eq!(session.account_label().await.expect("account"), "tester@example.com");
+
+        let fs = OneDriveFs::new(session.clone());
+        fs.create_dir("/faro-test").await.expect("mkdir");
+
+        // Simple upload (PUT …/content), then list/download/move/delete.
+        let token = session.access_token().await.unwrap();
+        let put = session
+            .client
+            .put(format!("{}{}", session.graph_base, content_ref("/faro-test/hello.txt")))
+            .bearer_auth(&token)
+            .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+            .body("hi onedrive")
+            .send()
+            .await
+            .expect("upload");
+        assert!(put.status().is_success(), "upload {}", put.status());
+
+        let entries = fs.list_dir("/faro-test").await.expect("list");
+        let hello = entries.iter().find(|e| e.name == "hello.txt").expect("hello");
+        assert_eq!(hello.kind, FileKind::File);
+        assert_eq!(hello.size, 11);
+
+        let dl = session
+            .get_stream(&content_ref("/faro-test/hello.txt"))
+            .await
+            .expect("download")
+            .text()
+            .await
+            .expect("body");
+        assert_eq!(dl, "hi onedrive");
+
+        fs.rename("/faro-test/hello.txt", "/faro-test/renamed.txt")
+            .await
+            .expect("move");
+        let entries = fs.list_dir("/faro-test").await.expect("list2");
+        assert!(entries.iter().any(|e| e.name == "renamed.txt"));
+        assert!(!entries.iter().any(|e| e.name == "hello.txt"));
+
+        fs.delete("/faro-test", true).await.expect("delete");
+        assert!(!fs
+            .list_dir("/")
+            .await
+            .expect("root")
+            .iter()
+            .any(|e| e.name == "faro-test"));
+
+        oauth::delete_tokens(ONEDRIVE_SERVICE, pid);
+        eprintln!("live_onedrive_roundtrip: OK");
+    }
+}

--- a/src-tauri/src/remotefs/sftp.rs
+++ b/src-tauri/src/remotefs/sftp.rs
@@ -1,4 +1,4 @@
-use super::{Capabilities, DirEntry, FileKind, RemoteFs};
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
 use crate::session::SshSession;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -60,6 +60,7 @@ impl RemoteFs for SftpFs {
                         size: attrs.size.unwrap_or(0),
                         modified: attrs.mtime.map(|t| t as i64),
                         mode: attrs.permissions,
+                        etag: None,
                     });
                 }
                 Ok(out)
@@ -153,6 +154,7 @@ impl RemoteFs for SftpFs {
             can_rename: true,
             has_directories: true,
             has_shell: true,
+            change_signal: ChangeSignal::MtimeSize,
         }
     }
 }

--- a/src-tauri/src/remotefs/webdav.rs
+++ b/src-tauri/src/remotefs/webdav.rs
@@ -1,0 +1,595 @@
+use super::{Capabilities, ChangeSignal, DirEntry, FileKind, RemoteFs};
+use crate::session::webdav::PROPFIND_BODY;
+use crate::session::WebdavSession;
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use percent_encoding::percent_decode_str;
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use reqwest::Method;
+use std::sync::Arc;
+
+/// RemoteFs over WebDAV (Nextcloud, ownCloud, Hetzner Storage Box, and the
+/// generic long tail). Real directories, rename via `MOVE`, no chmod. Change
+/// detection leans on the per-resource ETag (`getetag`); servers that omit it
+/// degrade to the mtime+size the entries still carry.
+pub struct WebdavFs {
+    session: Arc<WebdavSession>,
+}
+
+impl WebdavFs {
+    pub fn new(session: Arc<WebdavSession>) -> Self {
+        Self { session }
+    }
+
+    fn propfind_method() -> Method {
+        Method::from_bytes(b"PROPFIND").expect("PROPFIND is a valid method token")
+    }
+}
+
+#[async_trait]
+impl RemoteFs for WebdavFs {
+    async fn list_dir(&self, path: &str) -> Result<Vec<DirEntry>> {
+        let url = self.session.url_for(path, true);
+        let resp = self
+            .session
+            .request(Self::propfind_method(), url)
+            .header("Depth", "1")
+            .header("Content-Type", "application/xml")
+            .body(PROPFIND_BODY)
+            .send()
+            .await
+            .with_context(|| format!("PROPFIND {path}"))?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(anyhow!("{path}: not found"));
+        }
+        if !(status.is_success() || status.as_u16() == 207) {
+            return Err(anyhow!("PROPFIND {path} failed: HTTP {}", status.as_u16()));
+        }
+
+        let body = resp.text().await.context("read PROPFIND body")?;
+        Ok(parse_multistatus(&body, &self.session.base_path(), path))
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        let src = self.session.url_for(from, false);
+        let dst = self.session.url_for(to, false);
+        let resp = self
+            .session
+            .request(Method::from_bytes(b"MOVE").unwrap(), src)
+            .header("Destination", dst.as_str())
+            // Don't silently clobber an existing target — mirrors SFTP/local rename.
+            .header("Overwrite", "F")
+            .send()
+            .await
+            .with_context(|| format!("MOVE {from} -> {to}"))?;
+        if !resp.status().is_success() {
+            return Err(anyhow!(
+                "rename {from} -> {to} failed: HTTP {}",
+                resp.status().as_u16()
+            ));
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, path: &str, _recursive: bool) -> Result<()> {
+        // WebDAV DELETE on a collection removes the whole tree by spec, so the
+        // `recursive` flag needs no separate handling here.
+        let url = self.session.url_for(path, false);
+        let resp = self
+            .session
+            .request(Method::DELETE, url)
+            .send()
+            .await
+            .with_context(|| format!("DELETE {path}"))?;
+        let status = resp.status();
+        if !(status.is_success() || status == reqwest::StatusCode::NOT_FOUND) {
+            return Err(anyhow!("delete {path} failed: HTTP {}", status.as_u16()));
+        }
+        Ok(())
+    }
+
+    async fn create_dir(&self, path: &str) -> Result<()> {
+        let url = self.session.url_for(path, true);
+        let resp = self
+            .session
+            .request(Method::from_bytes(b"MKCOL").unwrap(), url)
+            .send()
+            .await
+            .with_context(|| format!("MKCOL {path}"))?;
+        if !resp.status().is_success() {
+            return Err(anyhow!(
+                "create dir {path} failed: HTTP {}",
+                resp.status().as_u16()
+            ));
+        }
+        Ok(())
+    }
+
+    async fn chmod(&self, _path: &str, _mode: u32) -> Result<()> {
+        Err(anyhow!("WebDAV has no POSIX permissions"))
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            can_chmod: false,
+            can_symlink: false,
+            can_rename: true,
+            has_directories: true,
+            has_shell: false,
+            // ETag is the reliable change token; entries also carry mtime+size
+            // for servers that omit getetag.
+            change_signal: ChangeSignal::Etag,
+        }
+    }
+}
+
+/// Which prop's text we're currently accumulating inside a `<response>`.
+#[derive(PartialEq)]
+enum Field {
+    Href,
+    ContentLength,
+    LastModified,
+    Etag,
+}
+
+/// Parse a WebDAV `multistatus` (207) body into directory entries, resolving each
+/// `href` against the DAV root `base_path` and dropping the self-entry for
+/// `request_path`. Namespace-prefix agnostic (matches on local element names) so
+/// it handles Nextcloud (`d:`), Apache mod_dav (`D:`/`lp1:`), and bare servers.
+fn parse_multistatus(xml: &str, base_path: &str, request_path: &str) -> Vec<DirEntry> {
+    let request_norm = format!("/{}", request_path.trim_matches('/'));
+    let request_norm = if request_norm == "/" {
+        "/".to_string()
+    } else {
+        request_norm
+    };
+
+    let mut reader = Reader::from_str(xml);
+    let mut out = Vec::new();
+
+    // Per-response accumulators.
+    let mut href: Option<String> = None;
+    let mut is_collection = false;
+    let mut size: u64 = 0;
+    let mut etag: Option<String> = None;
+    let mut modified: Option<i64> = None;
+
+    let mut in_resourcetype = false;
+    let mut capture: Option<Field> = None;
+    let mut buf = String::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) => {
+                let local = e.local_name();
+                match local.as_ref() {
+                    b"response" => {
+                        href = None;
+                        is_collection = false;
+                        size = 0;
+                        etag = None;
+                        modified = None;
+                    }
+                    b"href" => {
+                        capture = Some(Field::Href);
+                        buf.clear();
+                    }
+                    b"resourcetype" => in_resourcetype = true,
+                    b"collection" if in_resourcetype => is_collection = true,
+                    b"getcontentlength" => {
+                        capture = Some(Field::ContentLength);
+                        buf.clear();
+                    }
+                    b"getlastmodified" => {
+                        capture = Some(Field::LastModified);
+                        buf.clear();
+                    }
+                    b"getetag" => {
+                        capture = Some(Field::Etag);
+                        buf.clear();
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Empty(e)) => {
+                let local = e.local_name();
+                if local.as_ref() == b"collection" && in_resourcetype {
+                    is_collection = true;
+                }
+            }
+            Ok(Event::Text(e)) => {
+                if capture.is_some() {
+                    if let Ok(t) = e.unescape() {
+                        buf.push_str(&t);
+                    }
+                }
+            }
+            Ok(Event::CData(e)) => {
+                if capture.is_some() {
+                    buf.push_str(&String::from_utf8_lossy(&e));
+                }
+            }
+            Ok(Event::End(e)) => {
+                let local = e.local_name();
+                match local.as_ref() {
+                    b"href" => {
+                        href = Some(buf.trim().to_string());
+                        capture = None;
+                    }
+                    b"getcontentlength" => {
+                        // Only overwrite on a real value: a 404 propstat block
+                        // re-declares the prop empty and must not clobber the 200.
+                        if let Ok(n) = buf.trim().parse::<u64>() {
+                            size = n;
+                        }
+                        capture = None;
+                    }
+                    b"getlastmodified" => {
+                        if let Some(ts) = parse_http_date(buf.trim()) {
+                            modified = Some(ts);
+                        }
+                        capture = None;
+                    }
+                    b"getetag" => {
+                        let clean = clean_etag(buf.trim());
+                        if !clean.is_empty() {
+                            etag = Some(clean);
+                        }
+                        capture = None;
+                    }
+                    b"resourcetype" => in_resourcetype = false,
+                    b"response" => {
+                        if let Some(h) = href.take() {
+                            if let Some((entry_path, name)) = href_to_path(&h, base_path) {
+                                if entry_path != request_norm {
+                                    out.push(DirEntry {
+                                        name,
+                                        path: entry_path,
+                                        kind: if is_collection {
+                                            FileKind::Directory
+                                        } else {
+                                            FileKind::File
+                                        },
+                                        size,
+                                        modified,
+                                        mode: None,
+                                        etag: etag.take(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    out
+}
+
+/// Turn a PROPFIND `href` into a Faro path (`/dir/file`) + display name relative
+/// to the DAV root. Returns `None` for hrefs that aren't under the base (skipped
+/// rather than mis-rendered).
+fn href_to_path(href: &str, base_path: &str) -> Option<(String, String)> {
+    // href may be a full URL or a server-absolute path.
+    let path_part = if let Some(idx) = href.find("://") {
+        let rest = &href[idx + 3..];
+        match rest.find('/') {
+            Some(slash) => &rest[slash..],
+            None => "/",
+        }
+    } else {
+        href
+    };
+
+    let decoded_href = percent_decode_str(path_part).decode_utf8_lossy().into_owned();
+    let decoded_base = percent_decode_str(base_path)
+        .decode_utf8_lossy()
+        .into_owned();
+
+    let hp = decoded_href.trim_end_matches('/');
+    let bp = decoded_base.trim_end_matches('/');
+
+    let rel = if hp == bp {
+        "" // the collection itself
+    } else if let Some(r) = hp.strip_prefix(bp) {
+        r.trim_start_matches('/')
+    } else {
+        return None;
+    };
+
+    let entry_path = if rel.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{rel}")
+    };
+    let name = rel.rsplit('/').next().unwrap_or(rel).to_string();
+    Some((entry_path, name))
+}
+
+/// Strip the surrounding quotes and any weak-validator `W/` prefix off an ETag.
+fn clean_etag(raw: &str) -> String {
+    raw.trim()
+        .trim_start_matches("W/")
+        .trim_matches('"')
+        .to_string()
+}
+
+/// Parse an RFC 1123 HTTP-date (always GMT for `getlastmodified`) into a Unix
+/// timestamp. Deliberately dependency-free — the format is fixed.
+fn parse_http_date(s: &str) -> Option<i64> {
+    // "Mon, 15 Jul 2024 12:34:56 GMT"
+    let parts: Vec<&str> = s.split_whitespace().collect();
+    if parts.len() < 5 {
+        return None;
+    }
+    let day: i64 = parts[1].parse().ok()?;
+    let month = month_num(parts[2])?;
+    let year: i64 = parts[3].parse().ok()?;
+    let time: Vec<&str> = parts[4].split(':').collect();
+    if time.len() != 3 {
+        return None;
+    }
+    let hh: i64 = time[0].parse().ok()?;
+    let mm: i64 = time[1].parse().ok()?;
+    let ss: i64 = time[2].parse().ok()?;
+    Some(days_from_civil(year, month, day) * 86400 + hh * 3600 + mm * 60 + ss)
+}
+
+fn month_num(m: &str) -> Option<i64> {
+    Some(match m {
+        "Jan" => 1,
+        "Feb" => 2,
+        "Mar" => 3,
+        "Apr" => 4,
+        "May" => 5,
+        "Jun" => 6,
+        "Jul" => 7,
+        "Aug" => 8,
+        "Sep" => 9,
+        "Oct" => 10,
+        "Nov" => 11,
+        "Dec" => 12,
+        _ => return None,
+    })
+}
+
+/// Days since the Unix epoch for a civil (proleptic Gregorian) date. Howard
+/// Hinnant's `days_from_civil` algorithm.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = (if y >= 0 { y } else { y - 399 }) / 400;
+    let yoe = y - era * 400; // [0, 399]
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    era * 146097 + doe - 719468
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A Nextcloud-style multistatus: `d:` prefix, full-path hrefs, quoted etags,
+    // one collection (the requested dir, dropped as self) + a subdir + a file.
+    const NEXTCLOUD: &str = r#"<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/files/alice/docs/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:getlastmodified>Mon, 15 Jul 2024 12:34:56 GMT</d:getlastmodified>
+        <d:getetag>"abc123"</d:getetag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/files/alice/docs/sub/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:getetag>"dir-etag"</d:getetag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/files/alice/docs/report%20final.pdf</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:getcontentlength>2048</d:getcontentlength>
+        <d:getlastmodified>Tue, 16 Jul 2024 09:00:00 GMT</d:getlastmodified>
+        <d:getetag>W/"weak-etag"</d:getetag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop><d:getcontentlength/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>"#;
+
+    #[test]
+    fn parses_nextcloud_listing() {
+        let entries = parse_multistatus(NEXTCLOUD, "/remote.php/dav/files/alice/", "/docs");
+        // Self-entry (docs/) dropped; a subdir + a file remain.
+        assert_eq!(entries.len(), 2);
+
+        let sub = entries.iter().find(|e| e.name == "sub").expect("sub dir");
+        assert_eq!(sub.kind, FileKind::Directory);
+        assert_eq!(sub.path, "/docs/sub");
+        assert_eq!(sub.etag.as_deref(), Some("dir-etag"));
+
+        // Percent-encoded name is decoded; 404-block empty length doesn't clobber.
+        let file = entries
+            .iter()
+            .find(|e| e.name == "report final.pdf")
+            .expect("pdf file");
+        assert_eq!(file.kind, FileKind::File);
+        assert_eq!(file.path, "/docs/report final.pdf");
+        assert_eq!(file.size, 2048);
+        assert_eq!(file.etag.as_deref(), Some("weak-etag"));
+        assert!(file.modified.is_some());
+    }
+
+    // Apache mod_dav style: `D:` prefix, path hrefs, no etags, sizes present.
+    const APACHE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+<D:response>
+<D:href>/share/</D:href>
+<D:propstat><D:prop><D:resourcetype><D:collection/></D:resourcetype></D:prop>
+<D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+<D:response>
+<D:href>/share/notes.txt</D:href>
+<D:propstat><D:prop>
+<D:resourcetype/>
+<D:getcontentlength>17</D:getcontentlength>
+<D:getlastmodified>Wed, 01 Jan 2020 00:00:00 GMT</D:getlastmodified>
+</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+</D:multistatus>"#;
+
+    #[test]
+    fn parses_apache_listing_without_etags() {
+        let entries = parse_multistatus(APACHE, "/share/", "/");
+        assert_eq!(entries.len(), 1);
+        let f = &entries[0];
+        assert_eq!(f.name, "notes.txt");
+        assert_eq!(f.path, "/notes.txt");
+        assert_eq!(f.size, 17);
+        assert!(f.etag.is_none());
+        assert_eq!(f.modified, Some(1_577_836_800)); // 2020-01-01T00:00:00Z
+    }
+
+    #[test]
+    fn full_url_hrefs_resolve() {
+        let xml = r#"<multistatus xmlns="DAV:">
+<response><href>https://dav.example.com/dav/photo.jpg</href>
+<propstat><prop><resourcetype/><getcontentlength>9</getcontentlength></prop>
+<status>HTTP/1.1 200 OK</status></propstat></response></multistatus>"#;
+        let entries = parse_multistatus(xml, "/dav/", "/");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "photo.jpg");
+        assert_eq!(entries[0].path, "/photo.jpg");
+    }
+
+    #[test]
+    fn http_date_epoch() {
+        assert_eq!(parse_http_date("Thu, 01 Jan 1970 00:00:00 GMT"), Some(0));
+        assert_eq!(
+            parse_http_date("Mon, 15 Jul 2024 12:34:56 GMT"),
+            Some(1_721_046_896)
+        );
+        assert_eq!(parse_http_date("garbage"), None);
+    }
+
+    #[test]
+    fn etag_cleaning() {
+        assert_eq!(clean_etag(r#""abc""#), "abc");
+        assert_eq!(clean_etag(r#"W/"weak""#), "weak");
+        assert_eq!(clean_etag(""), "");
+    }
+
+    /// End-to-end against a real WebDAV server. Skipped unless FARO_WEBDAV_URL is
+    /// set; run with `cargo test -p faro -- --ignored webdav` after starting one
+    /// (e.g. wsgidav). Exercises connect → mkcol → put → list → get → move →
+    /// delete through Faro's own WebdavFs/WebdavSession, not just the parser.
+    #[tokio::test]
+    #[ignore = "requires a live WebDAV server (FARO_WEBDAV_URL/USER/PASS)"]
+    async fn live_webdav_roundtrip() {
+        use crate::profiles::{AuthMethod, ConnectionProfile};
+        use crate::session::webdav::webdav_connect;
+        use reqwest::Method;
+
+        let Ok(url) = std::env::var("FARO_WEBDAV_URL") else {
+            eprintln!("skip: FARO_WEBDAV_URL unset");
+            return;
+        };
+        let user = std::env::var("FARO_WEBDAV_USER").unwrap_or_default();
+        let pass = std::env::var("FARO_WEBDAV_PASS").unwrap_or_default();
+
+        let profile = ConnectionProfile {
+            id: "test".into(),
+            name: "webdav-test".into(),
+            protocol: "webdav".into(),
+            host: "127.0.0.1".into(),
+            port: 443,
+            username: user,
+            auth: AuthMethod::Password { password: pass },
+            default_remote_path: None,
+            color: None,
+            auto_connect: None,
+            bucket: None,
+            region: None,
+            endpoint: Some(url),
+            account: None,
+            agent_key: None,
+            group: None,
+            sort_order: None,
+        };
+
+        let sess = Arc::new(webdav_connect(&profile).await.expect("connect"));
+        let fs = WebdavFs::new(sess.clone());
+
+        // Clean slate.
+        let _ = fs.delete("/faro-test", true).await;
+        fs.create_dir("/faro-test").await.expect("mkcol");
+
+        // PUT a file through the session (same path the transfer manager uses).
+        let put = sess
+            .request(Method::PUT, sess.url_for("/faro-test/hello.txt", false))
+            .body("hi there")
+            .send()
+            .await
+            .expect("put send");
+        assert!(put.status().is_success(), "PUT status {}", put.status());
+
+        // LIST sees it, with the right kind + size.
+        let entries = fs.list_dir("/faro-test").await.expect("list");
+        let hello = entries
+            .iter()
+            .find(|e| e.name == "hello.txt")
+            .expect("hello.txt listed");
+        assert_eq!(hello.kind, FileKind::File);
+        assert_eq!(hello.size, 8);
+        assert_eq!(hello.path, "/faro-test/hello.txt");
+
+        // GET round-trips the bytes.
+        let got = sess
+            .request(Method::GET, sess.url_for("/faro-test/hello.txt", false))
+            .send()
+            .await
+            .expect("get send")
+            .text()
+            .await
+            .expect("get body");
+        assert_eq!(got, "hi there");
+
+        // MOVE (rename) then confirm the swap.
+        fs.rename("/faro-test/hello.txt", "/faro-test/renamed.txt")
+            .await
+            .expect("move");
+        let entries = fs.list_dir("/faro-test").await.expect("list after move");
+        assert!(entries.iter().any(|e| e.name == "renamed.txt"));
+        assert!(!entries.iter().any(|e| e.name == "hello.txt"));
+
+        // DELETE the file, then the collection.
+        fs.delete("/faro-test/renamed.txt", false)
+            .await
+            .expect("delete file");
+        fs.delete("/faro-test", true).await.expect("delete dir");
+        let root = fs.list_dir("/").await.expect("list root");
+        assert!(!root.iter().any(|e| e.name == "faro-test"));
+
+        eprintln!("live_webdav_roundtrip: OK");
+    }
+}

--- a/src-tauri/src/remotefs/webdav.rs
+++ b/src-tauri/src/remotefs/webdav.rs
@@ -363,8 +363,9 @@ fn month_num(m: &str) -> Option<i64> {
 }
 
 /// Days since the Unix epoch for a civil (proleptic Gregorian) date. Howard
-/// Hinnant's `days_from_civil` algorithm.
-fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+/// Hinnant's `days_from_civil` algorithm. Shared with the Dropbox backend's
+/// ISO-8601 timestamp parser.
+pub(crate) fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
     let y = if m <= 2 { y - 1 } else { y };
     let era = (if y >= 0 { y } else { y - 399 }) / 400;
     let yoe = y - era * 400; // [0, 399]

--- a/src-tauri/src/remotefs/webdav.rs
+++ b/src-tauri/src/remotefs/webdav.rs
@@ -323,8 +323,9 @@ fn clean_etag(raw: &str) -> String {
 }
 
 /// Parse an RFC 1123 HTTP-date (always GMT for `getlastmodified`) into a Unix
-/// timestamp. Deliberately dependency-free — the format is fixed.
-fn parse_http_date(s: &str) -> Option<i64> {
+/// timestamp. Deliberately dependency-free — the format is fixed. Shared with the
+/// HTTP autoindex backend (`Last-Modified` headers, nginx-JSON `mtime`).
+pub(crate) fn parse_http_date(s: &str) -> Option<i64> {
     // "Mon, 15 Jul 2024 12:34:56 GMT"
     let parts: Vec<&str> = s.split_whitespace().collect();
     if parts.len() < 5 {

--- a/src-tauri/src/scan.rs
+++ b/src-tauri/src/scan.rs
@@ -1,0 +1,163 @@
+//! Shared scan engine — the one place that walks a [`RemoteFs`] tree
+//! (see `docs/plans/3_scan-index-foundation.md`).
+//!
+//! Extracted from `sync.rs::walk`. Folder-sync's reconciler, disk usage
+//! (Plan 4), diff (Plan 6), and search (Plan 7) all call **this** instead of
+//! rolling their own recursion. Latency — not CPU — dominates on SFTP/FTP, so
+//! the generic walk lists many directories concurrently (bounded) rather than
+//! one round-trip at a time.
+//!
+//! Two protocol fast paths named in the plan (an exec `du`/`find` for
+//! SSH/agent, and an object-store flat listing for S3/Azure) will land with
+//! their first consumer (Plan 4). The generic walk here always works and is the
+//! fallback for all of them; the strategy hook is the [`ScanOptions`] the caller
+//! passes.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::stream::{FuturesUnordered, StreamExt};
+
+use crate::remotefs::{FileKind, RemoteFs};
+
+/// Default in-flight `list_dir` fan-out. High enough to hide per-request latency
+/// on SFTP/FTP, low enough not to swamp a server with parallel connections.
+pub const DEFAULT_CONCURRENCY: usize = 16;
+
+/// A cheap, cloneable cooperative-cancel flag. Mirrors the abort handles the
+/// `TransferManager` / `agent_host` use, without pulling in a runtime dep.
+#[derive(Clone, Default)]
+pub struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Progress emitted after each directory listing completes. Consumers (Plan 4's
+/// disk-usage tab) turn this into `scan://…` events; the sync poller ignores it.
+#[derive(Debug, Clone, Copy)]
+pub struct ScanProgress {
+    pub dirs_scanned: usize,
+    pub files_found: usize,
+}
+
+/// One file discovered by the walk. `modified` is normalised to `0` when the
+/// backend didn't report an mtime (matching the old `sync.rs` walk). `etag` is
+/// the backend's opaque change token when it has one (object stores).
+#[derive(Debug, Clone)]
+pub struct ScanEntry {
+    pub absolute: String,
+    pub size: u64,
+    pub modified: i64,
+    pub etag: Option<String>,
+}
+
+/// A flattened file tree keyed by relative path (POSIX `/`) from the scan root.
+/// Directories are implicit — only files are tracked, exactly as sync needs.
+#[derive(Debug, Default, Clone)]
+pub struct ScanTree {
+    pub files: BTreeMap<String, ScanEntry>,
+}
+
+/// Knobs for a walk. `Default` is what the sync poller wants: full concurrency,
+/// never cancelled.
+#[derive(Clone)]
+pub struct ScanOptions {
+    pub concurrency: usize,
+    pub cancel: CancelToken,
+}
+
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self { concurrency: DEFAULT_CONCURRENCY, cancel: CancelToken::new() }
+    }
+}
+
+/// Convenience wrapper for the common case (default options, no progress).
+pub async fn walk_tree(fs: &dyn RemoteFs, root: &str) -> Result<ScanTree> {
+    walk(fs, root, &ScanOptions::default(), |_| {}).await
+}
+
+/// Recursively list every file under `root`. Bounded-concurrency BFS: up to
+/// `opts.concurrency` `list_dir` calls are in flight at once. Unreadable
+/// directories are tolerated (skipped), symlinks are not followed — both
+/// preserving the behaviour of the walk this replaced. `on_progress` fires once
+/// per completed directory listing.
+pub async fn walk<F: FnMut(ScanProgress)>(
+    fs: &dyn RemoteFs,
+    root: &str,
+    opts: &ScanOptions,
+    mut on_progress: F,
+) -> Result<ScanTree> {
+    let normalized_root = root.trim_end_matches('/').to_string();
+    let limit = opts.concurrency.max(1);
+
+    let mut tree = ScanTree::default();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    queue.push_back(root.to_string());
+    let mut inflight = FuturesUnordered::new();
+    let mut dirs_scanned = 0usize;
+
+    loop {
+        if opts.cancel.is_cancelled() {
+            break;
+        }
+        // Keep the pipeline full: top up in-flight listings from the queue.
+        while inflight.len() < limit {
+            match queue.pop_front() {
+                Some(dir) => inflight.push(async move {
+                    let res = fs.list_dir(&dir).await;
+                    res
+                }),
+                None => break,
+            }
+        }
+        // Empty queue *and* nothing in flight ⇒ the tree is fully walked.
+        let Some(res) = inflight.next().await else {
+            break;
+        };
+        dirs_scanned += 1;
+        if let Ok(entries) = res {
+            for entry in entries {
+                match entry.kind {
+                    FileKind::Directory => queue.push_back(entry.path.clone()),
+                    FileKind::File => {
+                        let rel = relative_of(&normalized_root, &entry.path);
+                        tree.files.insert(
+                            rel,
+                            ScanEntry {
+                                absolute: entry.path.clone(),
+                                size: entry.size,
+                                modified: entry.modified.unwrap_or(0),
+                                // Phase 3 populates this from `entry.etag`.
+                                etag: None,
+                            },
+                        );
+                    }
+                    _ => {} // skip symlinks/other — don't chase cycles
+                }
+            }
+        }
+        on_progress(ScanProgress { dirs_scanned, files_found: tree.files.len() });
+    }
+
+    Ok(tree)
+}
+
+/// The path of `full` relative to `root`, POSIX-normalised. Shared with `sync.rs`.
+pub fn relative_of(root: &str, full: &str) -> String {
+    let stripped = full.strip_prefix(root).unwrap_or(full);
+    stripped
+        .trim_start_matches(|c| c == '/' || c == '\\')
+        .replace('\\', "/")
+}

--- a/src-tauri/src/scan.rs
+++ b/src-tauri/src/scan.rs
@@ -139,8 +139,7 @@ pub async fn walk<F: FnMut(ScanProgress)>(
                                 absolute: entry.path.clone(),
                                 size: entry.size,
                                 modified: entry.modified.unwrap_or(0),
-                                // Phase 3 populates this from `entry.etag`.
-                                etag: None,
+                                etag: entry.etag.clone(),
                             },
                         );
                     }

--- a/src-tauri/src/scan.rs
+++ b/src-tauri/src/scan.rs
@@ -49,6 +49,9 @@ impl CancelToken {
 pub struct ScanProgress {
     pub dirs_scanned: usize,
     pub files_found: usize,
+    /// Running total of every file byte seen so far. Disk usage (Plan 4) shows
+    /// this live ("1.2 GB found"); the sync poller ignores it.
+    pub bytes_found: u64,
 }
 
 /// One file discovered by the walk. `modified` is normalised to `0` when the
@@ -107,6 +110,7 @@ pub async fn walk<F: FnMut(ScanProgress)>(
     queue.push_back(root.to_string());
     let mut inflight = FuturesUnordered::new();
     let mut dirs_scanned = 0usize;
+    let mut bytes_found = 0u64;
 
     loop {
         if opts.cancel.is_cancelled() {
@@ -132,6 +136,7 @@ pub async fn walk<F: FnMut(ScanProgress)>(
                 match entry.kind {
                     FileKind::Directory => queue.push_back(entry.path.clone()),
                     FileKind::File => {
+                        bytes_found += entry.size;
                         let rel = relative_of(&normalized_root, &entry.path);
                         tree.files.insert(
                             rel,
@@ -147,7 +152,7 @@ pub async fn walk<F: FnMut(ScanProgress)>(
                 }
             }
         }
-        on_progress(ScanProgress { dirs_scanned, files_found: tree.files.len() });
+        on_progress(ScanProgress { dirs_scanned, files_found: tree.files.len(), bytes_found });
     }
 
     Ok(tree)

--- a/src-tauri/src/session/boxdrive.rs
+++ b/src-tauri/src/session/boxdrive.rs
@@ -1,0 +1,280 @@
+use crate::oauth::{self, OAuthConfig, RefreshingToken};
+use crate::profiles::ConnectionProfile;
+use anyhow::{anyhow, Context, Result};
+use reqwest::{Client, Method};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Mutex as StdMutex;
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Keychain service name for Box tokens (keyed by profile id).
+pub const BOX_SERVICE: &str = "faro-box";
+
+const DEFAULT_API_BASE: &str = "https://api.box.com/2.0";
+const DEFAULT_UPLOAD_BASE: &str = "https://upload.box.com/api/2.0";
+const DEFAULT_AUTH_URL: &str = "https://account.box.com/api/oauth2/authorize";
+const DEFAULT_TOKEN_URL: &str = "https://api.box.com/oauth2/token";
+
+/// Box root folder id.
+pub const ROOT_ID: &str = "0";
+
+/// Box app client id. Create a **Custom App → OAuth 2.0 (User Auth)** at
+/// <https://app.box.com/developers/console>, add `http://localhost:53682/` as a
+/// redirect, enable "write all files" scope, and paste the Client ID here or set
+/// `FARO_BOX_CLIENT_ID`. (Box also issues a client secret; PKCE is used so it's
+/// not embedded — leave it out of Faro.)
+const BOX_CLIENT_ID: &str = "";
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+pub fn box_config() -> OAuthConfig {
+    OAuthConfig {
+        client_id: env_or("FARO_BOX_CLIENT_ID", BOX_CLIENT_ID),
+        auth_url: env_or("FARO_BOX_AUTH_URL", DEFAULT_AUTH_URL),
+        token_url: env_or("FARO_BOX_TOKEN_URL", DEFAULT_TOKEN_URL),
+        // Box scopes are configured on the app, not requested per-flow.
+        scopes: vec![],
+        extra_auth_params: vec![],
+    }
+}
+
+/// A live Box connection. Box is **ID-addressed** like Google Drive, so this
+/// session carries a path→id resolver cache (cleared on structural mutations).
+pub struct BoxSession {
+    pub id: String,
+    pub profile: ConnectionProfile,
+    pub client: Client,
+    pub api_base: String,
+    pub upload_base: String,
+    token: RefreshingToken,
+    cache: StdMutex<HashMap<String, String>>,
+}
+
+impl BoxSession {
+    pub async fn access_token(&self) -> Result<String> {
+        self.token.access_token().await
+    }
+    pub async fn force_refresh(&self) -> Result<()> {
+        self.token.force_refresh().await
+    }
+    pub fn clear_cache(&self) {
+        self.cache.lock().unwrap().clear();
+    }
+    pub fn cache_path(&self, faro_path: &str, id: &str) {
+        self.cache
+            .lock()
+            .unwrap()
+            .insert(normalize(faro_path), id.to_string());
+    }
+
+    pub async fn send(
+        &self,
+        method: Method,
+        url: &str,
+        body: Option<&Value>,
+    ) -> Result<reqwest::Response> {
+        let full = if url.starts_with("http") {
+            url.to_string()
+        } else {
+            format!("{}{url}", self.api_base)
+        };
+        let mut attempt = 0;
+        loop {
+            let token = self.token.access_token().await?;
+            let mut rb = self.client.request(method.clone(), &full).bearer_auth(&token);
+            if let Some(b) = body {
+                rb = rb.json(b);
+            }
+            let resp = rb.send().await.with_context(|| format!("box {url}"))?;
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+                attempt += 1;
+                self.force_refresh().await?;
+                continue;
+            }
+            return Ok(resp);
+        }
+    }
+
+    pub async fn rpc(&self, method: Method, url: &str, body: Option<&Value>) -> Result<Value> {
+        let resp = self.send(method, url, body).await?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("box {url} failed ({}): {text}", status.as_u16()));
+        }
+        if text.trim().is_empty() {
+            return Ok(Value::Null);
+        }
+        serde_json::from_str(&text).with_context(|| format!("parse box {url} response"))
+    }
+
+    pub async fn get_stream(&self, url: &str) -> Result<reqwest::Response> {
+        let resp = self.send(Method::GET, url, None).await?;
+        if !resp.status().is_success() {
+            let code = resp.status().as_u16();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("box GET {url} failed ({code}): {text}"));
+        }
+        Ok(resp)
+    }
+
+    pub async fn account_label(&self) -> Result<String> {
+        let v = self.rpc(Method::GET, "/users/me", None).await?;
+        for key in ["login", "name"] {
+            if let Some(s) = v.get(key).and_then(|x| x.as_str()).filter(|s| !s.is_empty()) {
+                return Ok(s.to_string());
+            }
+        }
+        Ok("Box".to_string())
+    }
+
+    /// All entries in a folder (paged), each `{type,id,name,size,modified_at,sha1}`.
+    pub async fn folder_items(&self, folder_id: &str) -> Result<Vec<Value>> {
+        let mut out = Vec::new();
+        let mut offset = 0u64;
+        loop {
+            let url = format!(
+                "/folders/{folder_id}/items?fields=id,name,type,size,modified_at,sha1&limit=1000&offset={offset}"
+            );
+            let v = self.rpc(Method::GET, &url, None).await?;
+            let entries = v
+                .get("entries")
+                .and_then(|e| e.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let n = entries.len() as u64;
+            out.extend(entries);
+            let total = v.get("total_count").and_then(|t| t.as_u64()).unwrap_or(out.len() as u64);
+            offset += n;
+            if n == 0 || offset >= total {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// Find a direct child by name, returning `(id, is_folder)`.
+    pub async fn find_child(&self, parent_id: &str, name: &str) -> Result<Option<(String, bool)>> {
+        for e in self.folder_items(parent_id).await? {
+            if e.get("name").and_then(|n| n.as_str()) == Some(name) {
+                let id = e.get("id").and_then(|x| x.as_str()).unwrap_or("").to_string();
+                let is_folder = e.get("type").and_then(|t| t.as_str()) == Some("folder");
+                return Ok(Some((id, is_folder)));
+            }
+        }
+        Ok(None)
+    }
+
+    pub async fn folder_id(&self, faro_path: &str) -> Result<String> {
+        let norm = normalize(faro_path);
+        if let Some(id) = self.cache.lock().unwrap().get(&norm).cloned() {
+            return Ok(id);
+        }
+        if norm == "/" {
+            return Ok(ROOT_ID.to_string());
+        }
+        let mut id = ROOT_ID.to_string();
+        let mut acc = String::new();
+        for seg in norm.trim_matches('/').split('/') {
+            acc = format!("{acc}/{seg}");
+            let cached = self.cache.lock().unwrap().get(&acc).cloned();
+            id = match cached {
+                Some(c) => c,
+                None => {
+                    let (cid, is_folder) = self
+                        .find_child(&id, seg)
+                        .await?
+                        .ok_or_else(|| anyhow!("{faro_path}: no such folder"))?;
+                    if !is_folder {
+                        return Err(anyhow!("{acc} is a file, not a folder"));
+                    }
+                    self.cache.lock().unwrap().insert(acc.clone(), cid.clone());
+                    cid
+                }
+            };
+        }
+        Ok(id)
+    }
+
+    pub async fn resolve_item(&self, faro_path: &str) -> Result<Option<(String, bool)>> {
+        let norm = normalize(faro_path);
+        if norm == "/" {
+            return Ok(Some((ROOT_ID.to_string(), true)));
+        }
+        let parent_id = self.folder_id(&parent_of(&norm)).await?;
+        self.find_child(&parent_id, basename(&norm)).await
+    }
+
+    pub async fn size(&self, faro_path: &str) -> u64 {
+        if let Ok(Some((id, is_folder))) = self.resolve_item(faro_path).await {
+            if !is_folder {
+                if let Ok(v) = self
+                    .rpc(Method::GET, &format!("/files/{id}?fields=size"), None)
+                    .await
+                {
+                    return v.get("size").and_then(|s| s.as_u64()).unwrap_or(0);
+                }
+            }
+        }
+        0
+    }
+
+    pub async fn exists(&self, faro_path: &str) -> bool {
+        matches!(self.resolve_item(faro_path).await, Ok(Some(_)))
+    }
+}
+
+pub async fn box_connect(profile: &ConnectionProfile) -> Result<BoxSession> {
+    let tokens = oauth::load_tokens(BOX_SERVICE, &profile.id)?.ok_or_else(|| {
+        anyhow!(
+            "This Box connection isn't authorized yet. Open it in the connection editor \
+             and click “Connect with Box”."
+        )
+    })?;
+
+    let client = Client::builder()
+        .connect_timeout(Duration::from_secs(20))
+        .timeout(Duration::from_secs(300))
+        .user_agent(concat!("Faro/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("building Box HTTP client")?;
+
+    Ok(BoxSession {
+        id: Uuid::new_v4().to_string(),
+        profile: profile.clone(),
+        client,
+        api_base: env_or("FARO_BOX_API_BASE", DEFAULT_API_BASE),
+        upload_base: env_or("FARO_BOX_UPLOAD_BASE", DEFAULT_UPLOAD_BASE),
+        token: RefreshingToken::new(BOX_SERVICE, &profile.id, box_config(), tokens),
+        cache: StdMutex::new(HashMap::new()),
+    })
+}
+
+// ---- path helpers (shared shape with the Drive resolver) ----
+
+pub fn normalize(faro: &str) -> String {
+    let t = faro.trim().trim_matches('/');
+    if t.is_empty() || t == "." {
+        "/".to_string()
+    } else {
+        format!("/{t}")
+    }
+}
+
+pub fn basename(faro: &str) -> &str {
+    faro.trim_matches('/').rsplit('/').next().unwrap_or("")
+}
+
+pub fn parent_of(faro: &str) -> String {
+    let t = faro.trim_matches('/');
+    match t.rsplit_once('/') {
+        Some((p, _)) => format!("/{p}"),
+        None => "/".to_string(),
+    }
+}

--- a/src-tauri/src/session/dropbox.rs
+++ b/src-tauri/src/session/dropbox.rs
@@ -1,0 +1,223 @@
+use crate::oauth::{self, OAuthConfig, TokenSet};
+use crate::profiles::ConnectionProfile;
+use anyhow::{anyhow, Context, Result};
+use reqwest::Client;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+/// Keychain service name under which Dropbox tokens are stored (keyed by profile id).
+pub const DROPBOX_SERVICE: &str = "faro-dropbox";
+
+const DEFAULT_API_BASE: &str = "https://api.dropboxapi.com";
+const DEFAULT_CONTENT_BASE: &str = "https://content.dropboxapi.com";
+const DEFAULT_AUTH_URL: &str = "https://www.dropbox.com/oauth2/authorize";
+const DEFAULT_TOKEN_URL: &str = "https://api.dropboxapi.com/oauth2/token";
+
+/// Dropbox app key (client id). Register a **scoped** app at
+/// <https://www.dropbox.com/developers/apps>, set its redirect URI to
+/// `http://localhost:53682/`, enable the `account_info.read`,
+/// `files.metadata.read`, `files.content.read`, and `files.content.write`
+/// scopes, then paste the App key here (or set `FARO_DROPBOX_APP_KEY`). PKCE
+/// means no app secret is needed.
+const DROPBOX_APP_KEY: &str = "";
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// The OAuth config for Dropbox. Endpoints fall back to env overrides so the
+/// integration test can point the whole flow at a local mock.
+pub fn dropbox_config() -> OAuthConfig {
+    OAuthConfig {
+        client_id: env_or("FARO_DROPBOX_APP_KEY", DROPBOX_APP_KEY),
+        auth_url: env_or("FARO_DROPBOX_AUTH_URL", DEFAULT_AUTH_URL),
+        token_url: env_or("FARO_DROPBOX_TOKEN_URL", DEFAULT_TOKEN_URL),
+        scopes: vec![
+            "account_info.read".into(),
+            "files.metadata.read".into(),
+            "files.content.read".into(),
+            "files.content.write".into(),
+        ],
+        // Offline access ⇒ Dropbox returns a long-lived refresh token.
+        extra_auth_params: vec![("token_access_type".into(), "offline".into())],
+    }
+}
+
+/// A live Dropbox connection. Stateless HTTP like the object/webdav backends —
+/// every op is a request carrying a bearer access token, which is refreshed
+/// (and re-persisted to the keychain) transparently when it nears expiry or a
+/// request comes back 401.
+pub struct DropboxSession {
+    pub id: String,
+    pub profile: ConnectionProfile,
+    pub client: Client,
+    pub api_base: String,
+    pub content_base: String,
+    config: OAuthConfig,
+    tokens: Mutex<TokenSet>,
+}
+
+impl DropboxSession {
+    /// A valid access token, refreshing + persisting first if it's near expiry.
+    pub async fn access_token(&self) -> Result<String> {
+        let mut guard = self.tokens.lock().await;
+        if oauth::is_expired(&guard) {
+            let rt = guard
+                .refresh_token
+                .clone()
+                .ok_or_else(|| anyhow!("no refresh token — re-authorize this Dropbox connection"))?;
+            let fresh = oauth::refresh(&self.config, &rt).await?;
+            *guard = fresh;
+            oauth::store_tokens(DROPBOX_SERVICE, &self.profile.id, &guard)?;
+        }
+        Ok(guard.access_token.clone())
+    }
+
+    /// Force a refresh (used after a 401 on a token we thought was still valid).
+    pub async fn force_refresh(&self) -> Result<()> {
+        let mut guard = self.tokens.lock().await;
+        let rt = guard
+            .refresh_token
+            .clone()
+            .ok_or_else(|| anyhow!("no refresh token — re-authorize this Dropbox connection"))?;
+        let fresh = oauth::refresh(&self.config, &rt).await?;
+        *guard = fresh;
+        oauth::store_tokens(DROPBOX_SERVICE, &self.profile.id, &guard)?;
+        Ok(())
+    }
+
+    /// POST an RPC endpoint (`/2/…`) with a JSON body, retrying once on 401 after
+    /// a forced refresh. Returns the parsed JSON response.
+    pub async fn rpc(&self, endpoint: &str, body: serde_json::Value) -> Result<serde_json::Value> {
+        let url = format!("{}{endpoint}", self.api_base);
+        for attempt in 0..2 {
+            let token = self.access_token().await?;
+            let resp = self
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .json(&body)
+                .send()
+                .await
+                .with_context(|| format!("dropbox {endpoint}"))?;
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+                self.force_refresh().await?;
+                continue;
+            }
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                return Err(anyhow!(
+                    "dropbox {endpoint} failed ({}): {text}",
+                    status.as_u16()
+                ));
+            }
+            // No-arg endpoints (get_current_account) can return an empty body.
+            if text.trim().is_empty() {
+                return Ok(serde_json::Value::Null);
+            }
+            return serde_json::from_str(&text)
+                .with_context(|| format!("parse dropbox {endpoint} response"));
+        }
+        unreachable!("rpc loop always returns within 2 attempts")
+    }
+
+    /// A content-API GET (download): POST with the arg in the `Dropbox-API-Arg`
+    /// header, retrying once on 401. Returns the streaming success response.
+    pub async fn content_get(&self, endpoint: &str, arg: &str) -> Result<reqwest::Response> {
+        let url = format!("{}{endpoint}", self.content_base);
+        for attempt in 0..2 {
+            let token = self.access_token().await?;
+            let resp = self
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .header("Dropbox-API-Arg", arg)
+                .send()
+                .await
+                .with_context(|| format!("dropbox {endpoint}"))?;
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+                self.force_refresh().await?;
+                continue;
+            }
+            if !resp.status().is_success() {
+                let code = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow!("dropbox {endpoint} failed ({code}): {text}"));
+            }
+            return Ok(resp);
+        }
+        unreachable!("content_get loop always returns within 2 attempts")
+    }
+
+    /// The account's email (falling back to display name) for the connection label.
+    pub async fn account_label(&self) -> Result<String> {
+        let v = self
+            .rpc("/2/users/get_current_account", serde_json::Value::Null)
+            .await?;
+        let email = v.get("email").and_then(|x| x.as_str()).unwrap_or("");
+        if !email.is_empty() {
+            return Ok(email.to_string());
+        }
+        let name = v
+            .get("name")
+            .and_then(|n| n.get("display_name"))
+            .and_then(|x| x.as_str())
+            .unwrap_or("Dropbox");
+        Ok(name.to_string())
+    }
+
+    /// Whether a path exists (via get_metadata).
+    pub async fn exists(&self, dbx_path: &str) -> bool {
+        self.rpc(
+            "/2/files/get_metadata",
+            serde_json::json!({ "path": dbx_path }),
+        )
+        .await
+        .is_ok()
+    }
+
+    /// The size of a file at `dbx_path`, or 0 if unknown.
+    pub async fn size(&self, dbx_path: &str) -> u64 {
+        self.rpc(
+            "/2/files/get_metadata",
+            serde_json::json!({ "path": dbx_path }),
+        )
+        .await
+        .ok()
+        .and_then(|v| v.get("size").and_then(|s| s.as_u64()))
+        .unwrap_or(0)
+    }
+}
+
+/// Open a Dropbox session from a profile whose tokens were stored at authorize
+/// time. Errors clearly if the connection was never authorized.
+pub async fn dropbox_connect(profile: &ConnectionProfile) -> Result<DropboxSession> {
+    let tokens = oauth::load_tokens(DROPBOX_SERVICE, &profile.id)?.ok_or_else(|| {
+        anyhow!(
+            "This Dropbox connection isn't authorized yet. Open it in the connection \
+             editor and click “Connect with Dropbox”."
+        )
+    })?;
+
+    let client = Client::builder()
+        .connect_timeout(Duration::from_secs(20))
+        .timeout(Duration::from_secs(300))
+        .user_agent(concat!("Faro/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("building Dropbox HTTP client")?;
+
+    Ok(DropboxSession {
+        id: Uuid::new_v4().to_string(),
+        profile: profile.clone(),
+        client,
+        api_base: env_or("FARO_DROPBOX_API_BASE", DEFAULT_API_BASE),
+        content_base: env_or("FARO_DROPBOX_CONTENT_BASE", DEFAULT_CONTENT_BASE),
+        config: dropbox_config(),
+        tokens: Mutex::new(tokens),
+    })
+}

--- a/src-tauri/src/session/gdrive.rs
+++ b/src-tauri/src/session/gdrive.rs
@@ -1,0 +1,303 @@
+use crate::oauth::{self, OAuthConfig, RefreshingToken};
+use crate::profiles::ConnectionProfile;
+use anyhow::{anyhow, Context, Result};
+use reqwest::{Client, Method};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Mutex as StdMutex;
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Keychain service name for Google Drive tokens (keyed by profile id).
+pub const GDRIVE_SERVICE: &str = "faro-gdrive";
+
+const DEFAULT_API_BASE: &str = "https://www.googleapis.com/drive/v3";
+const DEFAULT_UPLOAD_BASE: &str = "https://www.googleapis.com/upload/drive/v3";
+const DEFAULT_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const DEFAULT_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+
+pub const FOLDER_MIME: &str = "application/vnd.google-apps.folder";
+
+/// Google OAuth client id. Create a **Desktop app** OAuth client at
+/// <https://console.cloud.google.com/apis/credentials>, enable the Drive API,
+/// add `http://localhost:53682/` as an authorized redirect, and paste the client
+/// id here or set `FARO_GDRIVE_CLIENT_ID`. PKCE ⇒ no secret needed for a public
+/// desktop client.
+const GDRIVE_CLIENT_ID: &str = "";
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// Google Drive OAuth config. `access_type=offline` + `prompt=consent` are what
+/// make Google return a refresh token.
+pub fn gdrive_config() -> OAuthConfig {
+    OAuthConfig {
+        client_id: env_or("FARO_GDRIVE_CLIENT_ID", GDRIVE_CLIENT_ID),
+        auth_url: env_or("FARO_GDRIVE_AUTH_URL", DEFAULT_AUTH_URL),
+        token_url: env_or("FARO_GDRIVE_TOKEN_URL", DEFAULT_TOKEN_URL),
+        scopes: vec!["https://www.googleapis.com/auth/drive".into()],
+        extra_auth_params: vec![
+            ("access_type".into(), "offline".into()),
+            ("prompt".into(), "consent".into()),
+        ],
+    }
+}
+
+/// A live Google Drive connection. Drive is **ID-addressed**, so this session
+/// carries a path→file-id resolver cache; every RemoteFs op resolves the path to
+/// an id first. The cache is cleared on any structural mutation to avoid stale ids.
+pub struct GDriveSession {
+    pub id: String,
+    pub profile: ConnectionProfile,
+    pub client: Client,
+    pub api_base: String,
+    pub upload_base: String,
+    token: RefreshingToken,
+    /// Faro path → Drive file id. `/` maps to the special id `root`.
+    cache: StdMutex<HashMap<String, String>>,
+}
+
+impl GDriveSession {
+    pub async fn access_token(&self) -> Result<String> {
+        self.token.access_token().await
+    }
+
+    pub async fn force_refresh(&self) -> Result<()> {
+        self.token.force_refresh().await
+    }
+
+    pub fn clear_cache(&self) {
+        self.cache.lock().unwrap().clear();
+    }
+
+    /// Warm the resolver cache with a known path→id (used while listing).
+    pub fn cache_path(&self, faro_path: &str, id: &str) {
+        self.cache
+            .lock()
+            .unwrap()
+            .insert(normalize(faro_path), id.to_string());
+    }
+
+    /// Send a Drive request (bearer + one 401→refresh retry). `path` may be a
+    /// Drive API path (`/files…`), an upload path, or an absolute URL.
+    pub async fn send(
+        &self,
+        method: Method,
+        url: &str,
+        body: Option<&Value>,
+    ) -> Result<reqwest::Response> {
+        let full = if url.starts_with("http") {
+            url.to_string()
+        } else {
+            format!("{}{url}", self.api_base)
+        };
+        let mut attempt = 0;
+        loop {
+            let token = self.token.access_token().await?;
+            let mut rb = self.client.request(method.clone(), &full).bearer_auth(&token);
+            if let Some(b) = body {
+                rb = rb.json(b);
+            }
+            let resp = rb.send().await.with_context(|| format!("drive {url}"))?;
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+                attempt += 1;
+                self.force_refresh().await?;
+                continue;
+            }
+            return Ok(resp);
+        }
+    }
+
+    pub async fn rpc(&self, method: Method, url: &str, body: Option<&Value>) -> Result<Value> {
+        let resp = self.send(method, url, body).await?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("drive {url} failed ({}): {text}", status.as_u16()));
+        }
+        if text.trim().is_empty() {
+            return Ok(Value::Null);
+        }
+        serde_json::from_str(&text).with_context(|| format!("parse drive {url} response"))
+    }
+
+    pub async fn get_stream(&self, url: &str) -> Result<reqwest::Response> {
+        let resp = self.send(Method::GET, url, None).await?;
+        if !resp.status().is_success() {
+            let code = resp.status().as_u16();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("drive GET {url} failed ({code}): {text}"));
+        }
+        Ok(resp)
+    }
+
+    pub async fn account_label(&self) -> Result<String> {
+        let v = self.rpc(Method::GET, "/about?fields=user", None).await?;
+        let user = v.get("user");
+        for key in ["emailAddress", "displayName"] {
+            if let Some(s) = user
+                .and_then(|u| u.get(key))
+                .and_then(|x| x.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                return Ok(s.to_string());
+            }
+        }
+        Ok("Google Drive".to_string())
+    }
+
+    /// Find a direct child of `parent_id` by name, returning `(id, is_folder)`.
+    pub async fn find_child(&self, parent_id: &str, name: &str) -> Result<Option<(String, bool)>> {
+        let q = format!(
+            "'{}' in parents and name = '{}' and trashed = false",
+            parent_id,
+            escape_q(name)
+        );
+        let url = format!(
+            "/files?q={}&fields=files(id,mimeType)&pageSize=2",
+            urlencode(&q)
+        );
+        let v = self.rpc(Method::GET, &url, None).await?;
+        let first = v
+            .get("files")
+            .and_then(|f| f.as_array())
+            .and_then(|a| a.first());
+        Ok(first.map(|f| {
+            let id = f.get("id").and_then(|x| x.as_str()).unwrap_or("").to_string();
+            let is_folder = f.get("mimeType").and_then(|m| m.as_str()) == Some(FOLDER_MIME);
+            (id, is_folder)
+        }))
+    }
+
+    /// Resolve a Faro directory path to a Drive folder id (`root` for `/`).
+    pub async fn folder_id(&self, faro_path: &str) -> Result<String> {
+        let norm = normalize(faro_path);
+        if let Some(id) = self.cache.lock().unwrap().get(&norm).cloned() {
+            return Ok(id);
+        }
+        if norm == "/" {
+            return Ok("root".to_string());
+        }
+        let mut id = "root".to_string();
+        let mut acc = String::new();
+        for seg in norm.trim_matches('/').split('/') {
+            acc = format!("{acc}/{seg}");
+            let cached = self.cache.lock().unwrap().get(&acc).cloned();
+            id = match cached {
+                Some(c) => c,
+                None => {
+                    let (child_id, is_folder) = self
+                        .find_child(&id, seg)
+                        .await?
+                        .ok_or_else(|| anyhow!("{faro_path}: no such folder"))?;
+                    if !is_folder {
+                        return Err(anyhow!("{acc} is a file, not a folder"));
+                    }
+                    self.cache.lock().unwrap().insert(acc.clone(), child_id.clone());
+                    child_id
+                }
+            };
+        }
+        Ok(id)
+    }
+
+    /// Resolve a Faro item path to `(id, is_folder)`, or `None` if missing.
+    pub async fn resolve_item(&self, faro_path: &str) -> Result<Option<(String, bool)>> {
+        let norm = normalize(faro_path);
+        if norm == "/" {
+            return Ok(Some(("root".to_string(), true)));
+        }
+        let parent = parent_of(&norm);
+        let name = basename(&norm);
+        let parent_id = self.folder_id(&parent).await?;
+        self.find_child(&parent_id, name).await
+    }
+
+    pub async fn size(&self, faro_path: &str) -> u64 {
+        if let Ok(Some((id, _))) = self.resolve_item(faro_path).await {
+            if let Ok(v) = self
+                .rpc(Method::GET, &format!("/files/{id}?fields=size"), None)
+                .await
+            {
+                return v
+                    .get("size")
+                    .and_then(|s| s.as_str())
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+            }
+        }
+        0
+    }
+
+    pub async fn exists(&self, faro_path: &str) -> bool {
+        matches!(self.resolve_item(faro_path).await, Ok(Some(_)))
+    }
+}
+
+pub async fn gdrive_connect(profile: &ConnectionProfile) -> Result<GDriveSession> {
+    let tokens = oauth::load_tokens(GDRIVE_SERVICE, &profile.id)?.ok_or_else(|| {
+        anyhow!(
+            "This Google Drive connection isn't authorized yet. Open it in the connection \
+             editor and click “Connect with Google Drive”."
+        )
+    })?;
+
+    let client = Client::builder()
+        .connect_timeout(Duration::from_secs(20))
+        .timeout(Duration::from_secs(300))
+        .user_agent(concat!("Faro/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("building Google Drive HTTP client")?;
+
+    Ok(GDriveSession {
+        id: Uuid::new_v4().to_string(),
+        profile: profile.clone(),
+        client,
+        api_base: env_or("FARO_GDRIVE_API_BASE", DEFAULT_API_BASE),
+        upload_base: env_or("FARO_GDRIVE_UPLOAD_BASE", DEFAULT_UPLOAD_BASE),
+        token: RefreshingToken::new(GDRIVE_SERVICE, &profile.id, gdrive_config(), tokens),
+        cache: StdMutex::new(HashMap::new()),
+    })
+}
+
+// ---- path helpers ----
+
+pub fn normalize(faro: &str) -> String {
+    let t = faro.trim().trim_matches('/');
+    if t.is_empty() || t == "." {
+        "/".to_string()
+    } else {
+        format!("/{t}")
+    }
+}
+
+pub fn basename(faro: &str) -> &str {
+    faro.trim_matches('/').rsplit('/').next().unwrap_or("")
+}
+
+pub fn parent_of(faro: &str) -> String {
+    let t = faro.trim_matches('/');
+    match t.rsplit_once('/') {
+        Some((p, _)) => format!("/{p}"),
+        None => "/".to_string(),
+    }
+}
+
+/// Escape a value for a Drive `q` string literal (backslash + single-quote).
+pub fn escape_q(name: &str) -> String {
+    name.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+/// Whether a Drive mimeType denotes a folder.
+pub fn folder_mime_is(mime: &str) -> bool {
+    mime == FOLDER_MIME
+}
+
+fn urlencode(s: &str) -> String {
+    use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+    utf8_percent_encode(s, NON_ALPHANUMERIC).to_string()
+}

--- a/src-tauri/src/session/http.rs
+++ b/src-tauri/src/session/http.rs
@@ -1,0 +1,171 @@
+use crate::profiles::{AuthMethod, ConnectionProfile};
+use anyhow::{anyhow, Context, Result};
+use percent_encoding::percent_decode_str;
+use reqwest::{Client, Method, RequestBuilder};
+use std::time::Duration;
+use url::Url;
+
+/// Optional HTTP Basic auth for static servers sitting behind a login.
+pub enum HttpAuth {
+    Basic { user: String, password: String },
+    None,
+}
+
+/// Whether the connection browses an autoindex listing or points straight at a
+/// single file. Decided at connect from the URL shape (trailing slash / a
+/// filename with an extension), so "paste a direct release-artifact URL" works
+/// without a listing at all.
+pub enum HttpMode {
+    /// Autoindex listing under `base` (which always ends in `/`).
+    Listing,
+    /// The URL is one file; `name` is its display name.
+    DirectFile { name: String },
+}
+
+/// A read-only HTTP(S) source. Like WebDAV, every op is an independent request
+/// off a shared `reqwest::Client`; unlike WebDAV there are no mutations — this
+/// backend only lists (autoindex) and reads (GET).
+pub struct HttpSession {
+    pub id: String,
+    pub profile: ConnectionProfile,
+    pub client: Client,
+    pub base: Url,
+    pub auth: HttpAuth,
+    pub mode: HttpMode,
+}
+
+impl HttpSession {
+    pub fn authed(&self, rb: RequestBuilder) -> RequestBuilder {
+        match &self.auth {
+            HttpAuth::Basic { user, password } => rb.basic_auth(user, Some(password)),
+            HttpAuth::None => rb,
+        }
+    }
+
+    pub fn request(&self, method: Method, url: Url) -> RequestBuilder {
+        self.authed(self.client.request(method, url))
+    }
+
+    /// Absolute URL for a Faro path. In `DirectFile` mode every path resolves to
+    /// the single file `base`; in `Listing` mode segments are appended (and
+    /// percent-encoded) under the base directory.
+    pub fn url_for(&self, path: &str, dir: bool) -> Url {
+        if matches!(self.mode, HttpMode::DirectFile { .. }) {
+            return self.base.clone();
+        }
+        let mut u = self.base.clone();
+        let rel = path.trim_start_matches('/');
+        {
+            let mut segs = u
+                .path_segments_mut()
+                .expect("http base is always a valid http(s) URL");
+            segs.pop_if_empty();
+            for part in rel.split('/').filter(|s| !s.is_empty() && *s != ".") {
+                segs.push(part);
+            }
+        }
+        if dir && !u.path().ends_with('/') {
+            u.set_path(&format!("{}/", u.path()));
+        }
+        u
+    }
+}
+
+/// Connect a read-only HTTP source: parse the URL, decide listing vs single-file
+/// mode, and probe reachability + auth with a cheap `HEAD` (falling back to
+/// proceeding when a server rejects HEAD).
+pub async fn http_connect(profile: &ConnectionProfile) -> Result<HttpSession> {
+    let raw = profile
+        .endpoint
+        .as_ref()
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| anyhow!("HTTP profile is missing the URL"))?
+        .trim()
+        .to_string();
+
+    let with_scheme = if raw.contains("://") {
+        raw.clone()
+    } else {
+        format!("https://{raw}")
+    };
+    let parsed = Url::parse(&with_scheme).with_context(|| format!("parse HTTP URL {raw}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(anyhow!("HTTP URL must be http or https, got {}", parsed.scheme()));
+    }
+
+    // Mode: trailing slash → listing; a final segment with an extension → single
+    // file; otherwise treat as a directory and add the slash.
+    let ends_slash = parsed.path().ends_with('/');
+    let last = parsed
+        .path()
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .unwrap_or("")
+        .to_string();
+    let (base, mode) = if ends_slash {
+        (parsed, HttpMode::Listing)
+    } else if last.contains('.') {
+        let name = percent_decode_str(&last).decode_utf8_lossy().into_owned();
+        (parsed, HttpMode::DirectFile { name })
+    } else {
+        let u = Url::parse(&format!("{with_scheme}/"))
+            .with_context(|| format!("parse HTTP URL {raw}"))?;
+        (u, HttpMode::Listing)
+    };
+
+    let auth = if !profile.username.is_empty() {
+        let password = match &profile.auth {
+            AuthMethod::Password { password } => password.clone(),
+            _ => String::new(),
+        };
+        HttpAuth::Basic {
+            user: profile.username.clone(),
+            password,
+        }
+    } else {
+        HttpAuth::None
+    };
+
+    let client = Client::builder()
+        .connect_timeout(Duration::from_secs(20))
+        .timeout(Duration::from_secs(120))
+        .user_agent(concat!("Faro/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("building HTTP client")?;
+
+    let session = HttpSession {
+        id: uuid::Uuid::new_v4().to_string(),
+        profile: profile.clone(),
+        client,
+        base,
+        auth,
+        mode,
+    };
+
+    // Reachability + auth probe. HEAD is cheap; a 405 (HEAD unsupported) is not a
+    // failure — just proceed.
+    let resp = session
+        .request(Method::HEAD, session.base.clone())
+        .send()
+        .await
+        .with_context(|| format!("HEAD {}", session.base))?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(anyhow!(
+            "HTTP source requires authentication ({}). Add a username + password.",
+            status.as_u16()
+        ));
+    }
+    if !(status.is_success()
+        || status.is_redirection()
+        || status == reqwest::StatusCode::METHOD_NOT_ALLOWED)
+    {
+        return Err(anyhow!(
+            "HTTP source returned {} for {} — check the URL.",
+            status.as_u16(),
+            session.base
+        ));
+    }
+
+    Ok(session)
+}

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,9 +1,11 @@
 pub mod agent;
 pub mod ftp;
 pub mod object;
+pub mod webdav;
 pub use agent::{agent_pair, AgentSession};
 pub use ftp::{ftp_connect, FtpSession};
 pub use object::{object_connect, ObjectSession};
+pub use webdav::{webdav_connect, WebdavSession};
 
 use crate::known_hosts;
 use crate::profiles::{AuthMethod, ConnectionProfile};
@@ -1114,6 +1116,10 @@ pub async fn open_session(
             let obj = object_connect(profile).await?;
             Ok(Session::Object(Arc::new(obj)))
         }
+        "webdav" => {
+            let dav = webdav_connect(profile).await?;
+            Ok(Session::Webdav(Arc::new(dav)))
+        }
         other => Err(anyhow!("unsupported protocol: {other}")),
     }
 }
@@ -1365,6 +1371,7 @@ pub enum Session {
     Ssh(Arc<SshSession>),
     Ftp(Arc<FtpSession>),
     Object(Arc<ObjectSession>),
+    Webdav(Arc<WebdavSession>),
     Agent(Arc<AgentSession>),
 }
 
@@ -1374,6 +1381,7 @@ impl Session {
             Self::Ssh(s) => &s.profile,
             Self::Ftp(s) => &s.profile,
             Self::Object(s) => &s.profile,
+            Self::Webdav(s) => &s.profile,
             Self::Agent(s) => &s.profile,
         }
     }
@@ -1383,6 +1391,7 @@ impl Session {
             Self::Ssh(_) => "sftp",
             Self::Ftp(_) => "ftp",
             Self::Object(s) => s.profile.protocol.as_str(),
+            Self::Webdav(_) => "webdav",
             Self::Agent(_) => "faro-agent",
         }
     }
@@ -1458,6 +1467,12 @@ impl SessionManager {
                 let id = obj.id.clone();
                 (id, Session::Object(Arc::new(obj)))
             }
+            "webdav" => {
+                let _ = app; // WebDAV auth is carried in each request, no UI prompt.
+                let dav = webdav_connect(&profile).await?;
+                let id = dav.id.clone();
+                (id, Session::Webdav(Arc::new(dav)))
+            }
             "faro-agent" => {
                 let agent = AgentSession::connect(profile).await?;
                 let id = agent.id.clone();
@@ -1528,6 +1543,9 @@ impl SessionManager {
                 }
                 Session::Object(_) => {
                     // Object stores are stateless HTTP — nothing to close.
+                }
+                Session::Webdav(_) => {
+                    // WebDAV is stateless HTTP too — reqwest's pool drops itself.
                 }
                 Session::Agent(agent) => {
                     agent.disconnect().await;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,9 +1,11 @@
 pub mod agent;
+pub mod dropbox;
 pub mod ftp;
 pub mod http;
 pub mod object;
 pub mod webdav;
 pub use agent::{agent_pair, AgentSession};
+pub use dropbox::{dropbox_connect, DropboxSession};
 pub use ftp::{ftp_connect, FtpSession};
 pub use http::{http_connect, HttpSession};
 pub use object::{object_connect, ObjectSession};
@@ -1126,6 +1128,10 @@ pub async fn open_session(
             let http = http_connect(profile).await?;
             Ok(Session::Http(Arc::new(http)))
         }
+        "dropbox" => {
+            let dbx = dropbox_connect(profile).await?;
+            Ok(Session::Dropbox(Arc::new(dbx)))
+        }
         other => Err(anyhow!("unsupported protocol: {other}")),
     }
 }
@@ -1379,6 +1385,7 @@ pub enum Session {
     Object(Arc<ObjectSession>),
     Webdav(Arc<WebdavSession>),
     Http(Arc<HttpSession>),
+    Dropbox(Arc<DropboxSession>),
     Agent(Arc<AgentSession>),
 }
 
@@ -1390,6 +1397,7 @@ impl Session {
             Self::Object(s) => &s.profile,
             Self::Webdav(s) => &s.profile,
             Self::Http(s) => &s.profile,
+            Self::Dropbox(s) => &s.profile,
             Self::Agent(s) => &s.profile,
         }
     }
@@ -1401,6 +1409,7 @@ impl Session {
             Self::Object(s) => s.profile.protocol.as_str(),
             Self::Webdav(_) => "webdav",
             Self::Http(_) => "http",
+            Self::Dropbox(_) => "dropbox",
             Self::Agent(_) => "faro-agent",
         }
     }
@@ -1488,6 +1497,12 @@ impl SessionManager {
                 let id = http.id.clone();
                 (id, Session::Http(Arc::new(http)))
             }
+            "dropbox" => {
+                let _ = app; // OAuth tokens loaded from the keychain; no prompt.
+                let dbx = dropbox_connect(&profile).await?;
+                let id = dbx.id.clone();
+                (id, Session::Dropbox(Arc::new(dbx)))
+            }
             "faro-agent" => {
                 let agent = AgentSession::connect(profile).await?;
                 let id = agent.id.clone();
@@ -1564,6 +1579,9 @@ impl SessionManager {
                 }
                 Session::Http(_) => {
                     // Read-only HTTP is stateless — nothing to close.
+                }
+                Session::Dropbox(_) => {
+                    // Dropbox is stateless HTTP — nothing to close.
                 }
                 Session::Agent(agent) => {
                     agent.disconnect().await;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -3,12 +3,14 @@ pub mod dropbox;
 pub mod ftp;
 pub mod http;
 pub mod object;
+pub mod onedrive;
 pub mod webdav;
 pub use agent::{agent_pair, AgentSession};
 pub use dropbox::{dropbox_connect, DropboxSession};
 pub use ftp::{ftp_connect, FtpSession};
 pub use http::{http_connect, HttpSession};
 pub use object::{object_connect, ObjectSession};
+pub use onedrive::{onedrive_connect, OneDriveSession};
 pub use webdav::{webdav_connect, WebdavSession};
 
 use crate::known_hosts;
@@ -1132,6 +1134,10 @@ pub async fn open_session(
             let dbx = dropbox_connect(profile).await?;
             Ok(Session::Dropbox(Arc::new(dbx)))
         }
+        "onedrive" => {
+            let od = onedrive_connect(profile).await?;
+            Ok(Session::OneDrive(Arc::new(od)))
+        }
         other => Err(anyhow!("unsupported protocol: {other}")),
     }
 }
@@ -1386,6 +1392,7 @@ pub enum Session {
     Webdav(Arc<WebdavSession>),
     Http(Arc<HttpSession>),
     Dropbox(Arc<DropboxSession>),
+    OneDrive(Arc<OneDriveSession>),
     Agent(Arc<AgentSession>),
 }
 
@@ -1398,6 +1405,7 @@ impl Session {
             Self::Webdav(s) => &s.profile,
             Self::Http(s) => &s.profile,
             Self::Dropbox(s) => &s.profile,
+            Self::OneDrive(s) => &s.profile,
             Self::Agent(s) => &s.profile,
         }
     }
@@ -1410,6 +1418,7 @@ impl Session {
             Self::Webdav(_) => "webdav",
             Self::Http(_) => "http",
             Self::Dropbox(_) => "dropbox",
+            Self::OneDrive(_) => "onedrive",
             Self::Agent(_) => "faro-agent",
         }
     }
@@ -1503,6 +1512,12 @@ impl SessionManager {
                 let id = dbx.id.clone();
                 (id, Session::Dropbox(Arc::new(dbx)))
             }
+            "onedrive" => {
+                let _ = app; // OAuth tokens loaded from the keychain; no prompt.
+                let od = onedrive_connect(&profile).await?;
+                let id = od.id.clone();
+                (id, Session::OneDrive(Arc::new(od)))
+            }
             "faro-agent" => {
                 let agent = AgentSession::connect(profile).await?;
                 let id = agent.id.clone();
@@ -1582,6 +1597,9 @@ impl SessionManager {
                 }
                 Session::Dropbox(_) => {
                     // Dropbox is stateless HTTP — nothing to close.
+                }
+                Session::OneDrive(_) => {
+                    // OneDrive/Graph is stateless HTTP — nothing to close.
                 }
                 Session::Agent(agent) => {
                     agent.disconnect().await;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,9 +1,11 @@
 pub mod agent;
 pub mod ftp;
+pub mod http;
 pub mod object;
 pub mod webdav;
 pub use agent::{agent_pair, AgentSession};
 pub use ftp::{ftp_connect, FtpSession};
+pub use http::{http_connect, HttpSession};
 pub use object::{object_connect, ObjectSession};
 pub use webdav::{webdav_connect, WebdavSession};
 
@@ -1120,6 +1122,10 @@ pub async fn open_session(
             let dav = webdav_connect(profile).await?;
             Ok(Session::Webdav(Arc::new(dav)))
         }
+        "http" | "https" => {
+            let http = http_connect(profile).await?;
+            Ok(Session::Http(Arc::new(http)))
+        }
         other => Err(anyhow!("unsupported protocol: {other}")),
     }
 }
@@ -1372,6 +1378,7 @@ pub enum Session {
     Ftp(Arc<FtpSession>),
     Object(Arc<ObjectSession>),
     Webdav(Arc<WebdavSession>),
+    Http(Arc<HttpSession>),
     Agent(Arc<AgentSession>),
 }
 
@@ -1382,6 +1389,7 @@ impl Session {
             Self::Ftp(s) => &s.profile,
             Self::Object(s) => &s.profile,
             Self::Webdav(s) => &s.profile,
+            Self::Http(s) => &s.profile,
             Self::Agent(s) => &s.profile,
         }
     }
@@ -1392,6 +1400,7 @@ impl Session {
             Self::Ftp(_) => "ftp",
             Self::Object(s) => s.profile.protocol.as_str(),
             Self::Webdav(_) => "webdav",
+            Self::Http(_) => "http",
             Self::Agent(_) => "faro-agent",
         }
     }
@@ -1473,6 +1482,12 @@ impl SessionManager {
                 let id = dav.id.clone();
                 (id, Session::Webdav(Arc::new(dav)))
             }
+            "http" | "https" => {
+                let _ = app; // Read-only HTTP source; no per-connect UI prompt.
+                let http = http_connect(&profile).await?;
+                let id = http.id.clone();
+                (id, Session::Http(Arc::new(http)))
+            }
             "faro-agent" => {
                 let agent = AgentSession::connect(profile).await?;
                 let id = agent.id.clone();
@@ -1546,6 +1561,9 @@ impl SessionManager {
                 }
                 Session::Webdav(_) => {
                     // WebDAV is stateless HTTP too — reqwest's pool drops itself.
+                }
+                Session::Http(_) => {
+                    // Read-only HTTP is stateless — nothing to close.
                 }
                 Session::Agent(agent) => {
                     agent.disconnect().await;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod dropbox;
 pub mod ftp;
+pub mod gdrive;
 pub mod http;
 pub mod object;
 pub mod onedrive;
@@ -8,6 +9,7 @@ pub mod webdav;
 pub use agent::{agent_pair, AgentSession};
 pub use dropbox::{dropbox_connect, DropboxSession};
 pub use ftp::{ftp_connect, FtpSession};
+pub use gdrive::{gdrive_connect, GDriveSession};
 pub use http::{http_connect, HttpSession};
 pub use object::{object_connect, ObjectSession};
 pub use onedrive::{onedrive_connect, OneDriveSession};
@@ -1138,6 +1140,10 @@ pub async fn open_session(
             let od = onedrive_connect(profile).await?;
             Ok(Session::OneDrive(Arc::new(od)))
         }
+        "gdrive" => {
+            let gd = gdrive_connect(profile).await?;
+            Ok(Session::GDrive(Arc::new(gd)))
+        }
         other => Err(anyhow!("unsupported protocol: {other}")),
     }
 }
@@ -1393,6 +1399,7 @@ pub enum Session {
     Http(Arc<HttpSession>),
     Dropbox(Arc<DropboxSession>),
     OneDrive(Arc<OneDriveSession>),
+    GDrive(Arc<GDriveSession>),
     Agent(Arc<AgentSession>),
 }
 
@@ -1406,6 +1413,7 @@ impl Session {
             Self::Http(s) => &s.profile,
             Self::Dropbox(s) => &s.profile,
             Self::OneDrive(s) => &s.profile,
+            Self::GDrive(s) => &s.profile,
             Self::Agent(s) => &s.profile,
         }
     }
@@ -1419,6 +1427,7 @@ impl Session {
             Self::Http(_) => "http",
             Self::Dropbox(_) => "dropbox",
             Self::OneDrive(_) => "onedrive",
+            Self::GDrive(_) => "gdrive",
             Self::Agent(_) => "faro-agent",
         }
     }
@@ -1518,6 +1527,12 @@ impl SessionManager {
                 let id = od.id.clone();
                 (id, Session::OneDrive(Arc::new(od)))
             }
+            "gdrive" => {
+                let _ = app; // OAuth tokens loaded from the keychain; no prompt.
+                let gd = gdrive_connect(&profile).await?;
+                let id = gd.id.clone();
+                (id, Session::GDrive(Arc::new(gd)))
+            }
             "faro-agent" => {
                 let agent = AgentSession::connect(profile).await?;
                 let id = agent.id.clone();
@@ -1600,6 +1615,9 @@ impl SessionManager {
                 }
                 Session::OneDrive(_) => {
                     // OneDrive/Graph is stateless HTTP — nothing to close.
+                }
+                Session::GDrive(_) => {
+                    // Google Drive is stateless HTTP — nothing to close.
                 }
                 Session::Agent(agent) => {
                     agent.disconnect().await;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod boxdrive;
 pub mod dropbox;
 pub mod ftp;
 pub mod gdrive;
@@ -7,6 +8,7 @@ pub mod object;
 pub mod onedrive;
 pub mod webdav;
 pub use agent::{agent_pair, AgentSession};
+pub use boxdrive::{box_connect, BoxSession};
 pub use dropbox::{dropbox_connect, DropboxSession};
 pub use ftp::{ftp_connect, FtpSession};
 pub use gdrive::{gdrive_connect, GDriveSession};
@@ -1144,6 +1146,10 @@ pub async fn open_session(
             let gd = gdrive_connect(profile).await?;
             Ok(Session::GDrive(Arc::new(gd)))
         }
+        "box" => {
+            let bx = box_connect(profile).await?;
+            Ok(Session::Box(Arc::new(bx)))
+        }
         other => Err(anyhow!("unsupported protocol: {other}")),
     }
 }
@@ -1400,6 +1406,7 @@ pub enum Session {
     Dropbox(Arc<DropboxSession>),
     OneDrive(Arc<OneDriveSession>),
     GDrive(Arc<GDriveSession>),
+    Box(Arc<BoxSession>),
     Agent(Arc<AgentSession>),
 }
 
@@ -1414,6 +1421,7 @@ impl Session {
             Self::Dropbox(s) => &s.profile,
             Self::OneDrive(s) => &s.profile,
             Self::GDrive(s) => &s.profile,
+            Self::Box(s) => &s.profile,
             Self::Agent(s) => &s.profile,
         }
     }
@@ -1428,6 +1436,7 @@ impl Session {
             Self::Dropbox(_) => "dropbox",
             Self::OneDrive(_) => "onedrive",
             Self::GDrive(_) => "gdrive",
+            Self::Box(_) => "box",
             Self::Agent(_) => "faro-agent",
         }
     }
@@ -1533,6 +1542,12 @@ impl SessionManager {
                 let id = gd.id.clone();
                 (id, Session::GDrive(Arc::new(gd)))
             }
+            "box" => {
+                let _ = app; // OAuth tokens loaded from the keychain; no prompt.
+                let bx = box_connect(&profile).await?;
+                let id = bx.id.clone();
+                (id, Session::Box(Arc::new(bx)))
+            }
             "faro-agent" => {
                 let agent = AgentSession::connect(profile).await?;
                 let id = agent.id.clone();
@@ -1618,6 +1633,9 @@ impl SessionManager {
                 }
                 Session::GDrive(_) => {
                     // Google Drive is stateless HTTP — nothing to close.
+                }
+                Session::Box(_) => {
+                    // Box is stateless HTTP — nothing to close.
                 }
                 Session::Agent(agent) => {
                     agent.disconnect().await;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1110,7 +1110,7 @@ pub async fn open_session(
             let ftp = ftp_connect(profile).await?;
             Ok(Session::Ftp(Arc::new(ftp)))
         }
-        "s3" | "azure" => {
+        "s3" | "azure" | "gcs" => {
             let obj = object_connect(profile).await?;
             Ok(Session::Object(Arc::new(obj)))
         }
@@ -1452,7 +1452,7 @@ impl SessionManager {
                 let id = ftp.id.clone();
                 (id, Session::Ftp(Arc::new(ftp)))
             }
-            "s3" | "azure" => {
+            "s3" | "azure" | "gcs" => {
                 let _ = app; // Object stores have no per-connect UI prompts.
                 let obj = object_connect(&profile).await?;
                 let id = obj.id.clone();

--- a/src-tauri/src/session/object.rs
+++ b/src-tauri/src/session/object.rs
@@ -2,6 +2,7 @@ use crate::profiles::{AuthMethod, ConnectionProfile};
 use anyhow::{anyhow, Context, Result};
 use object_store::aws::AmazonS3Builder;
 use object_store::azure::MicrosoftAzureBuilder;
+use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::ObjectStore;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -23,6 +24,7 @@ pub async fn object_connect(profile: &ConnectionProfile) -> Result<ObjectSession
     match profile.protocol.as_str() {
         "s3" => s3_connect(profile).await,
         "azure" => azure_connect(profile).await,
+        "gcs" => gcs_connect(profile).await,
         other => Err(anyhow!("not an object-store protocol: {other}")),
     }
 }
@@ -119,6 +121,47 @@ async fn azure_connect(profile: &ConnectionProfile) -> Result<ObjectSession> {
         id: Uuid::new_v4().to_string(),
         profile: profile.clone(),
         container,
+        store: Arc::new(store),
+    })
+}
+
+/// Native Google Cloud Storage, the same one-builder move that added Azure:
+/// `object_store`'s `gcp` feature does the signing. Credentials come from a
+/// service-account key — either a path to the downloaded JSON (auth = Key) or the
+/// JSON pasted directly (auth = Password). The bucket rides in `profile.bucket`,
+/// exactly like an S3 bucket / Azure container.
+async fn gcs_connect(profile: &ConnectionProfile) -> Result<ObjectSession> {
+    let bucket = profile
+        .bucket
+        .as_ref()
+        .ok_or_else(|| anyhow!("GCS profile is missing the bucket name"))?
+        .clone();
+
+    let mut builder = GoogleCloudStorageBuilder::new().with_bucket_name(&bucket);
+
+    match &profile.auth {
+        AuthMethod::Key { path, .. } => {
+            builder = builder.with_service_account_path(path.clone());
+        }
+        AuthMethod::Password { password } if !password.trim().is_empty() => {
+            builder = builder.with_service_account_key(password.clone());
+        }
+        _ => {
+            return Err(anyhow!(
+                "GCS backend needs a service-account key: either a path to the JSON \
+                 key file (Private key file auth) or the pasted JSON (Password auth)."
+            ))
+        }
+    }
+
+    let store = builder
+        .build()
+        .with_context(|| format!("constructing GCS client for bucket {bucket}"))?;
+
+    Ok(ObjectSession {
+        id: Uuid::new_v4().to_string(),
+        profile: profile.clone(),
+        container: bucket,
         store: Arc::new(store),
     })
 }

--- a/src-tauri/src/session/onedrive.rs
+++ b/src-tauri/src/session/onedrive.rs
@@ -1,0 +1,171 @@
+use crate::oauth::{self, OAuthConfig, RefreshingToken};
+use crate::profiles::ConnectionProfile;
+use anyhow::{anyhow, Context, Result};
+use reqwest::{Client, Method};
+use serde_json::Value;
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Keychain service name for OneDrive tokens (keyed by profile id).
+pub const ONEDRIVE_SERVICE: &str = "faro-onedrive";
+
+const DEFAULT_GRAPH_BASE: &str = "https://graph.microsoft.com/v1.0";
+const DEFAULT_AUTH_URL: &str =
+    "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
+const DEFAULT_TOKEN_URL: &str = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
+
+/// OneDrive (Microsoft) app client id. Register an app at
+/// <https://entra.microsoft.com> (App registrations), add a **Mobile & desktop**
+/// redirect `http://localhost:53682/`, enable public-client flows, and grant the
+/// delegated `Files.ReadWrite`, `offline_access`, and `User.Read` scopes. Paste
+/// the Application (client) id here or set `FARO_ONEDRIVE_CLIENT_ID`. PKCE ⇒ no
+/// secret.
+const ONEDRIVE_CLIENT_ID: &str = "";
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// OneDrive OAuth config. Endpoints fall back to env overrides for the mock test.
+pub fn onedrive_config() -> OAuthConfig {
+    OAuthConfig {
+        client_id: env_or("FARO_ONEDRIVE_CLIENT_ID", ONEDRIVE_CLIENT_ID),
+        auth_url: env_or("FARO_ONEDRIVE_AUTH_URL", DEFAULT_AUTH_URL),
+        token_url: env_or("FARO_ONEDRIVE_TOKEN_URL", DEFAULT_TOKEN_URL),
+        scopes: vec![
+            "Files.ReadWrite".into(),
+            "offline_access".into(),
+            "User.Read".into(),
+        ],
+        extra_auth_params: vec![],
+    }
+}
+
+/// A live OneDrive connection over Microsoft Graph. Stateless HTTP; the embedded
+/// [`RefreshingToken`] keeps the bearer token fresh.
+pub struct OneDriveSession {
+    pub id: String,
+    pub profile: ConnectionProfile,
+    pub client: Client,
+    pub graph_base: String,
+    token: RefreshingToken,
+}
+
+impl OneDriveSession {
+    pub async fn access_token(&self) -> Result<String> {
+        self.token.access_token().await
+    }
+
+    pub async fn force_refresh(&self) -> Result<()> {
+        self.token.force_refresh().await
+    }
+
+    /// Send a Graph request (bearer + one 401→refresh retry), returning the raw
+    /// response so callers can stream downloads or parse JSON.
+    pub async fn send(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&Value>,
+    ) -> Result<reqwest::Response> {
+        // A `@odata.nextLink` is already absolute; item paths are relative.
+        let url = if path.starts_with("http") {
+            path.to_string()
+        } else {
+            format!("{}{path}", self.graph_base)
+        };
+        let mut attempt = 0;
+        loop {
+            let token = self.token.access_token().await?;
+            let mut rb = self.client.request(method.clone(), &url).bearer_auth(&token);
+            if let Some(b) = body {
+                rb = rb.json(b);
+            }
+            let resp = rb.send().await.with_context(|| format!("graph {path}"))?;
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+                attempt += 1;
+                self.force_refresh().await?;
+                continue;
+            }
+            return Ok(resp);
+        }
+    }
+
+    /// Send a Graph request and parse the JSON response, erroring on non-2xx.
+    pub async fn rpc(&self, method: Method, path: &str, body: Option<&Value>) -> Result<Value> {
+        let resp = self.send(method, path, body).await?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("graph {path} failed ({}): {text}", status.as_u16()));
+        }
+        if text.trim().is_empty() {
+            return Ok(Value::Null);
+        }
+        serde_json::from_str(&text).with_context(|| format!("parse graph {path} response"))
+    }
+
+    /// A streaming GET (download), erroring on non-2xx. `path` may be a Graph
+    /// item path (`/me/…`) or an absolute URL (a `@odata.nextLink`).
+    pub async fn get_stream(&self, path: &str) -> Result<reqwest::Response> {
+        let resp = self.send(Method::GET, path, None).await?;
+        if !resp.status().is_success() {
+            let code = resp.status().as_u16();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("graph GET {path} failed ({code}): {text}"));
+        }
+        Ok(resp)
+    }
+
+    /// The account's email/UPN (falling back to display name) for the label.
+    pub async fn account_label(&self) -> Result<String> {
+        let v = self.rpc(Method::GET, "/me", None).await?;
+        for key in ["userPrincipalName", "mail", "displayName"] {
+            if let Some(s) = v.get(key).and_then(|x| x.as_str()).filter(|s| !s.is_empty()) {
+                return Ok(s.to_string());
+            }
+        }
+        Ok("OneDrive".to_string())
+    }
+
+    /// Whether the item at a Graph item-ref exists.
+    pub async fn exists(&self, item_ref: &str) -> bool {
+        self.rpc(Method::GET, item_ref, None).await.is_ok()
+    }
+
+    /// Size of the item at a Graph item-ref, or 0.
+    pub async fn size(&self, item_ref: &str) -> u64 {
+        self.rpc(Method::GET, item_ref, None)
+            .await
+            .ok()
+            .and_then(|v| v.get("size").and_then(|s| s.as_u64()))
+            .unwrap_or(0)
+    }
+}
+
+pub async fn onedrive_connect(profile: &ConnectionProfile) -> Result<OneDriveSession> {
+    let tokens = oauth::load_tokens(ONEDRIVE_SERVICE, &profile.id)?.ok_or_else(|| {
+        anyhow!(
+            "This OneDrive connection isn't authorized yet. Open it in the connection \
+             editor and click “Connect with OneDrive”."
+        )
+    })?;
+
+    let client = Client::builder()
+        .connect_timeout(Duration::from_secs(20))
+        .timeout(Duration::from_secs(300))
+        .user_agent(concat!("Faro/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("building OneDrive HTTP client")?;
+
+    Ok(OneDriveSession {
+        id: Uuid::new_v4().to_string(),
+        profile: profile.clone(),
+        client,
+        graph_base: env_or("FARO_ONEDRIVE_GRAPH_BASE", DEFAULT_GRAPH_BASE),
+        token: RefreshingToken::new(ONEDRIVE_SERVICE, &profile.id, onedrive_config(), tokens),
+    })
+}

--- a/src-tauri/src/session/webdav.rs
+++ b/src-tauri/src/session/webdav.rs
@@ -1,0 +1,181 @@
+use crate::profiles::{AuthMethod, ConnectionProfile};
+use anyhow::{anyhow, Context, Result};
+use reqwest::{Client, Method, RequestBuilder};
+use std::time::Duration;
+use url::Url;
+
+/// How the WebDAV requests authenticate. Basic covers Nextcloud/ownCloud app
+/// passwords, Hetzner Storage Box, and the generic long tail; Bearer covers
+/// token servers (leave the username blank in the UI to select it).
+pub enum WebdavAuth {
+    Basic { user: String, password: String },
+    Bearer { token: String },
+    None,
+}
+
+/// A WebDAV connection. Unlike SSH/FTP there is no persistent socket — every op
+/// is an independent HTTP request off a shared `reqwest::Client` (connection
+/// pooling + keep-alive happen inside reqwest). The `base` URL already carries
+/// the DAV root path (e.g. `/remote.php/dav/files/alice/`) and always ends in a
+/// `/`, so `url_for` can just append the resource's Faro path.
+pub struct WebdavSession {
+    pub id: String,
+    pub profile: ConnectionProfile,
+    pub client: Client,
+    pub base: Url,
+    pub auth: WebdavAuth,
+}
+
+impl WebdavSession {
+    /// Apply the session's credentials to a request builder.
+    pub fn authed(&self, rb: RequestBuilder) -> RequestBuilder {
+        match &self.auth {
+            WebdavAuth::Basic { user, password } => rb.basic_auth(user, Some(password)),
+            WebdavAuth::Bearer { token } => rb.bearer_auth(token),
+            WebdavAuth::None => rb,
+        }
+    }
+
+    /// Absolute URL for a Faro path like `/dir/file.txt`. Each segment is
+    /// percent-encoded by the `url` crate. `dir` appends a trailing slash so
+    /// collections address correctly (some servers 301 otherwise).
+    pub fn url_for(&self, path: &str, dir: bool) -> Url {
+        let mut u = self.base.clone();
+        let rel = path.trim_start_matches('/');
+        {
+            // `base` ends in `/`, i.e. a trailing empty segment — drop it before
+            // appending so we don't get a doubled slash.
+            let mut segs = u
+                .path_segments_mut()
+                .expect("webdav base is always a valid http(s) URL");
+            segs.pop_if_empty();
+            // Skip empty and "." segments so a "." default remote path (or a
+            // doubled slash) resolves to the DAV root, not a bogus child.
+            for part in rel.split('/').filter(|s| !s.is_empty() && *s != ".") {
+                segs.push(part);
+            }
+        }
+        if dir && !u.path().ends_with('/') {
+            u.set_path(&format!("{}/", u.path()));
+        }
+        u
+    }
+
+    /// The decoded path component of the base URL (the DAV root), used to strip
+    /// the prefix off PROPFIND `href`s. Always ends in `/`.
+    pub fn base_path(&self) -> String {
+        let p = self.base.path();
+        if p.ends_with('/') {
+            p.to_string()
+        } else {
+            format!("{p}/")
+        }
+    }
+
+    pub fn request(&self, method: Method, url: Url) -> RequestBuilder {
+        self.authed(self.client.request(method, url))
+    }
+}
+
+/// Connect a WebDAV session: parse the server URL, resolve the auth style, and
+/// do a cheap `PROPFIND` depth-0 on the root so bad credentials / wrong URLs
+/// fail here instead of on the first browse.
+pub async fn webdav_connect(profile: &ConnectionProfile) -> Result<WebdavSession> {
+    let raw = profile
+        .endpoint
+        .as_ref()
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| anyhow!("WebDAV profile is missing the server URL"))?
+        .trim()
+        .to_string();
+
+    // Normalize: ensure a scheme and a trailing slash so `url_for` joins cleanly.
+    let with_scheme = if raw.contains("://") {
+        raw.clone()
+    } else {
+        format!("https://{raw}")
+    };
+    let with_slash = if with_scheme.ends_with('/') {
+        with_scheme
+    } else {
+        format!("{with_scheme}/")
+    };
+    let base = Url::parse(&with_slash).with_context(|| format!("parse WebDAV URL {raw}"))?;
+    if !matches!(base.scheme(), "http" | "https") {
+        return Err(anyhow!("WebDAV URL must be http or https, got {}", base.scheme()));
+    }
+
+    let password = match &profile.auth {
+        AuthMethod::Password { password } => password.clone(),
+        _ => {
+            return Err(anyhow!(
+                "WebDAV needs password/token auth. Use a username + password (Basic) \
+                 or leave the username blank and paste a bearer token."
+            ))
+        }
+    };
+    let auth = if !profile.username.is_empty() {
+        WebdavAuth::Basic {
+            user: profile.username.clone(),
+            password,
+        }
+    } else if !password.is_empty() {
+        WebdavAuth::Bearer { token: password }
+    } else {
+        WebdavAuth::None
+    };
+
+    let client = Client::builder()
+        .connect_timeout(Duration::from_secs(20))
+        .timeout(Duration::from_secs(120))
+        .user_agent(concat!("Faro/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("building WebDAV HTTP client")?;
+
+    let session = WebdavSession {
+        id: uuid::Uuid::new_v4().to_string(),
+        profile: profile.clone(),
+        client,
+        base,
+        auth,
+    };
+
+    // Validate credentials + URL up front with a depth-0 PROPFIND on the root.
+    let url = session.url_for("/", true);
+    let resp = session
+        .request(Method::from_bytes(b"PROPFIND").unwrap(), url)
+        .header("Depth", "0")
+        .header("Content-Type", "application/xml")
+        .body(PROPFIND_BODY)
+        .send()
+        .await
+        .with_context(|| format!("PROPFIND {}", session.base))?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(anyhow!(
+            "WebDAV authentication failed ({}). Check the username and password/token.",
+            status.as_u16()
+        ));
+    }
+    if !(status.is_success() || status.as_u16() == 207) {
+        return Err(anyhow!(
+            "WebDAV server returned {} for {} — check the URL path.",
+            status.as_u16(),
+            session.base
+        ));
+    }
+
+    Ok(session)
+}
+
+/// Minimal PROPFIND body requesting just the props we render/sync on. Sending a
+/// specific set (rather than `allprop`) keeps responses small on big folders.
+pub const PROPFIND_BODY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<D:propfind xmlns:D="DAV:">
+  <D:prop>
+    <D:resourcetype/>
+    <D:getcontentlength/>
+    <D:getlastmodified/>
+    <D:getetag/>
+  </D:prop>
+</D:propfind>"#;

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -60,63 +60,6 @@ pub struct SyncPlan {
     pub total_bytes: u64,
 }
 
-/// In-memory representation of a flattened directory tree, keyed by the
-/// relative path from the walk root. We only track files — directory entries
-/// are implicit (we create destination directories on demand during execute).
-struct Tree {
-    files: std::collections::BTreeMap<String, FileEntry>,
-}
-
-struct FileEntry {
-    absolute: String,
-    size: u64,
-    modified: i64,
-}
-
-async fn walk(fs: &dyn RemoteFs, root: &str) -> Result<Tree> {
-    let mut tree = Tree {
-        files: Default::default(),
-    };
-    let mut stack: Vec<String> = vec![root.to_string()];
-    let normalized_root = root.trim_end_matches('/').to_string();
-
-    while let Some(dir) = stack.pop() {
-        let entries = match fs.list_dir(&dir).await {
-            Ok(e) => e,
-            Err(_) => continue, // tolerate unreadable directories
-        };
-        for entry in entries {
-            // Skip symlinks — we don't want sync to follow them into cycles
-            // or accidentally copy host-system pointers.
-            match entry.kind {
-                FileKind::Directory => {
-                    stack.push(entry.path.clone());
-                }
-                FileKind::File => {
-                    let rel = relative_of(&normalized_root, &entry.path);
-                    tree.files.insert(
-                        rel,
-                        FileEntry {
-                            absolute: entry.path.clone(),
-                            size: entry.size,
-                            modified: entry.modified.unwrap_or(0),
-                        },
-                    );
-                }
-                _ => {}
-            }
-        }
-    }
-    Ok(tree)
-}
-
-fn relative_of(root: &str, full: &str) -> String {
-    let stripped = full.strip_prefix(root).unwrap_or(full);
-    stripped
-        .trim_start_matches(|c| c == '/' || c == '\\')
-        .replace('\\', "/")
-}
-
 fn join(base: &str, rel: &str) -> String {
     let base = base.trim_end_matches('/').trim_end_matches('\\');
     if base.is_empty() {
@@ -139,8 +82,8 @@ pub async fn plan(
     direction: SyncDirection,
     strategy: SyncStrategy,
 ) -> Result<SyncPlan> {
-    let local_tree = walk(local_fs, local_root).await?;
-    let remote_tree = walk(remote_fs, remote_root).await?;
+    let local_tree = crate::scan::walk_tree(local_fs, local_root).await?;
+    let remote_tree = crate::scan::walk_tree(remote_fs, remote_root).await?;
 
     let (source, dest, source_root, dest_root) = match direction {
         SyncDirection::LocalToRemote => (&local_tree, &remote_tree, local_root, remote_root),

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -27,6 +27,7 @@ pub enum SyncReason {
     Missing,     // not present on destination
     Newer,       // source mtime > destination mtime
     SizeChanged, // same name but bytes differ
+    Edited,      // same size, but the sync_state index says the source changed
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,6 +75,10 @@ fn join(base: &str, rel: &str) -> String {
     }
 }
 
+/// Stateless one-shot diff (size + mtime), used by the manual Sync dialog and
+/// `faro-cli`. No persistent memory — a same-size in-place edit whose mtime the
+/// destination doesn't reflect can be missed. Folder-sync uses [`plan_indexed`]
+/// to close that gap.
 pub async fn plan(
     local_fs: &dyn RemoteFs,
     remote_fs: &dyn RemoteFs,
@@ -82,59 +87,278 @@ pub async fn plan(
     direction: SyncDirection,
     strategy: SyncStrategy,
 ) -> Result<SyncPlan> {
+    let (plan, _source_tree) = plan_indexed(
+        local_fs,
+        remote_fs,
+        local_root,
+        remote_root,
+        direction,
+        strategy,
+        None,
+        crate::remotefs::ChangeSignal::MtimeSize,
+    )
+    .await?;
+    Ok(plan)
+}
+
+/// Diff with an optional `sync_state` index (the folder-sync path). When a file
+/// looks up-to-date by the live size/mtime comparison, the index is consulted:
+/// if the *current* source signal differs from what was recorded at last sync,
+/// the file is re-copied as [`SyncReason::Edited`] — this catches same-size edits
+/// the stateless diff misses. Returns the plan plus the walked **source** tree so
+/// the caller can snapshot it back into the index without a second walk.
+pub(crate) async fn plan_indexed(
+    local_fs: &dyn RemoteFs,
+    remote_fs: &dyn RemoteFs,
+    local_root: &str,
+    remote_root: &str,
+    direction: SyncDirection,
+    strategy: SyncStrategy,
+    index: Option<&std::collections::HashMap<String, crate::db::SyncStateRow>>,
+    source_signal: crate::remotefs::ChangeSignal,
+) -> Result<(SyncPlan, crate::scan::ScanTree)> {
     let local_tree = crate::scan::walk_tree(local_fs, local_root).await?;
     let remote_tree = crate::scan::walk_tree(remote_fs, remote_root).await?;
 
-    let (source, dest, source_root, dest_root) = match direction {
-        SyncDirection::LocalToRemote => (&local_tree, &remote_tree, local_root, remote_root),
-        SyncDirection::RemoteToLocal => (&remote_tree, &local_tree, remote_root, local_root),
-    };
-
-    let mut copies: Vec<SyncFile> = Vec::new();
-    let mut total_bytes: u64 = 0;
-    for (rel, src) in &source.files {
-        let reason = match dest.files.get(rel) {
-            None => Some(SyncReason::Missing),
-            Some(d) if src.size != d.size => Some(SyncReason::SizeChanged),
-            Some(d) if src.modified > d.modified && src.modified > 0 && d.modified > 0 => {
-                Some(SyncReason::Newer)
-            }
-            _ => None,
+    // Borrow both trees only for the diff, then move the source tree out to hand
+    // back to the caller (moving while `source`/`dest` still borrow would fail).
+    let (copies, deletes, total_bytes) = {
+        let (source, dest, dest_root) = match direction {
+            SyncDirection::LocalToRemote => (&local_tree, &remote_tree, remote_root),
+            SyncDirection::RemoteToLocal => (&remote_tree, &local_tree, local_root),
         };
-        if let Some(reason) = reason {
-            total_bytes = total_bytes.saturating_add(src.size);
-            copies.push(SyncFile {
-                relative: rel.clone(),
-                source_path: src.absolute.clone(),
-                destination_path: join(dest_root, rel),
-                size: src.size,
-                reason,
-            });
-        }
-    }
 
-    let mut deletes: Vec<SyncDelete> = Vec::new();
-    if matches!(strategy, SyncStrategy::Mirror) {
-        for (rel, d) in &dest.files {
-            if !source.files.contains_key(rel) {
-                deletes.push(SyncDelete {
+        let mut copies: Vec<SyncFile> = Vec::new();
+        let mut total_bytes: u64 = 0;
+        for (rel, src) in &source.files {
+            let reason = match dest.files.get(rel) {
+                None => Some(SyncReason::Missing),
+                Some(d) if src.size != d.size => Some(SyncReason::SizeChanged),
+                Some(d) if src.modified > d.modified && src.modified > 0 && d.modified > 0 => {
+                    Some(SyncReason::Newer)
+                }
+                // Live diff says up-to-date. Ask the index whether the source has
+                // changed since we last synced this file (same-size edit).
+                Some(_) => index
+                    .and_then(|ix| ix.get(rel))
+                    .filter(|row| source_changed(source_signal, src, row))
+                    .map(|_| SyncReason::Edited),
+            };
+            if let Some(reason) = reason {
+                total_bytes = total_bytes.saturating_add(src.size);
+                copies.push(SyncFile {
                     relative: rel.clone(),
-                    path: d.absolute.clone(),
-                    kind: FileKind::File,
-                    size: d.size,
+                    source_path: src.absolute.clone(),
+                    destination_path: join(dest_root, rel),
+                    size: src.size,
+                    reason,
                 });
             }
         }
+
+        let mut deletes: Vec<SyncDelete> = Vec::new();
+        if matches!(strategy, SyncStrategy::Mirror) {
+            for (rel, d) in &dest.files {
+                if !source.files.contains_key(rel) {
+                    deletes.push(SyncDelete {
+                        relative: rel.clone(),
+                        path: d.absolute.clone(),
+                        kind: FileKind::File,
+                        size: d.size,
+                    });
+                }
+            }
+        }
+        (copies, deletes, total_bytes)
+    };
+
+    let source_tree = match direction {
+        SyncDirection::LocalToRemote => local_tree,
+        SyncDirection::RemoteToLocal => remote_tree,
+    };
+
+    Ok((
+        SyncPlan {
+            direction,
+            strategy,
+            local_root: local_root.to_string(),
+            remote_root: remote_root.to_string(),
+            copies,
+            deletes,
+            total_bytes,
+        },
+        source_tree,
+    ))
+}
+
+/// True when the current source entry differs from what the index recorded at
+/// last sync. For ETag backends this compares the opaque token (falling back to
+/// size+mtime when either side lacks one); otherwise it's size+mtime.
+fn source_changed(
+    signal: crate::remotefs::ChangeSignal,
+    cur: &crate::scan::ScanEntry,
+    row: &crate::db::SyncStateRow,
+) -> bool {
+    use crate::remotefs::ChangeSignal;
+    match signal {
+        ChangeSignal::Etag => match (&cur.etag, &row.remote_signal) {
+            (Some(a), Some(b)) => a != b,
+            // Missing a token on either side → fall back to size+mtime.
+            _ => cur.size != row.size || cur.modified != row.mtime,
+        },
+        ChangeSignal::MtimeSize | ChangeSignal::Hash => {
+            cur.size != row.size || cur.modified != row.mtime
+        }
+    }
+}
+
+#[cfg(test)]
+mod index_tests {
+    use super::*;
+    use crate::db::Db;
+    use crate::remotefs::{local::LocalFs, ChangeSignal};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::{Duration, UNIX_EPOCH};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn scratch(tag: &str) -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut d = std::env::temp_dir();
+        d.push(format!("faro_idx_test_{}_{tag}_{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
     }
 
-    let _ = source_root;
-    Ok(SyncPlan {
-        direction,
-        strategy,
-        local_root: local_root.to_string(),
-        remote_root: remote_root.to_string(),
-        copies,
-        deletes,
-        total_bytes,
-    })
+    /// Pin a file's mtime so the diff is deterministic (no sleeps). Requires
+    /// write access to the handle, which is why we reopen it writable.
+    fn set_mtime(p: &Path, secs: u64) {
+        let f = std::fs::OpenOptions::new().write(true).open(p).unwrap();
+        f.set_modified(UNIX_EPOCH + Duration::from_secs(secs)).unwrap();
+    }
+
+    async fn plan_stateless(src: &Path, dst: &Path) -> SyncPlan {
+        let fs = LocalFs;
+        plan(
+            &fs,
+            &fs,
+            src.to_str().unwrap(),
+            dst.to_str().unwrap(),
+            SyncDirection::LocalToRemote,
+            SyncStrategy::Additive,
+        )
+        .await
+        .unwrap()
+    }
+
+    async fn plan_with(
+        src: &Path,
+        dst: &Path,
+        index: &std::collections::HashMap<String, crate::db::SyncStateRow>,
+    ) -> (SyncPlan, crate::scan::ScanTree) {
+        let fs = LocalFs;
+        plan_indexed(
+            &fs,
+            &fs,
+            src.to_str().unwrap(),
+            dst.to_str().unwrap(),
+            SyncDirection::LocalToRemote,
+            SyncStrategy::Additive,
+            Some(index),
+            ChangeSignal::MtimeSize,
+        )
+        .await
+        .unwrap()
+    }
+
+    // The payoff, exercised end-to-end against a real SQLite Db and real files:
+    // a same-size in-place edit that the stateless size+mtime diff misses (because
+    // the destination's mtime is newer than the source's — the object-store
+    // upload-time quirk), that the sync_state index catches, and that a seeded
+    // index then declines to re-upload on the next pass (resume).
+    #[test]
+    fn index_catches_same_size_edit_and_resume_is_a_noop() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let src = scratch("src");
+            let dst = scratch("dst");
+            let base = 1_000_000u64;
+
+            // Both sides hold the same 5-byte file; the destination's mtime is
+            // *newer* than the source's, so "src newer than dst" never fires.
+            std::fs::write(src.join("a.txt"), "hello").unwrap();
+            std::fs::write(dst.join("a.txt"), "hello").unwrap();
+            set_mtime(&dst.join("a.txt"), base + 100);
+            set_mtime(&src.join("a.txt"), base); // original source state
+
+            let db = Db::open_in_memory().unwrap();
+            db.upsert_sync_state("pair1", "a.txt", 5, base as i64, None, 0)
+                .unwrap();
+
+            // Edit in place: same byte count, mtime bumped but still < dest's.
+            std::fs::write(src.join("a.txt"), "world").unwrap();
+            set_mtime(&src.join("a.txt"), base + 1);
+
+            // 1) Stateless diff misses it — proves the gap the index closes.
+            let stateless = plan_stateless(&src, &dst).await;
+            assert!(
+                stateless.copies.is_empty(),
+                "stateless size+mtime diff should miss a same-size edit under a newer dest mtime"
+            );
+
+            // 2) Index-aware diff catches it as an Edited copy.
+            let index = db.load_sync_state("pair1").unwrap();
+            let (indexed, source_tree) = plan_with(&src, &dst, &index).await;
+            assert_eq!(indexed.copies.len(), 1, "index should flag the edit");
+            assert_eq!(indexed.copies[0].relative, "a.txt");
+            assert!(matches!(indexed.copies[0].reason, SyncReason::Edited));
+
+            // 3) Snapshot the source back into the DB (what a real reconcile does)
+            //    and re-plan: the index now matches reality → no re-upload (resume).
+            for (rel, e) in &source_tree.files {
+                db.upsert_sync_state("pair1", rel, e.size, e.modified, e.etag.as_deref(), 1)
+                    .unwrap();
+            }
+            let index2 = db.load_sync_state("pair1").unwrap();
+            let (resumed, _) = plan_with(&src, &dst, &index2).await;
+            assert!(
+                resumed.copies.is_empty(),
+                "a seeded, up-to-date index must not re-upload unchanged files"
+            );
+
+            let _ = std::fs::remove_dir_all(&src);
+            let _ = std::fs::remove_dir_all(&dst);
+        });
+    }
+
+    // ETag backends compare the opaque token, not mtime: same size, same mtime,
+    // different ETag ⇒ changed.
+    #[test]
+    fn etag_signal_detects_token_change() {
+        let cur = crate::scan::ScanEntry {
+            absolute: "/x".into(),
+            size: 10,
+            modified: 42,
+            etag: Some("etag-B".into()),
+        };
+        let row = crate::db::SyncStateRow {
+            size: 10,
+            mtime: 42,
+            remote_signal: Some("etag-A".into()),
+            last_synced_ms: 0,
+        };
+        assert!(source_changed(ChangeSignal::Etag, &cur, &row));
+
+        // Same token ⇒ unchanged, even if mtime drifted.
+        let row_same = crate::db::SyncStateRow {
+            remote_signal: Some("etag-B".into()),
+            mtime: 999,
+            ..row
+        };
+        assert!(!source_changed(ChangeSignal::Etag, &cur, &row_same));
+    }
 }

--- a/src-tauri/src/transfer.rs
+++ b/src-tauri/src/transfer.rs
@@ -1,6 +1,6 @@
 use crate::session::{
-    DropboxSession, FtpSession, HttpSession, ObjectSession, OneDriveSession, Session, SshSession,
-    WebdavSession,
+    DropboxSession, FtpSession, GDriveSession, HttpSession, ObjectSession, OneDriveSession,
+    Session, SshSession, WebdavSession,
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -286,6 +286,16 @@ impl TransferManager {
                     )
                     .await
                 }
+                Session::GDrive(gd) => {
+                    mgr.run_gdrive_download(
+                        &id_for_task,
+                        gd.clone(),
+                        &remote_path,
+                        &final_path,
+                        &app,
+                    )
+                    .await
+                }
                 Session::Agent(agent) => {
                     mgr.run_agent_download(
                         &id_for_task,
@@ -508,6 +518,16 @@ impl TransferManager {
                     mgr.run_onedrive_upload(
                         &id_for_task,
                         od.clone(),
+                        &local,
+                        &final_remote,
+                        &app,
+                    )
+                    .await
+                }
+                Session::GDrive(gd) => {
+                    mgr.run_gdrive_upload(
+                        &id_for_task,
+                        gd.clone(),
                         &local,
                         &final_remote,
                         &app,
@@ -1428,6 +1448,133 @@ impl TransferManager {
         }
         Ok(())
     }
+
+    /// Stream a Google Drive download: resolve the path to a file id, then GET
+    /// `/files/{id}?alt=media`.
+    async fn run_gdrive_download(
+        &self,
+        id: &str,
+        session: Arc<GDriveSession>,
+        remote_path: &str,
+        local_path: &Path,
+        app: &AppHandle,
+    ) -> Result<()> {
+        use futures::StreamExt;
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let (file_id, _) = session
+            .resolve_item(remote_path)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("{remote_path}: not found"))?;
+        let resp = session
+            .get_stream(&format!("/files/{file_id}?alt=media"))
+            .await?;
+
+        let mut file = tokio::fs::File::create(local_path)
+            .await
+            .with_context(|| format!("create {}", local_path.display()))?;
+        let mut stream = resp.bytes_stream();
+        let mut transferred: u64 = 0;
+        let mut last_emit = Instant::now();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("drive chunk for {remote_path}"))?;
+            file.write_all(&chunk).await?;
+            transferred += chunk.len() as u64;
+            if last_emit.elapsed() > Duration::from_millis(100) {
+                self.update(id, |t| t.transferred = transferred).await;
+                if let Some(t) = self.get(id).await {
+                    let _ = app.emit("transfer://progress", &t);
+                }
+                last_emit = Instant::now();
+            }
+        }
+        file.flush().await?;
+        self.update(id, |t| t.transferred = transferred).await;
+        Ok(())
+    }
+
+    /// Upload to Google Drive: update the existing file's media if a same-named
+    /// child exists, else create a new file via a multipart/related request.
+    async fn run_gdrive_upload(
+        &self,
+        id: &str,
+        session: Arc<GDriveSession>,
+        local_path: &Path,
+        remote_path: &str,
+        _app: &AppHandle,
+    ) -> Result<()> {
+        use crate::session::gdrive::{basename, normalize, parent_of};
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let size = tokio::fs::metadata(local_path)
+            .await
+            .with_context(|| format!("stat {}", local_path.display()))?
+            .len();
+        let norm = normalize(remote_path);
+        let name = basename(&norm).to_string();
+        let parent_id = session.folder_id(&parent_of(&norm)).await?;
+        let existing = session.find_child(&parent_id, &name).await?;
+        let bytes = tokio::fs::read(local_path)
+            .await
+            .with_context(|| format!("read {}", local_path.display()))?;
+        let token = session.access_token().await?;
+
+        let resp = if let Some((file_id, _)) = existing {
+            // Update the existing file's content in place.
+            session
+                .client
+                .patch(format!(
+                    "{}/files/{file_id}?uploadType=media",
+                    session.upload_base
+                ))
+                .bearer_auth(&token)
+                .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+                .body(bytes)
+                .send()
+                .await
+                .with_context(|| format!("update {remote_path}"))?
+        } else {
+            // Create a new file: multipart/related metadata + media.
+            let boundary = format!("faro{}", Uuid::new_v4().simple());
+            let meta = serde_json::json!({ "name": name, "parents": [parent_id] });
+            let mut body: Vec<u8> = Vec::with_capacity(bytes.len() + 256);
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(b"Content-Type: application/json; charset=UTF-8\r\n\r\n");
+            body.extend_from_slice(meta.to_string().as_bytes());
+            body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+            body.extend_from_slice(&bytes);
+            body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+            session
+                .client
+                .post(format!(
+                    "{}/files?uploadType=multipart&fields=id",
+                    session.upload_base
+                ))
+                .bearer_auth(&token)
+                .header(
+                    reqwest::header::CONTENT_TYPE,
+                    format!("multipart/related; boundary={boundary}"),
+                )
+                .body(body)
+                .send()
+                .await
+                .with_context(|| format!("create {remote_path}"))?
+        };
+
+        if !resp.status().is_success() {
+            let code = resp.status().as_u16();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!("upload {remote_path} failed ({code}): {text}"));
+        }
+        session.clear_cache();
+        self.update(id, |t| t.transferred = size).await;
+        Ok(())
+    }
 }
 
 /// Build a RemoteFs handle for the right backend.
@@ -1442,6 +1589,7 @@ fn fs_for_session(session: &Arc<Session>) -> Box<dyn crate::remotefs::RemoteFs> 
         Session::Http(http) => Box::new(crate::remotefs::http::HttpFs::new(http.clone())),
         Session::Dropbox(dbx) => Box::new(crate::remotefs::dropbox::DropboxFs::new(dbx.clone())),
         Session::OneDrive(od) => Box::new(crate::remotefs::onedrive::OneDriveFs::new(od.clone())),
+        Session::GDrive(gd) => Box::new(crate::remotefs::gdrive::GDriveFs::new(gd.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }
@@ -1524,6 +1672,7 @@ async fn remote_size(session: &Arc<Session>, path: &str) -> Result<u64> {
             Ok(dbx.size(&crate::remotefs::dropbox::dropbox_api_path(path)).await)
         }
         Session::OneDrive(od) => Ok(od.size(&crate::remotefs::onedrive::item_ref(path)).await),
+        Session::GDrive(gd) => Ok(gd.size(path).await),
         Session::Agent(agent) => Ok(agent_stat(agent, path).await.0),
     }
 }
@@ -1658,6 +1807,25 @@ async fn remote_resolve(
                             .exists(&crate::remotefs::onedrive::item_ref(&candidate))
                             .await
                         {
+                            break;
+                        }
+                    }
+                    (candidate, false)
+                }
+            })
+        }
+        Session::GDrive(gd) => {
+            let exists = gd.exists(initial_remote).await;
+            Ok(match policy {
+                OverwritePolicy::Overwrite => (initial_remote.to_string(), false),
+                OverwritePolicy::Skip => (initial_remote.to_string(), exists),
+                OverwritePolicy::Rename if !exists => (initial_remote.to_string(), false),
+                OverwritePolicy::Rename => {
+                    let mut candidate = initial_remote.to_string();
+                    for i in 1..=999 {
+                        let (stem, ext) = split_ext(initial_remote);
+                        candidate = format!("{stem}_{i}{ext}");
+                        if !gd.exists(&candidate).await {
                             break;
                         }
                     }

--- a/src-tauri/src/transfer.rs
+++ b/src-tauri/src/transfer.rs
@@ -1,5 +1,5 @@
 use crate::session::{
-    FtpSession, HttpSession, ObjectSession, Session, SshSession, WebdavSession,
+    DropboxSession, FtpSession, HttpSession, ObjectSession, Session, SshSession, WebdavSession,
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -265,6 +265,16 @@ impl TransferManager {
                     )
                     .await
                 }
+                Session::Dropbox(dbx) => {
+                    mgr.run_dropbox_download(
+                        &id_for_task,
+                        dbx.clone(),
+                        &remote_path,
+                        &final_path,
+                        &app,
+                    )
+                    .await
+                }
                 Session::Agent(agent) => {
                     mgr.run_agent_download(
                         &id_for_task,
@@ -472,6 +482,16 @@ impl TransferManager {
                 }
                 Session::Http(_) => {
                     Err(anyhow::anyhow!("HTTP source is read-only — upload not supported"))
+                }
+                Session::Dropbox(dbx) => {
+                    mgr.run_dropbox_upload(
+                        &id_for_task,
+                        dbx.clone(),
+                        &local,
+                        &final_remote,
+                        &app,
+                    )
+                    .await
                 }
                 Session::Agent(agent) => {
                     mgr.run_agent_upload(
@@ -1085,6 +1105,120 @@ impl TransferManager {
         self.update(id, |t| t.transferred = transferred).await;
         Ok(())
     }
+
+    /// Stream a Dropbox download: POST `/2/files/download` (path in the
+    /// `Dropbox-API-Arg` header), written chunk by chunk.
+    async fn run_dropbox_download(
+        &self,
+        id: &str,
+        session: Arc<DropboxSession>,
+        remote_path: &str,
+        local_path: &Path,
+        app: &AppHandle,
+    ) -> Result<()> {
+        use futures::StreamExt;
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let dbx = crate::remotefs::dropbox::dropbox_api_path(remote_path);
+        let arg = serde_json::json!({ "path": dbx }).to_string();
+        let resp = session.content_get("/2/files/download", &arg).await?;
+
+        let mut file = tokio::fs::File::create(local_path)
+            .await
+            .with_context(|| format!("create {}", local_path.display()))?;
+        let mut stream = resp.bytes_stream();
+        let mut transferred: u64 = 0;
+        let mut last_emit = Instant::now();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("dropbox chunk for {remote_path}"))?;
+            file.write_all(&chunk).await?;
+            transferred += chunk.len() as u64;
+            if last_emit.elapsed() > Duration::from_millis(100) {
+                self.update(id, |t| t.transferred = transferred).await;
+                if let Some(t) = self.get(id).await {
+                    let _ = app.emit("transfer://progress", &t);
+                }
+                last_emit = Instant::now();
+            }
+        }
+        file.flush().await?;
+        self.update(id, |t| t.transferred = transferred).await;
+        Ok(())
+    }
+
+    /// Upload a file to Dropbox via `/2/files/upload` (overwrite mode). Simple
+    /// single-shot upload; Dropbox caps that at 150 MB, so larger files are
+    /// refused with a clear message (chunked upload_session is a follow-up).
+    async fn run_dropbox_upload(
+        &self,
+        id: &str,
+        session: Arc<DropboxSession>,
+        local_path: &Path,
+        remote_path: &str,
+        app: &AppHandle,
+    ) -> Result<()> {
+        use tokio_util::io::ReaderStream;
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+        let _ = app; // Dropbox reports at completion, like the FTP/WebDAV paths.
+
+        let size = tokio::fs::metadata(local_path)
+            .await
+            .with_context(|| format!("stat {}", local_path.display()))?
+            .len();
+        const SIMPLE_UPLOAD_MAX: u64 = 150 * 1024 * 1024;
+        if size > SIMPLE_UPLOAD_MAX {
+            return Err(anyhow::anyhow!(
+                "{} exceeds Dropbox's 150 MB single-request upload limit \
+                 (chunked upload not yet implemented)",
+                local_path.display()
+            ));
+        }
+
+        let dbx = crate::remotefs::dropbox::dropbox_api_path(remote_path);
+        let arg = serde_json::json!({
+            "path": dbx, "mode": "overwrite", "autorename": false, "mute": true
+        })
+        .to_string();
+        let url = format!("{}/2/files/upload", session.content_base);
+
+        // Proactive refresh covers the common case; on a hard 401 we refresh and
+        // retry once, re-opening the file for a fresh streamed body.
+        let mut attempt = 0;
+        loop {
+            let token = session.access_token().await?;
+            let file = tokio::fs::File::open(local_path)
+                .await
+                .with_context(|| format!("open {}", local_path.display()))?;
+            let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+            let resp = session
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .header("Dropbox-API-Arg", &arg)
+                .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+                .body(body)
+                .send()
+                .await
+                .with_context(|| format!("PUT {remote_path}"))?;
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+                attempt += 1;
+                session.force_refresh().await?;
+                continue;
+            }
+            if !resp.status().is_success() {
+                let code = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!("upload {remote_path} failed ({code}): {text}"));
+            }
+            break;
+        }
+        self.update(id, |t| t.transferred = size).await;
+        Ok(())
+    }
 }
 
 /// Build a RemoteFs handle for the right backend.
@@ -1097,6 +1231,7 @@ fn fs_for_session(session: &Arc<Session>) -> Box<dyn crate::remotefs::RemoteFs> 
         }
         Session::Webdav(dav) => Box::new(crate::remotefs::webdav::WebdavFs::new(dav.clone())),
         Session::Http(http) => Box::new(crate::remotefs::http::HttpFs::new(http.clone())),
+        Session::Dropbox(dbx) => Box::new(crate::remotefs::dropbox::DropboxFs::new(dbx.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }
@@ -1175,6 +1310,9 @@ async fn remote_size(session: &Arc<Session>, path: &str) -> Result<u64> {
         }
         Session::Webdav(dav) => Ok(webdav_head(dav, path).await.0),
         Session::Http(http) => Ok(http_size(http, path).await),
+        Session::Dropbox(dbx) => {
+            Ok(dbx.size(&crate::remotefs::dropbox::dropbox_api_path(path)).await)
+        }
         Session::Agent(agent) => Ok(agent_stat(agent, path).await.0),
     }
 }
@@ -1272,6 +1410,27 @@ async fn remote_resolve(
             // Read-only: no upload will actually run (run_http_upload errors), so
             // resolution is a no-op that just echoes the target back.
             Ok((initial_remote.to_string(), false))
+        }
+        Session::Dropbox(dbx) => {
+            let dbx_path = crate::remotefs::dropbox::dropbox_api_path(initial_remote);
+            let exists = dbx.exists(&dbx_path).await;
+            Ok(match policy {
+                OverwritePolicy::Overwrite => (initial_remote.to_string(), false),
+                OverwritePolicy::Skip => (initial_remote.to_string(), exists),
+                OverwritePolicy::Rename if !exists => (initial_remote.to_string(), false),
+                OverwritePolicy::Rename => {
+                    let mut candidate = initial_remote.to_string();
+                    for i in 1..=999 {
+                        let (stem, ext) = split_ext(initial_remote);
+                        candidate = format!("{stem}_{i}{ext}");
+                        let p = crate::remotefs::dropbox::dropbox_api_path(&candidate);
+                        if !dbx.exists(&p).await {
+                            break;
+                        }
+                    }
+                    (candidate, false)
+                }
+            })
         }
         Session::Agent(agent) => {
             let (_, exists) = agent_stat(agent, initial_remote).await;

--- a/src-tauri/src/transfer.rs
+++ b/src-tauri/src/transfer.rs
@@ -1,4 +1,6 @@
-use crate::session::{FtpSession, ObjectSession, Session, SshSession, WebdavSession};
+use crate::session::{
+    FtpSession, HttpSession, ObjectSession, Session, SshSession, WebdavSession,
+};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -253,6 +255,16 @@ impl TransferManager {
                     )
                     .await
                 }
+                Session::Http(http) => {
+                    mgr.run_http_download(
+                        &id_for_task,
+                        http.clone(),
+                        &remote_path,
+                        &final_path,
+                        &app,
+                    )
+                    .await
+                }
                 Session::Agent(agent) => {
                     mgr.run_agent_download(
                         &id_for_task,
@@ -457,6 +469,9 @@ impl TransferManager {
                         &app,
                     )
                     .await
+                }
+                Session::Http(_) => {
+                    Err(anyhow::anyhow!("HTTP source is read-only — upload not supported"))
                 }
                 Session::Agent(agent) => {
                     mgr.run_agent_upload(
@@ -1020,6 +1035,56 @@ impl TransferManager {
         self.update(id, |t| t.transferred = size).await;
         Ok(())
     }
+
+    /// Stream a read-only HTTP download: a single `GET`, written chunk by chunk.
+    async fn run_http_download(
+        &self,
+        id: &str,
+        session: Arc<HttpSession>,
+        remote_path: &str,
+        local_path: &Path,
+        app: &AppHandle,
+    ) -> Result<()> {
+        use futures::StreamExt;
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let url = session.url_for(remote_path, false);
+        let resp = session
+            .request(reqwest::Method::GET, url)
+            .send()
+            .await
+            .with_context(|| format!("GET {remote_path}"))?;
+        if !resp.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "download {remote_path} failed: HTTP {}",
+                resp.status().as_u16()
+            ));
+        }
+
+        let mut file = tokio::fs::File::create(local_path)
+            .await
+            .with_context(|| format!("create {}", local_path.display()))?;
+        let mut stream = resp.bytes_stream();
+        let mut transferred: u64 = 0;
+        let mut last_emit = Instant::now();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("http chunk for {remote_path}"))?;
+            file.write_all(&chunk).await?;
+            transferred += chunk.len() as u64;
+            if last_emit.elapsed() > Duration::from_millis(100) {
+                self.update(id, |t| t.transferred = transferred).await;
+                if let Some(t) = self.get(id).await {
+                    let _ = app.emit("transfer://progress", &t);
+                }
+                last_emit = Instant::now();
+            }
+        }
+        file.flush().await?;
+        self.update(id, |t| t.transferred = transferred).await;
+        Ok(())
+    }
 }
 
 /// Build a RemoteFs handle for the right backend.
@@ -1031,6 +1096,7 @@ fn fs_for_session(session: &Arc<Session>) -> Box<dyn crate::remotefs::RemoteFs> 
             Box::new(crate::remotefs::object::ObjectFs::new(obj.clone()))
         }
         Session::Webdav(dav) => Box::new(crate::remotefs::webdav::WebdavFs::new(dav.clone())),
+        Session::Http(http) => Box::new(crate::remotefs::http::HttpFs::new(http.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }
@@ -1050,6 +1116,20 @@ async fn webdav_head(session: &Arc<WebdavSession>, path: &str) -> (u64, bool) {
             (size, true)
         }
         _ => (0, false),
+    }
+}
+
+/// HEAD an HTTP-source file for its size. Best-effort (0 on any failure).
+async fn http_size(session: &Arc<HttpSession>, path: &str) -> u64 {
+    let url = session.url_for(path, false);
+    match session.request(reqwest::Method::HEAD, url).send().await {
+        Ok(resp) if resp.status().is_success() => resp
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0),
+        _ => 0,
     }
 }
 
@@ -1094,6 +1174,7 @@ async fn remote_size(session: &Arc<Session>, path: &str) -> Result<u64> {
             Ok(meta.size as u64)
         }
         Session::Webdav(dav) => Ok(webdav_head(dav, path).await.0),
+        Session::Http(http) => Ok(http_size(http, path).await),
         Session::Agent(agent) => Ok(agent_stat(agent, path).await.0),
     }
 }
@@ -1186,6 +1267,11 @@ async fn remote_resolve(
                     (candidate, false)
                 }
             })
+        }
+        Session::Http(_) => {
+            // Read-only: no upload will actually run (run_http_upload errors), so
+            // resolution is a no-op that just echoes the target back.
+            Ok((initial_remote.to_string(), false))
         }
         Session::Agent(agent) => {
             let (_, exists) = agent_stat(agent, initial_remote).await;

--- a/src-tauri/src/transfer.rs
+++ b/src-tauri/src/transfer.rs
@@ -1,5 +1,6 @@
 use crate::session::{
-    DropboxSession, FtpSession, HttpSession, ObjectSession, Session, SshSession, WebdavSession,
+    DropboxSession, FtpSession, HttpSession, ObjectSession, OneDriveSession, Session, SshSession,
+    WebdavSession,
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -275,6 +276,16 @@ impl TransferManager {
                     )
                     .await
                 }
+                Session::OneDrive(od) => {
+                    mgr.run_onedrive_download(
+                        &id_for_task,
+                        od.clone(),
+                        &remote_path,
+                        &final_path,
+                        &app,
+                    )
+                    .await
+                }
                 Session::Agent(agent) => {
                     mgr.run_agent_download(
                         &id_for_task,
@@ -487,6 +498,16 @@ impl TransferManager {
                     mgr.run_dropbox_upload(
                         &id_for_task,
                         dbx.clone(),
+                        &local,
+                        &final_remote,
+                        &app,
+                    )
+                    .await
+                }
+                Session::OneDrive(od) => {
+                    mgr.run_onedrive_upload(
+                        &id_for_task,
+                        od.clone(),
                         &local,
                         &final_remote,
                         &app,
@@ -1219,6 +1240,194 @@ impl TransferManager {
         self.update(id, |t| t.transferred = size).await;
         Ok(())
     }
+
+    /// Stream a OneDrive download: GET the item's `/content` (Graph 302s to a
+    /// pre-authorized URL, which reqwest follows), written chunk by chunk.
+    async fn run_onedrive_download(
+        &self,
+        id: &str,
+        session: Arc<OneDriveSession>,
+        remote_path: &str,
+        local_path: &Path,
+        app: &AppHandle,
+    ) -> Result<()> {
+        use futures::StreamExt;
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let content = crate::remotefs::onedrive::content_ref(remote_path);
+        let resp = session.get_stream(&content).await?;
+
+        let mut file = tokio::fs::File::create(local_path)
+            .await
+            .with_context(|| format!("create {}", local_path.display()))?;
+        let mut stream = resp.bytes_stream();
+        let mut transferred: u64 = 0;
+        let mut last_emit = Instant::now();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("onedrive chunk for {remote_path}"))?;
+            file.write_all(&chunk).await?;
+            transferred += chunk.len() as u64;
+            if last_emit.elapsed() > Duration::from_millis(100) {
+                self.update(id, |t| t.transferred = transferred).await;
+                if let Some(t) = self.get(id).await {
+                    let _ = app.emit("transfer://progress", &t);
+                }
+                last_emit = Instant::now();
+            }
+        }
+        file.flush().await?;
+        self.update(id, |t| t.transferred = transferred).await;
+        Ok(())
+    }
+
+    /// Upload to OneDrive: a single `PUT …/content` for small files, or a
+    /// chunked upload session for larger ones (Graph caps simple PUT at 4 MB).
+    async fn run_onedrive_upload(
+        &self,
+        id: &str,
+        session: Arc<OneDriveSession>,
+        local_path: &Path,
+        remote_path: &str,
+        app: &AppHandle,
+    ) -> Result<()> {
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let size = tokio::fs::metadata(local_path)
+            .await
+            .with_context(|| format!("stat {}", local_path.display()))?
+            .len();
+        // Graph's simple-upload ceiling is 4 MB; overridable for tests.
+        let simple_max: u64 = std::env::var("FARO_ONEDRIVE_SIMPLE_MAX")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(4 * 1024 * 1024);
+
+        if size <= simple_max {
+            self.onedrive_simple_upload(id, &session, local_path, remote_path)
+                .await?;
+        } else {
+            self.onedrive_session_upload(id, &session, local_path, remote_path, size, app)
+                .await?;
+        }
+        self.update(id, |t| t.transferred = size).await;
+        Ok(())
+    }
+
+    async fn onedrive_simple_upload(
+        &self,
+        _id: &str,
+        session: &Arc<OneDriveSession>,
+        local_path: &Path,
+        remote_path: &str,
+    ) -> Result<()> {
+        use tokio_util::io::ReaderStream;
+        let content = crate::remotefs::onedrive::content_ref(remote_path);
+        let url = format!("{}{content}", session.graph_base);
+        let mut attempt = 0;
+        loop {
+            let token = session.access_token().await?;
+            let file = tokio::fs::File::open(local_path)
+                .await
+                .with_context(|| format!("open {}", local_path.display()))?;
+            let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+            let resp = session
+                .client
+                .put(&url)
+                .bearer_auth(&token)
+                .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+                .body(body)
+                .send()
+                .await
+                .with_context(|| format!("PUT {remote_path}"))?;
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
+                attempt += 1;
+                session.force_refresh().await?;
+                continue;
+            }
+            if !resp.status().is_success() {
+                let code = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!("upload {remote_path} failed ({code}): {text}"));
+            }
+            return Ok(());
+        }
+    }
+
+    async fn onedrive_session_upload(
+        &self,
+        id: &str,
+        session: &Arc<OneDriveSession>,
+        local_path: &Path,
+        remote_path: &str,
+        size: u64,
+        app: &AppHandle,
+    ) -> Result<()> {
+        // Create the upload session.
+        let item = crate::remotefs::onedrive::item_ref(remote_path);
+        let create = format!("{item}/createUploadSession");
+        let body = serde_json::json!({
+            "item": { "@microsoft.graph.conflictBehavior": "replace" }
+        });
+        let sess = session
+            .rpc(reqwest::Method::POST, &create, Some(&body))
+            .await?;
+        let upload_url = sess
+            .get("uploadUrl")
+            .and_then(|u| u.as_str())
+            .ok_or_else(|| anyhow::anyhow!("createUploadSession returned no uploadUrl"))?
+            .to_string();
+
+        // Chunks must be a multiple of 320 KiB (except the last). ~6 MiB.
+        const CHUNK: usize = 320 * 1024 * 20;
+        let mut file = tokio::fs::File::open(local_path)
+            .await
+            .with_context(|| format!("open {}", local_path.display()))?;
+        let mut buf = vec![0u8; CHUNK];
+        let mut offset: u64 = 0;
+        let mut last_emit = Instant::now();
+        while offset < size {
+            let mut filled = 0;
+            while filled < buf.len() {
+                let n = file.read(&mut buf[filled..]).await?;
+                if n == 0 {
+                    break;
+                }
+                filled += n;
+            }
+            if filled == 0 {
+                break;
+            }
+            let start = offset;
+            let end = offset + filled as u64 - 1;
+            let range = format!("bytes {start}-{end}/{size}");
+            let resp = session
+                .client
+                .put(&upload_url)
+                .header(reqwest::header::CONTENT_LENGTH, filled as u64)
+                .header("Content-Range", range)
+                .body(bytes::Bytes::copy_from_slice(&buf[..filled]))
+                .send()
+                .await
+                .with_context(|| format!("upload chunk for {remote_path}"))?;
+            if !resp.status().is_success() {
+                let code = resp.status().as_u16();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!("upload {remote_path} chunk failed ({code}): {text}"));
+            }
+            offset += filled as u64;
+            if last_emit.elapsed() > Duration::from_millis(100) {
+                self.update(id, |t| t.transferred = offset).await;
+                if let Some(t) = self.get(id).await {
+                    let _ = app.emit("transfer://progress", &t);
+                }
+                last_emit = Instant::now();
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Build a RemoteFs handle for the right backend.
@@ -1232,6 +1441,7 @@ fn fs_for_session(session: &Arc<Session>) -> Box<dyn crate::remotefs::RemoteFs> 
         Session::Webdav(dav) => Box::new(crate::remotefs::webdav::WebdavFs::new(dav.clone())),
         Session::Http(http) => Box::new(crate::remotefs::http::HttpFs::new(http.clone())),
         Session::Dropbox(dbx) => Box::new(crate::remotefs::dropbox::DropboxFs::new(dbx.clone())),
+        Session::OneDrive(od) => Box::new(crate::remotefs::onedrive::OneDriveFs::new(od.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }
@@ -1313,6 +1523,7 @@ async fn remote_size(session: &Arc<Session>, path: &str) -> Result<u64> {
         Session::Dropbox(dbx) => {
             Ok(dbx.size(&crate::remotefs::dropbox::dropbox_api_path(path)).await)
         }
+        Session::OneDrive(od) => Ok(od.size(&crate::remotefs::onedrive::item_ref(path)).await),
         Session::Agent(agent) => Ok(agent_stat(agent, path).await.0),
     }
 }
@@ -1425,6 +1636,28 @@ async fn remote_resolve(
                         candidate = format!("{stem}_{i}{ext}");
                         let p = crate::remotefs::dropbox::dropbox_api_path(&candidate);
                         if !dbx.exists(&p).await {
+                            break;
+                        }
+                    }
+                    (candidate, false)
+                }
+            })
+        }
+        Session::OneDrive(od) => {
+            let exists = od.exists(&crate::remotefs::onedrive::item_ref(initial_remote)).await;
+            Ok(match policy {
+                OverwritePolicy::Overwrite => (initial_remote.to_string(), false),
+                OverwritePolicy::Skip => (initial_remote.to_string(), exists),
+                OverwritePolicy::Rename if !exists => (initial_remote.to_string(), false),
+                OverwritePolicy::Rename => {
+                    let mut candidate = initial_remote.to_string();
+                    for i in 1..=999 {
+                        let (stem, ext) = split_ext(initial_remote);
+                        candidate = format!("{stem}_{i}{ext}");
+                        if !od
+                            .exists(&crate::remotefs::onedrive::item_ref(&candidate))
+                            .await
+                        {
                             break;
                         }
                     }

--- a/src-tauri/src/transfer.rs
+++ b/src-tauri/src/transfer.rs
@@ -1,6 +1,6 @@
 use crate::session::{
-    DropboxSession, FtpSession, GDriveSession, HttpSession, ObjectSession, OneDriveSession,
-    Session, SshSession, WebdavSession,
+    BoxSession, DropboxSession, FtpSession, GDriveSession, HttpSession, ObjectSession,
+    OneDriveSession, Session, SshSession, WebdavSession,
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -296,6 +296,16 @@ impl TransferManager {
                     )
                     .await
                 }
+                Session::Box(bx) => {
+                    mgr.run_box_download(
+                        &id_for_task,
+                        bx.clone(),
+                        &remote_path,
+                        &final_path,
+                        &app,
+                    )
+                    .await
+                }
                 Session::Agent(agent) => {
                     mgr.run_agent_download(
                         &id_for_task,
@@ -528,6 +538,16 @@ impl TransferManager {
                     mgr.run_gdrive_upload(
                         &id_for_task,
                         gd.clone(),
+                        &local,
+                        &final_remote,
+                        &app,
+                    )
+                    .await
+                }
+                Session::Box(bx) => {
+                    mgr.run_box_upload(
+                        &id_for_task,
+                        bx.clone(),
                         &local,
                         &final_remote,
                         &app,
@@ -1575,6 +1595,113 @@ impl TransferManager {
         self.update(id, |t| t.transferred = size).await;
         Ok(())
     }
+
+    /// Stream a Box download: resolve the path to a file id, GET `/files/{id}/content`.
+    async fn run_box_download(
+        &self,
+        id: &str,
+        session: Arc<BoxSession>,
+        remote_path: &str,
+        local_path: &Path,
+        app: &AppHandle,
+    ) -> Result<()> {
+        use futures::StreamExt;
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let (file_id, _) = session
+            .resolve_item(remote_path)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("{remote_path}: not found"))?;
+        let resp = session
+            .get_stream(&format!("/files/{file_id}/content"))
+            .await?;
+
+        let mut file = tokio::fs::File::create(local_path)
+            .await
+            .with_context(|| format!("create {}", local_path.display()))?;
+        let mut stream = resp.bytes_stream();
+        let mut transferred: u64 = 0;
+        let mut last_emit = Instant::now();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("box chunk for {remote_path}"))?;
+            file.write_all(&chunk).await?;
+            transferred += chunk.len() as u64;
+            if last_emit.elapsed() > Duration::from_millis(100) {
+                self.update(id, |t| t.transferred = transferred).await;
+                if let Some(t) = self.get(id).await {
+                    let _ = app.emit("transfer://progress", &t);
+                }
+                last_emit = Instant::now();
+            }
+        }
+        file.flush().await?;
+        self.update(id, |t| t.transferred = transferred).await;
+        Ok(())
+    }
+
+    /// Upload to Box via multipart/form-data: a new file (`/files/content` with
+    /// attributes) or a new version of an existing one (`/files/{id}/content`).
+    async fn run_box_upload(
+        &self,
+        id: &str,
+        session: Arc<BoxSession>,
+        local_path: &Path,
+        remote_path: &str,
+        _app: &AppHandle,
+    ) -> Result<()> {
+        use crate::session::boxdrive::{basename, normalize, parent_of};
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let size = tokio::fs::metadata(local_path)
+            .await
+            .with_context(|| format!("stat {}", local_path.display()))?
+            .len();
+        let norm = normalize(remote_path);
+        let name = basename(&norm).to_string();
+        let parent_id = session.folder_id(&parent_of(&norm)).await?;
+        let existing = session.find_child(&parent_id, &name).await?;
+        let bytes = tokio::fs::read(local_path)
+            .await
+            .with_context(|| format!("read {}", local_path.display()))?;
+        let token = session.access_token().await?;
+
+        let file_part = reqwest::multipart::Part::bytes(bytes).file_name(name.clone());
+        let (url, form) = match existing {
+            Some((file_id, false)) => (
+                format!("{}/files/{file_id}/content", session.upload_base),
+                reqwest::multipart::Form::new().part("file", file_part),
+            ),
+            _ => {
+                let attrs = serde_json::json!({ "name": name, "parent": { "id": parent_id } });
+                (
+                    format!("{}/files/content", session.upload_base),
+                    reqwest::multipart::Form::new()
+                        .text("attributes", attrs.to_string())
+                        .part("file", file_part),
+                )
+            }
+        };
+        let resp = session
+            .client
+            .post(&url)
+            .bearer_auth(&token)
+            .multipart(form)
+            .send()
+            .await
+            .with_context(|| format!("upload {remote_path}"))?;
+        if !resp.status().is_success() {
+            let code = resp.status().as_u16();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!("upload {remote_path} failed ({code}): {text}"));
+        }
+        session.clear_cache();
+        self.update(id, |t| t.transferred = size).await;
+        Ok(())
+    }
 }
 
 /// Build a RemoteFs handle for the right backend.
@@ -1590,6 +1717,7 @@ fn fs_for_session(session: &Arc<Session>) -> Box<dyn crate::remotefs::RemoteFs> 
         Session::Dropbox(dbx) => Box::new(crate::remotefs::dropbox::DropboxFs::new(dbx.clone())),
         Session::OneDrive(od) => Box::new(crate::remotefs::onedrive::OneDriveFs::new(od.clone())),
         Session::GDrive(gd) => Box::new(crate::remotefs::gdrive::GDriveFs::new(gd.clone())),
+        Session::Box(bx) => Box::new(crate::remotefs::boxdrive::BoxFs::new(bx.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
     }
 }
@@ -1673,6 +1801,7 @@ async fn remote_size(session: &Arc<Session>, path: &str) -> Result<u64> {
         }
         Session::OneDrive(od) => Ok(od.size(&crate::remotefs::onedrive::item_ref(path)).await),
         Session::GDrive(gd) => Ok(gd.size(path).await),
+        Session::Box(bx) => Ok(bx.size(path).await),
         Session::Agent(agent) => Ok(agent_stat(agent, path).await.0),
     }
 }
@@ -1826,6 +1955,25 @@ async fn remote_resolve(
                         let (stem, ext) = split_ext(initial_remote);
                         candidate = format!("{stem}_{i}{ext}");
                         if !gd.exists(&candidate).await {
+                            break;
+                        }
+                    }
+                    (candidate, false)
+                }
+            })
+        }
+        Session::Box(bx) => {
+            let exists = bx.exists(initial_remote).await;
+            Ok(match policy {
+                OverwritePolicy::Overwrite => (initial_remote.to_string(), false),
+                OverwritePolicy::Skip => (initial_remote.to_string(), exists),
+                OverwritePolicy::Rename if !exists => (initial_remote.to_string(), false),
+                OverwritePolicy::Rename => {
+                    let mut candidate = initial_remote.to_string();
+                    for i in 1..=999 {
+                        let (stem, ext) = split_ext(initial_remote);
+                        candidate = format!("{stem}_{i}{ext}");
+                        if !bx.exists(&candidate).await {
                             break;
                         }
                     }

--- a/src-tauri/src/transfer.rs
+++ b/src-tauri/src/transfer.rs
@@ -1,4 +1,4 @@
-use crate::session::{FtpSession, ObjectSession, Session, SshSession};
+use crate::session::{FtpSession, ObjectSession, Session, SshSession, WebdavSession};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -243,6 +243,16 @@ impl TransferManager {
                     )
                     .await
                 }
+                Session::Webdav(dav) => {
+                    mgr.run_webdav_download(
+                        &id_for_task,
+                        dav.clone(),
+                        &remote_path,
+                        &final_path,
+                        &app,
+                    )
+                    .await
+                }
                 Session::Agent(agent) => {
                     mgr.run_agent_download(
                         &id_for_task,
@@ -432,6 +442,16 @@ impl TransferManager {
                     mgr.run_object_upload(
                         &id_for_task,
                         obj.clone(),
+                        &local,
+                        &final_remote,
+                        &app,
+                    )
+                    .await
+                }
+                Session::Webdav(dav) => {
+                    mgr.run_webdav_upload(
+                        &id_for_task,
+                        dav.clone(),
                         &local,
                         &final_remote,
                         &app,
@@ -906,6 +926,100 @@ impl TransferManager {
         self.update(id, |t| t.transferred = transferred).await;
         Ok(())
     }
+
+    /// Stream a WebDAV download: a single ranged-capable `GET`, written to the
+    /// local file chunk by chunk so progress is real (not 0→size at the end).
+    async fn run_webdav_download(
+        &self,
+        id: &str,
+        session: Arc<WebdavSession>,
+        remote_path: &str,
+        local_path: &Path,
+        app: &AppHandle,
+    ) -> Result<()> {
+        use futures::StreamExt;
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+
+        let url = session.url_for(remote_path, false);
+        let resp = session
+            .request(reqwest::Method::GET, url)
+            .send()
+            .await
+            .with_context(|| format!("GET {remote_path}"))?;
+        if !resp.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "download {remote_path} failed: HTTP {}",
+                resp.status().as_u16()
+            ));
+        }
+
+        let mut file = tokio::fs::File::create(local_path)
+            .await
+            .with_context(|| format!("create {}", local_path.display()))?;
+        let mut stream = resp.bytes_stream();
+        let mut transferred: u64 = 0;
+        let mut last_emit = Instant::now();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("webdav chunk for {remote_path}"))?;
+            file.write_all(&chunk).await?;
+            transferred += chunk.len() as u64;
+            if last_emit.elapsed() > Duration::from_millis(100) {
+                self.update(id, |t| t.transferred = transferred).await;
+                if let Some(t) = self.get(id).await {
+                    let _ = app.emit("transfer://progress", &t);
+                }
+                last_emit = Instant::now();
+            }
+        }
+        file.flush().await?;
+        self.update(id, |t| t.transferred = transferred).await;
+        Ok(())
+    }
+
+    /// Upload via WebDAV `PUT`, streaming the file body straight off disk (no
+    /// full-file buffering) with an explicit Content-Length so servers accept it.
+    async fn run_webdav_upload(
+        &self,
+        id: &str,
+        session: Arc<WebdavSession>,
+        local_path: &Path,
+        remote_path: &str,
+        app: &AppHandle,
+    ) -> Result<()> {
+        use tokio_util::io::ReaderStream;
+
+        self.update(id, |t| t.status = TransferStatus::Transferring)
+            .await;
+        let _ = app; // WebDAV PUT reports at completion, like the FTP path.
+
+        let size = tokio::fs::metadata(local_path)
+            .await
+            .with_context(|| format!("stat {}", local_path.display()))?
+            .len();
+        let file = tokio::fs::File::open(local_path)
+            .await
+            .with_context(|| format!("open {}", local_path.display()))?;
+        let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+
+        let url = session.url_for(remote_path, false);
+        let resp = session
+            .request(reqwest::Method::PUT, url)
+            .header(reqwest::header::CONTENT_LENGTH, size)
+            .body(body)
+            .send()
+            .await
+            .with_context(|| format!("PUT {remote_path}"))?;
+        if !resp.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "upload {remote_path} failed: HTTP {}",
+                resp.status().as_u16()
+            ));
+        }
+        self.update(id, |t| t.transferred = size).await;
+        Ok(())
+    }
 }
 
 /// Build a RemoteFs handle for the right backend.
@@ -916,7 +1030,26 @@ fn fs_for_session(session: &Arc<Session>) -> Box<dyn crate::remotefs::RemoteFs> 
         Session::Object(obj) => {
             Box::new(crate::remotefs::object::ObjectFs::new(obj.clone()))
         }
+        Session::Webdav(dav) => Box::new(crate::remotefs::webdav::WebdavFs::new(dav.clone())),
         Session::Agent(agent) => Box::new(crate::remotefs::agent::AgentFs::new(agent.clone())),
+    }
+}
+
+/// HEAD a WebDAV resource, returning its size (from Content-Length) and whether
+/// it exists. Best-effort: a server that rejects HEAD reports (0, false).
+async fn webdav_head(session: &Arc<WebdavSession>, path: &str) -> (u64, bool) {
+    let url = session.url_for(path, false);
+    match session.request(reqwest::Method::HEAD, url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let size = resp
+                .headers()
+                .get(reqwest::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(0);
+            (size, true)
+        }
+        _ => (0, false),
     }
 }
 
@@ -960,6 +1093,7 @@ async fn remote_size(session: &Arc<Session>, path: &str) -> Result<u64> {
                 .with_context(|| format!("object head {key}"))?;
             Ok(meta.size as u64)
         }
+        Session::Webdav(dav) => Ok(webdav_head(dav, path).await.0),
         Session::Agent(agent) => Ok(agent_stat(agent, path).await.0),
     }
 }
@@ -1027,6 +1161,25 @@ async fn remote_resolve(
                         let key = candidate.trim_start_matches('/');
                         let p = object_store::path::Path::from(key);
                         if obj.store.head(&p).await.is_err() {
+                            break;
+                        }
+                    }
+                    (candidate, false)
+                }
+            })
+        }
+        Session::Webdav(dav) => {
+            let (_, exists) = webdav_head(dav, initial_remote).await;
+            Ok(match policy {
+                OverwritePolicy::Overwrite => (initial_remote.to_string(), false),
+                OverwritePolicy::Skip => (initial_remote.to_string(), exists),
+                OverwritePolicy::Rename if !exists => (initial_remote.to_string(), false),
+                OverwritePolicy::Rename => {
+                    let mut candidate = initial_remote.to_string();
+                    for i in 1..=999 {
+                        let (stem, ext) = split_ext(initial_remote);
+                        candidate = format!("{stem}_{i}{ext}");
+                        if !webdav_head(dav, &candidate).await.1 {
                             break;
                         }
                     }

--- a/src-tauri/tests/box_mock.py
+++ b/src-tauri/tests/box_mock.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Minimal in-memory mock of the Box API v2 + OAuth token endpoint, for the
+`live_box_roundtrip` test in `src/remotefs/boxdrive.rs`.
+
+Box is ID-addressed (root id "0"), so this models an id→node tree and just enough
+endpoints to exercise Faro's resolver + RemoteFs/transfer ops (token exchange,
+401→refresh, list folder items, create folder, multipart upload, download, move
+via PUT, recursive delete) without a real account.
+
+Run:  python src-tauri/tests/box_mock.py <port>
+Auth: Box calls need Authorization: Bearer ACCESS1|ACCESS-REFRESHED.
+"""
+import hashlib
+import json
+import sys
+from urllib.parse import urlparse, parse_qs
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+VALID_TOKENS = {"ACCESS1", "ACCESS-REFRESHED"}
+# id -> {name, type:"folder"|"file", parent:id, content: bytes|None}
+NODES = {}
+_next = [0]
+
+
+def new_id():
+    _next[0] += 1
+    return str(1000 + _next[0])
+
+
+def meta(fid):
+    n = NODES[fid]
+    m = {"id": fid, "name": n["name"], "type": n["type"]}
+    if n["type"] == "file" and n["content"] is not None:
+        m["size"] = len(n["content"])
+        m["modified_at"] = "2024-07-15T09:30:00-07:00"
+        m["sha1"] = hashlib.sha1(n["content"]).hexdigest()
+    return m
+
+
+def parse_form(body, boundary):
+    """Return {field_name: bytes} for a multipart/form-data body."""
+    out = {}
+    for seg in body.split(b"--" + boundary.encode()):
+        i = seg.find(b"\r\n\r\n")
+        if i < 0:
+            continue
+        head = seg[:i].decode(errors="replace")
+        if 'name="' not in head:
+            continue
+        name = head.split('name="', 1)[1].split('"', 1)[0]
+        out[name] = seg[i + 4:].rstrip(b"\r\n")
+    return out
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj=None, raw=None):
+        body = raw if raw is not None else json.dumps(obj or {}).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/octet-stream" if raw is not None
+                         else "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _authed(self):
+        if self.headers.get("Authorization", "")[7:] not in VALID_TOKENS:
+            self._send(401, {"code": "unauthorized"})
+            return False
+        return True
+
+    def _body(self):
+        n = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(n) if n else b""
+
+    def do_POST(self):
+        u = urlparse(self.path)
+        raw = self._body()
+        if u.path.endswith("/token"):
+            form = dict(kv.split("=", 1) for kv in raw.decode().split("&") if "=" in kv)
+            if form.get("grant_type") == "refresh_token":
+                return self._send(200, {"access_token": "ACCESS-REFRESHED",
+                                        "token_type": "bearer", "expires_in": 3600})
+            return self._send(200, {"access_token": "ACCESS1", "refresh_token": "REFRESH1",
+                                    "token_type": "bearer", "expires_in": 3600})
+        if not self._authed():
+            return
+        # Uploads: /files/content (new) or /files/{id}/content (new version).
+        if "/files/content" in u.path or u.path.endswith("/content"):
+            boundary = self.headers.get("Content-Type", "").split("boundary=", 1)[1]
+            fields = parse_form(raw, boundary)
+            media = fields.get("file", b"")
+            if u.path.endswith("/files/content"):
+                attrs = json.loads(fields.get("attributes", b"{}"))
+                fid = new_id()
+                NODES[fid] = {"name": attrs["name"], "type": "file",
+                              "parent": attrs["parent"]["id"], "content": media}
+            else:
+                fid = u.path.rsplit("/", 2)[-2]           # /files/{id}/content
+                NODES[fid]["content"] = media
+            return self._send(201, {"total_count": 1, "entries": [meta(fid)]})
+        if u.path.endswith("/folders"):
+            m = json.loads(raw or b"null")
+            fid = new_id()
+            NODES[fid] = {"name": m["name"], "type": "folder",
+                          "parent": m["parent"]["id"], "content": None}
+            return self._send(201, meta(fid))
+        self._send(400, {"code": "unknown"})
+
+    def do_PUT(self):
+        if not self._authed():
+            return
+        raw = self._body()
+        fid = urlparse(self.path).path.rsplit("/", 1)[-1]
+        m = json.loads(raw or b"null")
+        if "name" in m:
+            NODES[fid]["name"] = m["name"]
+        if "parent" in m:
+            NODES[fid]["parent"] = m["parent"]["id"]
+        self._send(200, meta(fid))
+
+    def do_DELETE(self):
+        if not self._authed():
+            return
+        fid = urlparse(self.path).path.rsplit("/", 1)[-1]
+
+        def rm(x):
+            for c in [k for k, n in NODES.items() if n["parent"] == x]:
+                rm(c)
+            NODES.pop(x, None)
+        rm(fid)
+        self._send(204)
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        if not self._authed():
+            return
+        if u.path.endswith("/users/me"):
+            return self._send(200, {"login": "tester@example.com", "name": "Test User"})
+        if u.path.endswith("/content"):                   # /files/{id}/content
+            fid = u.path.rsplit("/", 2)[-2]
+            return self._send(200, raw=NODES.get(fid, {}).get("content") or b"")
+        if "/folders/" in u.path and u.path.endswith("/items"):
+            parent = u.path.split("/folders/", 1)[1].split("/", 1)[0]
+            entries = [meta(k) for k, n in NODES.items() if n["parent"] == parent]
+            return self._send(200, {"entries": entries, "total_count": len(entries),
+                                    "offset": 0, "limit": 1000})
+        # /files/{id}?fields=size
+        fid = u.path.rsplit("/", 1)[-1]
+        if fid in NODES:
+            return self._send(200, meta(fid))
+        self._send(404, {"code": "not_found"})
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8823
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()

--- a/src-tauri/tests/dropbox_mock.py
+++ b/src-tauri/tests/dropbox_mock.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""A minimal in-memory mock of the Dropbox OAuth token endpoint + API v2, used by
+the `live_dropbox_roundtrip` integration test in `src/remotefs/dropbox.rs`.
+
+It is NOT a faithful Dropbox — just enough of the shapes Faro's DropboxSession /
+DropboxFs actually call, so the whole client path (token exchange, 401→refresh
+retry, list/upload/download/move/delete) can be exercised without a real account.
+
+Run:  python src-tauri/tests/dropbox_mock.py <port>
+Endpoints (same host serves api + content bases):
+  POST /oauth2/token                     grant_type=authorization_code | refresh_token
+  POST /2/users/get_current_account
+  POST /2/files/list_folder[/continue]
+  POST /2/files/get_metadata
+  POST /2/files/create_folder_v2 | move_v2 | delete_v2
+  POST /2/files/upload    (content; Dropbox-API-Arg header, octet-stream body)
+  POST /2/files/download  (content; Dropbox-API-Arg header)
+Auth: API calls need `Authorization: Bearer ACCESS1|ACCESS-REFRESHED`, else 401.
+"""
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+VALID_TOKENS = {"ACCESS1", "ACCESS-REFRESHED"}
+
+# In-memory tree. files: path -> bytes; folders: set of paths. Paths look like
+# "/a/b"; root is "".
+FILES = {}
+FOLDERS = set()
+
+
+def meta(path, is_dir):
+    name = path.rsplit("/", 1)[-1] or path
+    if is_dir:
+        return {".tag": "folder", "name": name,
+                "path_display": path, "path_lower": path.lower(), "id": "id:" + path}
+    data = FILES.get(path, b"")
+    return {".tag": "file", "name": name, "path_display": path,
+            "path_lower": path.lower(), "size": len(data),
+            "server_modified": "2024-07-15T09:30:00Z", "rev": "01rev" + str(len(data)),
+            "id": "id:" + path}
+
+
+def direct_children(parent):
+    prefix = (parent + "/") if parent else "/"
+    out = []
+    for p in list(FOLDERS):
+        if p.startswith(prefix) and "/" not in p[len(prefix):] and p[len(prefix):]:
+            out.append(meta(p, True))
+    for p in list(FILES):
+        if p.startswith(prefix) and "/" not in p[len(prefix):] and p[len(prefix):]:
+            out.append(meta(p, False))
+    return out
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj=None, raw=None, headers=None):
+        body = raw if raw is not None else json.dumps(obj or {}).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/octet-stream" if raw is not None
+                         else "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (headers or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _authed(self):
+        auth = self.headers.get("Authorization", "")
+        token = auth[7:] if auth.startswith("Bearer ") else ""
+        if token not in VALID_TOKENS:
+            self._send(401, {"error_summary": "invalid_access_token/"})
+            return False
+        return True
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(n) if n else b""
+        path = self.path.split("?", 1)[0]
+
+        if path == "/oauth2/token":
+            form = dict(kv.split("=", 1) for kv in raw.decode().split("&") if "=" in kv)
+            if form.get("grant_type") == "refresh_token":
+                return self._send(200, {"access_token": "ACCESS-REFRESHED",
+                                        "token_type": "bearer", "expires_in": 3600})
+            return self._send(200, {"access_token": "ACCESS1", "refresh_token": "REFRESH1",
+                                    "token_type": "bearer", "expires_in": 3600,
+                                    "account_id": "dbid:1"})
+
+        # Content endpoints carry their arg in a header, body is the file bytes.
+        if path == "/2/files/upload":
+            if not self._authed():
+                return
+            arg = json.loads(self.headers.get("Dropbox-API-Arg", "{}"))
+            FILES[arg["path"]] = raw
+            return self._send(200, meta(arg["path"], False))
+        if path == "/2/files/download":
+            if not self._authed():
+                return
+            arg = json.loads(self.headers.get("Dropbox-API-Arg", "{}"))
+            data = FILES.get(arg["path"])
+            if data is None:
+                return self._send(409, {"error_summary": "path/not_found/"})
+            return self._send(200, raw=data,
+                              headers={"Dropbox-API-Result": json.dumps(meta(arg["path"], False))})
+
+        # RPC endpoints: JSON body.
+        if not self._authed():
+            return
+        body = json.loads(raw.decode() or "null")
+
+        if path == "/2/users/get_current_account":
+            return self._send(200, {"account_id": "dbid:1", "email": "tester@example.com",
+                                    "name": {"display_name": "Test User"}})
+        if path == "/2/files/list_folder":
+            return self._send(200, {"entries": direct_children(body.get("path", "")),
+                                    "cursor": "CUR", "has_more": False})
+        if path == "/2/files/list_folder/continue":
+            return self._send(200, {"entries": [], "cursor": "CUR", "has_more": False})
+        if path == "/2/files/get_metadata":
+            p = body["path"]
+            if p in FILES:
+                return self._send(200, meta(p, False))
+            if p in FOLDERS:
+                return self._send(200, meta(p, True))
+            return self._send(409, {"error_summary": "path/not_found/"})
+        if path == "/2/files/create_folder_v2":
+            FOLDERS.add(body["path"])
+            return self._send(200, {"metadata": meta(body["path"], True)})
+        if path == "/2/files/move_v2":
+            src, dst = body["from_path"], body["to_path"]
+            if src in FILES:
+                FILES[dst] = FILES.pop(src)
+            elif src in FOLDERS:
+                FOLDERS.discard(src)
+                FOLDERS.add(dst)
+            return self._send(200, {"metadata": meta(dst, dst in FOLDERS)})
+        if path == "/2/files/delete_v2":
+            p = body["path"]
+            was_dir = p in FOLDERS
+            for f in list(FILES):
+                if f == p or f.startswith(p + "/"):
+                    FILES.pop(f, None)
+            for d in list(FOLDERS):
+                if d == p or d.startswith(p + "/"):
+                    FOLDERS.discard(d)
+            return self._send(200, {"metadata": meta(p, was_dir)})
+
+        self._send(409, {"error_summary": "unknown_endpoint/"})
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8820
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()

--- a/src-tauri/tests/gdrive_mock.py
+++ b/src-tauri/tests/gdrive_mock.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Minimal in-memory mock of the Google Drive v3 API + OAuth token endpoint, for
+the `live_gdrive_roundtrip` test in `src/remotefs/gdrive.rs`.
+
+Drive is ID-addressed, so this models an id→node tree and just enough endpoints to
+exercise Faro's path↔id resolver and the RemoteFs/transfer ops (token exchange,
+401→refresh, list via q, create folder, multipart create, media update, download,
+move via addParents/removeParents, delete) without a real account.
+
+Run:  python src-tauri/tests/gdrive_mock.py <port>
+Auth: Drive calls need Authorization: Bearer ACCESS1|ACCESS-REFRESHED.
+"""
+import hashlib
+import json
+import sys
+from urllib.parse import urlparse, parse_qs, unquote
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+VALID_TOKENS = {"ACCESS1", "ACCESS-REFRESHED"}
+FOLDER_MIME = "application/vnd.google-apps.folder"
+# id -> {name, mimeType, parents:[ids], content: bytes|None}
+NODES = {}
+_next = [0]
+
+
+def new_id():
+    _next[0] += 1
+    return f"id{_next[0]}"
+
+
+def meta(fid):
+    n = NODES[fid]
+    m = {"id": fid, "name": n["name"], "mimeType": n["mimeType"],
+         "modifiedTime": "2024-07-15T09:30:00Z"}
+    if n["mimeType"] != FOLDER_MIME and n["content"] is not None:
+        m["size"] = str(len(n["content"]))
+        m["md5Checksum"] = hashlib.md5(n["content"]).hexdigest()
+    return m
+
+
+def parse_multipart(body, boundary):
+    delim = b"--" + boundary.encode()
+    segs = body.split(delim)
+
+    def payload(seg):
+        i = seg.find(b"\r\n\r\n")
+        return seg[i + 4:].rstrip(b"\r\n")
+
+    return json.loads(payload(segs[1])), payload(segs[2])
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj=None, raw=None):
+        body = raw if raw is not None else json.dumps(obj or {}).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/octet-stream" if raw is not None
+                         else "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _authed(self):
+        if self.headers.get("Authorization", "")[7:] not in VALID_TOKENS:
+            self._send(401, {"error": {"code": 401, "message": "invalid"}})
+            return False
+        return True
+
+    def _body(self):
+        n = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(n) if n else b""
+
+    def do_POST(self):
+        u = urlparse(self.path)
+        raw = self._body()
+        if u.path.endswith("/token"):
+            form = dict(kv.split("=", 1) for kv in raw.decode().split("&") if "=" in kv)
+            if form.get("grant_type") == "refresh_token":
+                return self._send(200, {"access_token": "ACCESS-REFRESHED",
+                                        "token_type": "Bearer", "expires_in": 3600})
+            return self._send(200, {"access_token": "ACCESS1", "refresh_token": "REFRESH1",
+                                    "token_type": "Bearer", "expires_in": 3600})
+        if not self._authed():
+            return
+        q = parse_qs(u.query)
+        if u.path.endswith("/files") and q.get("uploadType", [""])[0] == "multipart":
+            ctype = self.headers.get("Content-Type", "")
+            boundary = ctype.split("boundary=", 1)[1]
+            m, media = parse_multipart(raw, boundary)
+            fid = new_id()
+            NODES[fid] = {"name": m["name"], "mimeType": "application/octet-stream",
+                          "parents": m.get("parents", []), "content": media}
+            return self._send(200, meta(fid))
+        if u.path.endswith("/files"):                       # create folder (metadata only)
+            m = json.loads(raw or b"null")
+            fid = new_id()
+            NODES[fid] = {"name": m["name"], "mimeType": m.get("mimeType", FOLDER_MIME),
+                          "parents": m.get("parents", []), "content": None}
+            return self._send(200, meta(fid))
+        self._send(400, {"error": {"message": "unknown"}})
+
+    def do_PATCH(self):
+        if not self._authed():
+            return
+        u = urlparse(self.path)
+        raw = self._body()
+        fid = u.path.rsplit("/", 1)[-1]
+        q = parse_qs(u.query)
+        if q.get("uploadType", [""])[0] == "media":         # update content
+            NODES[fid]["content"] = raw
+            return self._send(200, meta(fid))
+        body = json.loads(raw or b"null")                   # rename / move
+        if "name" in body:
+            NODES[fid]["name"] = body["name"]
+        add = q.get("addParents", [None])[0]
+        rem = q.get("removeParents", [None])[0]
+        if rem and rem in NODES[fid]["parents"]:
+            NODES[fid]["parents"].remove(rem)
+        if add and add not in NODES[fid]["parents"]:
+            NODES[fid]["parents"].append(add)
+        self._send(200, meta(fid))
+
+    def do_DELETE(self):
+        if not self._authed():
+            return
+        fid = urlparse(self.path).path.rsplit("/", 1)[-1]
+
+        def rm(x):
+            for c in [k for k, n in NODES.items() if x in n["parents"]]:
+                rm(c)
+            NODES.pop(x, None)
+        rm(fid)
+        self._send(204)
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        if not self._authed():
+            return
+        if u.path.endswith("/about"):
+            return self._send(200, {"user": {"emailAddress": "tester@example.com",
+                                             "displayName": "Test User"}})
+        q = parse_qs(u.query)
+        if u.path.endswith("/files"):                       # list by q
+            query = q.get("q", [""])[0]
+            parent = query.split("'", 2)[1] if "in parents" in query else "root"
+            name = None
+            if "name = '" in query:
+                name = query.split("name = '", 1)[1].split("'", 1)[0]
+            files = []
+            for fid, n in NODES.items():
+                if parent in n["parents"] and (name is None or n["name"] == name):
+                    files.append(meta(fid))
+            return self._send(200, {"files": files})
+        # /files/{id}
+        fid = u.path.rsplit("/", 1)[-1]
+        if fid not in NODES:
+            return self._send(404, {"error": {"code": 404}})
+        if q.get("alt", [""])[0] == "media":
+            return self._send(200, raw=NODES[fid]["content"] or b"")
+        self._send(200, meta(fid))
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8822
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()

--- a/src-tauri/tests/onedrive_mock.py
+++ b/src-tauri/tests/onedrive_mock.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Minimal in-memory mock of the Microsoft Graph OneDrive API + OAuth token
+endpoint, for the `live_onedrive_roundtrip` test in `src/remotefs/onedrive.rs`.
+
+Just enough of the shapes Faro's OneDriveSession/OneDriveFs call to exercise the
+whole client path (token exchange, 401→refresh, list/create/upload/download/
+move/delete) without a real Microsoft account.
+
+Run:  python src-tauri/tests/onedrive_mock.py <port>
+Auth: Graph calls need Authorization: Bearer ACCESS1|ACCESS-REFRESHED.
+"""
+import json
+import sys
+from urllib.parse import unquote
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+VALID_TOKENS = {"ACCESS1", "ACCESS-REFRESHED"}
+FILES = {}     # "/a/b" -> bytes
+FOLDERS = set()
+ROOT = "/me/drive/root"
+
+
+def meta(path, is_dir):
+    name = path.rsplit("/", 1)[-1] or path
+    m = {"name": name, "id": "id:" + path,
+         "lastModifiedDateTime": "2024-07-15T09:30:00Z", "cTag": "ctag:" + path}
+    if is_dir:
+        m["folder"] = {"childCount": 0}
+        m["size"] = 0
+    else:
+        m["file"] = {"mimeType": "application/octet-stream"}
+        m["size"] = len(FILES.get(path, b""))
+    return m
+
+
+def children(parent):
+    prefix = (parent + "/") if parent else "/"
+    out = []
+    for p in list(FOLDERS):
+        if p.startswith(prefix) and "/" not in p[len(prefix):] and p[len(prefix):]:
+            out.append(meta(p, True))
+    for p in list(FILES):
+        if p.startswith(prefix) and "/" not in p[len(prefix):] and p[len(prefix):]:
+            out.append(meta(p, False))
+    return out
+
+
+def parse_ref(path):
+    """(item_path, suffix) from a Graph URL path. item_path is decoded, '' at root."""
+    if path == ROOT:
+        return "", ""
+    if path == ROOT + "/children":
+        return "", "children"
+    if path.startswith(ROOT + ":/"):
+        rest = path[len(ROOT) + 2:]           # "a/b:/children" | "a/b:"
+        item_enc, _, after = rest.partition(":")
+        suffix = after.lstrip("/")
+        return "/" + unquote(item_enc), suffix
+    return None, None
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj=None, raw=None, headers=None):
+        body = raw if raw is not None else json.dumps(obj or {}).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/octet-stream" if raw is not None
+                         else "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (headers or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _authed(self):
+        token = self.headers.get("Authorization", "")[7:]
+        if token not in VALID_TOKENS:
+            self._send(401, {"error": {"code": "InvalidAuthenticationToken"}})
+            return False
+        return True
+
+    def _body(self):
+        n = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(n) if n else b""
+
+    def do_POST(self):
+        path = self.path.split("?", 1)[0]
+        raw = self._body()
+
+        if path.endswith("/oauth2/token") or path.endswith("/token"):
+            form = dict(kv.split("=", 1) for kv in raw.decode().split("&") if "=" in kv)
+            if form.get("grant_type") == "refresh_token":
+                return self._send(200, {"access_token": "ACCESS-REFRESHED",
+                                        "token_type": "Bearer", "expires_in": 3600})
+            return self._send(200, {"access_token": "ACCESS1", "refresh_token": "REFRESH1",
+                                    "token_type": "Bearer", "expires_in": 3600})
+
+        # Resumable upload chunk PUTs land here (see do_PUT); POST handles RPC.
+        if not self._authed():
+            return
+        item, suffix = parse_ref(path)
+        if suffix == "children":                      # create folder
+            body = json.loads(raw or b"null")
+            new = (item.rstrip("/") + "/" + body["name"]) if item else "/" + body["name"]
+            FOLDERS.add(new)
+            return self._send(201, meta(new, True))
+        if suffix == "createUploadSession":
+            return self._send(200, {"uploadUrl": f"http://{self.headers['Host']}"
+                                    f"/upload-session?item={item}"})
+        self._send(400, {"error": {"code": "unknown"}})
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if not self._authed():
+            return
+        if path == "/me":
+            return self._send(200, {"userPrincipalName": "tester@example.com",
+                                    "displayName": "Test User", "id": "u1"})
+        item, suffix = parse_ref(path)
+        if suffix == "children":
+            return self._send(200, {"value": children(item)})
+        if suffix == "content":
+            data = FILES.get(item)
+            if data is None:
+                return self._send(404, {"error": {"code": "itemNotFound"}})
+            return self._send(200, raw=data)
+        if suffix == "":                              # metadata
+            if item in FILES:
+                return self._send(200, meta(item, False))
+            if item in FOLDERS:
+                return self._send(200, meta(item, True))
+            return self._send(404, {"error": {"code": "itemNotFound"}})
+        self._send(404, {"error": {"code": "itemNotFound"}})
+
+    def do_PUT(self):
+        path = self.path.split("?", 1)[0]
+        raw = self._body()
+        # Resumable upload chunk — the uploadUrl carries ?item=… and needs no auth.
+        if path == "/upload-session":
+            from urllib.parse import urlparse, parse_qs
+            item = parse_qs(urlparse(self.path).query).get("item", [""])[0]
+            rng = self.headers.get("Content-Range", "")
+            # "bytes start-end/total"
+            span, _, total = rng[len("bytes "):].partition("/")
+            start, _, end = span.partition("-")
+            buf = FILES.get(item, b"") if int(start) else b""
+            FILES[item] = buf + raw
+            if int(end) + 1 >= int(total):
+                return self._send(201, meta(item, False))
+            return self._send(202, {"nextExpectedRanges": [f"{int(end)+1}-"]})
+        # Simple upload PUT …/content.
+        if not self._authed():
+            return
+        item, suffix = parse_ref(path)
+        if suffix == "content":
+            FILES[item] = raw
+            return self._send(201, meta(item, False))
+        self._send(400, {"error": {"code": "unknown"}})
+
+    def do_PATCH(self):
+        if not self._authed():
+            return
+        raw = self._body()
+        item, _ = parse_ref(self.path.split("?", 1)[0])
+        body = json.loads(raw or b"null")
+        name = body["name"]
+        pref = body.get("parentReference", {}).get("path", "/drive/root:")
+        parent = "" if pref == "/drive/root:" else "/" + unquote(pref[len("/drive/root:/"):])
+        new = (parent.rstrip("/") + "/" + name) if parent else "/" + name
+        if item in FILES:
+            FILES[new] = FILES.pop(item)
+        elif item in FOLDERS:
+            FOLDERS.discard(item)
+            FOLDERS.add(new)
+        self._send(200, meta(new, new in FOLDERS))
+
+    def do_DELETE(self):
+        if not self._authed():
+            return
+        item, _ = parse_ref(self.path.split("?", 1)[0])
+        for f in list(FILES):
+            if f == item or f.startswith(item + "/"):
+                FILES.pop(f, None)
+        for d in list(FOLDERS):
+            if d == item or d.startswith(item + "/"):
+                FOLDERS.discard(d)
+        self._send(204)
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8821
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,7 +595,7 @@ function DeepLinkListener() {
 /// Map a parsed deep link to editor seed values. `pair` links become a
 /// faro-agent profile; everything else a server profile of the named protocol.
 function deepLinkToPrefill(dl: DeepLink): Partial<ConnectionProfile> {
-  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "faro-agent"];
+  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "faro-agent"];
   const protocol: Protocol =
     dl.action === "pair"
       ? "faro-agent"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,7 +595,7 @@ function DeepLinkListener() {
 /// Map a parsed deep link to editor seed values. `pair` links become a
 /// faro-agent profile; everything else a server profile of the named protocol.
 function deepLinkToPrefill(dl: DeepLink): Partial<ConnectionProfile> {
-  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "faro-agent"];
+  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "faro-agent"];
   const protocol: Protocol =
     dl.action === "pair"
       ? "faro-agent"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,7 +595,7 @@ function DeepLinkListener() {
 /// Map a parsed deep link to editor seed values. `pair` links become a
 /// faro-agent profile; everything else a server profile of the named protocol.
 function deepLinkToPrefill(dl: DeepLink): Partial<ConnectionProfile> {
-  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "faro-agent"];
+  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "faro-agent"];
   const protocol: Protocol =
     dl.action === "pair"
       ? "faro-agent"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import { KeyboardShortcutsDialog } from "./components/KeyboardShortcutsDialog";
 import { AgentBridge, AgentBridgeHost } from "./components/AgentBridge";
 import { AgentConsoleDock } from "./components/AgentConsole";
 import { AgentChatDock } from "./components/AgentChat";
+import { DiskUsageHost } from "./components/DiskUsage";
 import { useShortcuts } from "./hooks/useShortcuts";
 import { relTime } from "./lib/format";
 import { cn } from "./lib/cn";
@@ -118,6 +119,7 @@ export default function App() {
       <Toaster />
       <AgentBridgeHost />
       <OverwriteDialogHost />
+      <DiskUsageHost />
       <CommandPalette />
       <KeyboardShortcutsDialog />
       <div className="flex flex-1 overflow-hidden">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,7 +595,7 @@ function DeepLinkListener() {
 /// Map a parsed deep link to editor seed values. `pair` links become a
 /// faro-agent profile; everything else a server profile of the named protocol.
 function deepLinkToPrefill(dl: DeepLink): Partial<ConnectionProfile> {
-  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "faro-agent"];
+  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "faro-agent"];
   const protocol: Protocol =
     dl.action === "pair"
       ? "faro-agent"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,7 +595,7 @@ function DeepLinkListener() {
 /// Map a parsed deep link to editor seed values. `pair` links become a
 /// faro-agent profile; everything else a server profile of the named protocol.
 function deepLinkToPrefill(dl: DeepLink): Partial<ConnectionProfile> {
-  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "faro-agent"];
+  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "box", "faro-agent"];
   const protocol: Protocol =
     dl.action === "pair"
       ? "faro-agent"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,7 +595,7 @@ function DeepLinkListener() {
 /// Map a parsed deep link to editor seed values. `pair` links become a
 /// faro-agent profile; everything else a server profile of the named protocol.
 function deepLinkToPrefill(dl: DeepLink): Partial<ConnectionProfile> {
-  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "faro-agent"];
+  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "faro-agent"];
   const protocol: Protocol =
     dl.action === "pair"
       ? "faro-agent"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,7 +595,7 @@ function DeepLinkListener() {
 /// Map a parsed deep link to editor seed values. `pair` links become a
 /// faro-agent profile; everything else a server profile of the named protocol.
 function deepLinkToPrefill(dl: DeepLink): Partial<ConnectionProfile> {
-  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "faro-agent"];
+  const known: Protocol[] = ["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "faro-agent"];
   const protocol: Protocol =
     dl.action === "pair"
       ? "faro-agent"

--- a/src/components/AgentBridge.tsx
+++ b/src/components/AgentBridge.tsx
@@ -645,7 +645,7 @@ export function AgentBridge({ onClose }: { onClose: () => void }) {
                   const isSsh = p.protocol === "sftp";
                   const isAgent = p.protocol === "faro-agent";
                   const canExec = isSsh || isAgent;
-                  const isObject = p.protocol === "s3" || p.protocol === "azure";
+                  const isObject = p.protocol === "s3" || p.protocol === "azure" || p.protocol === "gcs";
                   return (
                     <div
                       key={sessionId}

--- a/src/components/DiskTreemap.tsx
+++ b/src/components/DiskTreemap.tsx
@@ -158,6 +158,7 @@ export function DiskTreemap({
   colorMode,
   onDrill,
   onHover,
+  onContext,
 }: {
   root: DuNode;
   colorMode: ColorMode;
@@ -165,6 +166,8 @@ export function DiskTreemap({
   onDrill: (node: DuNode) => void;
   /** The deepest node under the cursor (null when the cursor leaves). */
   onHover: (node: DuNode | null) => void;
+  /** Right-click on the deepest node under the cursor. */
+  onContext: (node: DuNode, x: number, y: number) => void;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -286,6 +289,15 @@ export function DiskTreemap({
     if (cell) onDrill(cell.node);
   };
 
+  const onContextMenu = (e: React.MouseEvent) => {
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const cell = cellAt(e.clientX - rect.left, e.clientY - rect.top, false);
+    if (cell) {
+      e.preventDefault();
+      onContext(cell.node, e.clientX, e.clientY);
+    }
+  };
+
   return (
     <div ref={wrapRef} className="relative h-full w-full overflow-hidden">
       <canvas
@@ -295,6 +307,7 @@ export function DiskTreemap({
         onMouseMove={onMove}
         onMouseLeave={onLeave}
         onClick={onClick}
+        onContextMenu={onContextMenu}
         title={
           hoverPath
             ? undefined

--- a/src/components/DiskTreemap.tsx
+++ b/src/components/DiskTreemap.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useRef, useState } from "react";
+import type { DuNode } from "@/lib/types";
+import type { ColorMode } from "@/stores/diskScanStore";
+import { fmtSize } from "@/lib/format";
+
+// A squarified-ish treemap on a Canvas. Thousands of rectangles stay smooth on
+// canvas where SVG would choke. Layout is a recursive binary split — each node's
+// children are partitioned into two groups of ~equal total size and the box is
+// cut along its longer axis, which keeps tiles reasonably square without the
+// full squarify bookkeeping. Nested directories draw as inset boxes (WinDirStat
+// look); hover reports the deepest node under the cursor, click drills into the
+// deepest directory there.
+
+interface Cell {
+  node: DuNode;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  depth: number;
+}
+
+const MAX_DEPTH = 6;
+const PAD = 2;
+const MIN_SIDE = 4;
+
+interface SizedChild {
+  node: DuNode;
+  value: number;
+}
+
+/** Split children into two size-balanced groups (input is size-desc sorted). */
+function partition(items: SizedChild[]): [SizedChild[], SizedChild[]] {
+  const total = items.reduce((a, c) => a + c.value, 0);
+  let acc = 0;
+  let i = 0;
+  while (i < items.length - 1 && acc + items[i].value < total / 2) {
+    acc += items[i].value;
+    i++;
+  }
+  // Keep at least one item in each group.
+  if (i > items.length - 2) i = items.length - 2;
+  return [items.slice(0, i + 1), items.slice(i + 1)];
+}
+
+function splitLayout(
+  items: SizedChild[],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  out: { node: DuNode; x: number; y: number; w: number; h: number }[]
+) {
+  if (items.length === 0 || w <= 0 || h <= 0) return;
+  if (items.length === 1) {
+    out.push({ node: items[0].node, x, y, w, h });
+    return;
+  }
+  const [a, b] = partition(items);
+  const aVal = a.reduce((s, c) => s + c.value, 0);
+  const total = aVal + b.reduce((s, c) => s + c.value, 0);
+  if (total <= 0) return;
+  const frac = aVal / total;
+  if (w >= h) {
+    const aw = w * frac;
+    splitLayout(a, x, y, aw, h, out);
+    splitLayout(b, x + aw, y, w - aw, h, out);
+  } else {
+    const ah = h * frac;
+    splitLayout(a, x, y, w, ah, out);
+    splitLayout(b, x, y + ah, w, h - ah, out);
+  }
+}
+
+function buildCells(
+  node: DuNode,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  depth: number,
+  cells: Cell[]
+) {
+  cells.push({ node, x, y, w, h, depth });
+  if (depth >= MAX_DEPTH) return;
+  const kids = (node.children ?? []).filter((c) => c.size > 0);
+  if (kids.length === 0) return;
+  const ix = x + PAD;
+  const iy = y + PAD;
+  const iw = w - PAD * 2;
+  const ih = h - PAD * 2;
+  if (iw < MIN_SIDE * 2 || ih < MIN_SIDE * 2) return;
+  const rects: { node: DuNode; x: number; y: number; w: number; h: number }[] = [];
+  splitLayout(
+    kids.map((k) => ({ node: k, value: k.size })),
+    ix,
+    iy,
+    iw,
+    ih,
+    rects
+  );
+  for (const r of rects) {
+    if (r.w < MIN_SIDE || r.h < MIN_SIDE) {
+      cells.push({ node: r.node, x: r.x, y: r.y, w: r.w, h: r.h, depth: depth + 1 });
+    } else {
+      buildCells(r.node, r.x, r.y, r.w, r.h, depth + 1, cells);
+    }
+  }
+}
+
+// Distinct, pleasant hues for the type palette. Files hash their extension onto
+// this ring; directories are drawn as translucent frames, not fills.
+const TYPE_HUES = [210, 145, 35, 275, 0, 190, 55, 320, 95, 235, 15, 165];
+
+function extHue(name: string): number {
+  const dot = name.lastIndexOf(".");
+  const ext = dot > 0 ? name.slice(dot + 1).toLowerCase() : name.toLowerCase();
+  let h = 0;
+  for (let i = 0; i < ext.length; i++) h = (h * 31 + ext.charCodeAt(i)) >>> 0;
+  return TYPE_HUES[h % TYPE_HUES.length];
+}
+
+/** Read a Faro theme token (an "r g b" triple) as a canvas-ready `rgb(...)`. */
+function rgbVar(name: string): string {
+  const v = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  const [r, g, b] = v.split(/\s+/).map(Number);
+  if ([r, g, b].some(Number.isNaN)) return "rgb(120,120,120)";
+  return `rgb(${r},${g},${b})`;
+}
+
+/** Dark vs light per the active theme's background luminance (works across all
+ *  the named `data-theme` palettes, not just "dark"/"light"). */
+function isDarkTheme(): boolean {
+  const v = getComputedStyle(document.documentElement)
+    .getPropertyValue("--bg")
+    .trim();
+  const [r, g, b] = v.split(/\s+/).map(Number);
+  if ([r, g, b].some(Number.isNaN)) return true;
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b < 128;
+}
+
+function cellFill(cell: Cell, colorMode: ColorMode, dark: boolean): string {
+  if (colorMode === "depth") {
+    const light = dark
+      ? Math.min(60, 22 + cell.depth * 7)
+      : Math.max(45, 82 - cell.depth * 7);
+    return `hsl(210 45% ${light}%)`;
+  }
+  const hue = extHue(cell.node.name);
+  const l = dark ? 52 : 62;
+  return `hsl(${hue} 55% ${l}%)`;
+}
+
+export function DiskTreemap({
+  root,
+  colorMode,
+  onDrill,
+  onHover,
+}: {
+  root: DuNode;
+  colorMode: ColorMode;
+  /** Drill into a directory the user clicked. */
+  onDrill: (node: DuNode) => void;
+  /** The deepest node under the cursor (null when the cursor leaves). */
+  onHover: (node: DuNode | null) => void;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  const cellsRef = useRef<Cell[]>([]);
+  const [hoverPath, setHoverPath] = useState<string | null>(null);
+  // Bumped when the app theme changes so the canvas repaints with fresh tokens.
+  const [themeTick, setThemeTick] = useState(0);
+
+  // Track the pixel box.
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const r = entries[0].contentRect;
+      setSize((prev) =>
+        prev.w === Math.floor(r.width) && prev.h === Math.floor(r.height)
+          ? prev
+          : { w: Math.floor(r.width), h: Math.floor(r.height) }
+      );
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Repaint on theme switches (the app toggles `data-theme` on <html>).
+  useEffect(() => {
+    const mo = new MutationObserver(() => setThemeTick((t) => t + 1));
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => mo.disconnect();
+  }, []);
+
+  // Recompute cells + repaint whenever the node, size, or palette change.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || size.w === 0 || size.h === 0) return;
+    const dark = isDarkTheme();
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = size.w * dpr;
+    canvas.height = size.h * dpr;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, size.w, size.h);
+
+    const cells: Cell[] = [];
+    if (root.size > 0 && (root.children?.length ?? 0) > 0) {
+      buildCells(root, 0, 0, size.w, size.h, 0, cells);
+    }
+    cellsRef.current = cells;
+
+    // Parents first (already ordered that way), so nested children paint on top.
+    for (const cell of cells) {
+      const isLeaf =
+        cell.node.kind !== "directory" ||
+        !cell.node.children ||
+        cell.node.children.length === 0 ||
+        cell.depth >= MAX_DEPTH;
+      if (cell.depth === 0) {
+        // The container itself: neutral backdrop from the theme.
+        ctx.fillStyle = rgbVar("--bg-subtle");
+        ctx.fillRect(cell.x, cell.y, cell.w, cell.h);
+        continue;
+      }
+      if (isLeaf) {
+        ctx.fillStyle = cellFill(cell, colorMode, dark);
+        ctx.fillRect(cell.x, cell.y, cell.w, cell.h);
+        // Hairline separator.
+        ctx.strokeStyle = dark ? "rgba(0,0,0,0.35)" : "rgba(0,0,0,0.15)";
+        ctx.lineWidth = 0.5;
+        ctx.strokeRect(cell.x + 0.25, cell.y + 0.25, cell.w - 0.5, cell.h - 0.5);
+      }
+    }
+
+    // Highlight the hovered cell.
+    if (hoverPath) {
+      const hc = cells.find((c) => c.node.path === hoverPath);
+      if (hc) {
+        ctx.strokeStyle = dark ? "#fff" : "#111";
+        ctx.lineWidth = 1.5;
+        ctx.strokeRect(hc.x + 0.75, hc.y + 0.75, hc.w - 1.5, hc.h - 1.5);
+      }
+    }
+  }, [root, size, colorMode, hoverPath, themeTick]);
+
+  const cellAt = (px: number, py: number, wantDir: boolean): Cell | null => {
+    // Deepest cell (last in array among containers) wins.
+    let best: Cell | null = null;
+    for (const c of cellsRef.current) {
+      if (c.depth === 0) continue;
+      if (px < c.x || px > c.x + c.w || py < c.y || py > c.y + c.h) continue;
+      if (wantDir && c.node.kind !== "directory") continue;
+      if (!best || c.depth >= best.depth) best = c;
+    }
+    return best;
+  };
+
+  const onMove = (e: React.MouseEvent) => {
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const cell = cellAt(e.clientX - rect.left, e.clientY - rect.top, false);
+    const path = cell?.node.path ?? null;
+    if (path !== hoverPath) {
+      setHoverPath(path);
+      onHover(cell?.node ?? null);
+    }
+  };
+
+  const onLeave = () => {
+    setHoverPath(null);
+    onHover(null);
+  };
+
+  const onClick = (e: React.MouseEvent) => {
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const cell = cellAt(e.clientX - rect.left, e.clientY - rect.top, true);
+    if (cell) onDrill(cell.node);
+  };
+
+  return (
+    <div ref={wrapRef} className="relative h-full w-full overflow-hidden">
+      <canvas
+        ref={canvasRef}
+        style={{ width: size.w, height: size.h }}
+        className="block cursor-pointer"
+        onMouseMove={onMove}
+        onMouseLeave={onLeave}
+        onClick={onClick}
+        title={
+          hoverPath
+            ? undefined
+            : "Click a box to drill into a folder"
+        }
+      />
+      {root.size === 0 && (
+        <div className="absolute inset-0 flex items-center justify-center text-xs text-text-dim">
+          Nothing to show — this folder is empty ({fmtSize(0)}).
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/DiskUsage.tsx
+++ b/src/components/DiskUsage.tsx
@@ -10,13 +10,30 @@ import {
   Folder,
   Palette,
   AlertCircle,
+  Eye,
+  Copy,
+  Trash2,
 } from "lucide-react";
-import { useDiskScan, resolveNode, type ColorMode } from "@/stores/diskScanStore";
+import { useDiskScan, resolveNode } from "@/stores/diskScanStore";
+import { useLayout } from "@/stores/layoutStore";
+import { toast } from "@/stores/toastStore";
 import type { DuNode, ScanStrategy } from "@/lib/types";
 import { fmtSize } from "@/lib/format";
-import { materialIconUrl } from "@faro/file-ui";
+import {
+  materialIconUrl,
+  ContextMenu,
+  ConfirmModal,
+  type MenuItem,
+} from "@faro/file-ui";
 import { cn } from "@/lib/cn";
 import { DiskTreemap } from "./DiskTreemap";
+
+/** Parent directory of a POSIX/Windows path (its own root when at top). */
+function parentDir(p: string): string {
+  const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  if (i <= 0) return p.startsWith("/") ? "/" : p;
+  return p.slice(0, i);
+}
 
 const STRATEGY_LABEL: Record<ScanStrategy, string> = {
   generic: "Walk",
@@ -51,8 +68,56 @@ function DiskUsage() {
   const drillTo = useDiskScan((s) => s.drillTo);
   const navigateTo = useDiskScan((s) => s.navigateTo);
   const setColorMode = useDiskScan((s) => s.setColorMode);
+  const removeNode = useDiskScan((s) => s.removeNode);
+  const sessionId = useDiskScan((s) => s.sessionId);
+  const requestReveal = useLayout((s) => s.requestReveal);
 
   const [hover, setHover] = useState<DuNode | null>(null);
+  const [menu, setMenu] = useState<{ x: number; y: number; items: MenuItem[] } | null>(
+    null
+  );
+  const [confirmDel, setConfirmDel] = useState<DuNode | null>(null);
+
+  const reveal = (node: DuNode) => {
+    if (!sessionId) return;
+    const dir = node.kind === "directory" ? node.path : parentDir(node.path);
+    requestReveal(sessionId, dir);
+    close();
+  };
+
+  const copyPath = (node: DuNode) => {
+    navigator.clipboard.writeText(node.path);
+    toast.info("Path copied", node.path);
+  };
+
+  const openMenu = (node: DuNode, x: number, y: number) => {
+    const isRoot = node.path === (tree?.path ?? "");
+    const items: MenuItem[] = [
+      {
+        label:
+          node.kind === "directory"
+            ? "Open in file browser"
+            : "Reveal in file browser",
+        icon: <Eye size={12} />,
+        onClick: () => reveal(node),
+      },
+      {
+        label: "Copy path",
+        icon: <Copy size={12} />,
+        onClick: () => copyPath(node),
+        separatorAfter: !isRoot,
+      },
+    ];
+    if (!isRoot) {
+      items.push({
+        label: "Delete",
+        icon: <Trash2 size={12} />,
+        destructive: true,
+        onClick: () => setConfirmDel(node),
+      });
+    }
+    setMenu({ x, y, items });
+  };
 
   // Esc closes the explorer (matches every other overlay).
   useEffect(() => {
@@ -196,6 +261,7 @@ function DiskUsage() {
                   colorMode={colorMode}
                   onDrill={(n) => drillTo(n)}
                   onHover={setHover}
+                  onContext={openMenu}
                 />
               ) : (
                 <div className="flex h-full items-center justify-center text-xs text-text-dim">
@@ -227,8 +293,39 @@ function DiskUsage() {
           <RankedList
             node={current}
             onDrill={(n) => drillTo(n)}
+            onContext={openMenu}
           />
         </div>
+      )}
+
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          items={menu.items}
+          onClose={() => setMenu(null)}
+        />
+      )}
+      {confirmDel && (
+        <ConfirmModal
+          title={`Delete ${confirmDel.name}?`}
+          message={
+            `Path: ${confirmDel.path}` +
+            (confirmDel.kind === "directory"
+              ? `\nThis folder and everything under it (${fmtSize(
+                  confirmDel.size
+                )}) will be permanently removed.`
+              : `\n${fmtSize(confirmDel.size)} will be permanently removed.`)
+          }
+          destructive
+          confirmLabel="Delete"
+          onClose={() => setConfirmDel(null)}
+          onConfirm={() => {
+            const n = confirmDel;
+            setConfirmDel(null);
+            void removeNode(n);
+          }}
+        />
       )}
     </div>,
     document.body
@@ -240,9 +337,11 @@ const MAX_ROWS = 500;
 function RankedList({
   node,
   onDrill,
+  onContext,
 }: {
   node: DuNode | null;
   onDrill: (n: DuNode) => void;
+  onContext: (node: DuNode, x: number, y: number) => void;
 }) {
   const children = node?.children ?? [];
   const parentSize = node?.size ?? 0;
@@ -269,7 +368,10 @@ function RankedList({
               <button
                 key={c.path}
                 onClick={() => isDir && onDrill(c)}
-                disabled={!isDir}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  onContext(c, e.clientX, e.clientY);
+                }}
                 title={c.path}
                 className={cn(
                   "flex w-full items-center gap-2 border-b border-border-subtle px-3 py-1.5 text-left text-xs",

--- a/src/components/DiskUsage.tsx
+++ b/src/components/DiskUsage.tsx
@@ -1,0 +1,314 @@
+import { createPortal } from "react-dom";
+import { useEffect, useState } from "react";
+import {
+  HardDrive,
+  X,
+  RefreshCw,
+  Ban,
+  Loader2,
+  ChevronRight,
+  Folder,
+  Palette,
+  AlertCircle,
+} from "lucide-react";
+import { useDiskScan, resolveNode, type ColorMode } from "@/stores/diskScanStore";
+import type { DuNode, ScanStrategy } from "@/lib/types";
+import { fmtSize } from "@/lib/format";
+import { materialIconUrl } from "@faro/file-ui";
+import { cn } from "@/lib/cn";
+import { DiskTreemap } from "./DiskTreemap";
+
+const STRATEGY_LABEL: Record<ScanStrategy, string> = {
+  generic: "Walk",
+  shell: "Shell du",
+  objectFlat: "Object listing",
+};
+
+/** Mount point: renders the overlay only while the explorer is open. */
+export function DiskUsageHost() {
+  const open = useDiskScan((s) => s.open);
+  if (!open) return null;
+  return <DiskUsage />;
+}
+
+function DiskUsage() {
+  const {
+    root,
+    state,
+    strategy,
+    dirsScanned,
+    filesFound,
+    totalBytes,
+    error,
+    tree,
+    crumbs,
+    colorMode,
+  } = useDiskScan();
+  const rescan = useDiskScan((s) => s.rescan);
+  const cancel = useDiskScan((s) => s.cancel);
+  const close = useDiskScan((s) => s.close);
+  const drillTo = useDiskScan((s) => s.drillTo);
+  const navigateTo = useDiskScan((s) => s.navigateTo);
+  const setColorMode = useDiskScan((s) => s.setColorMode);
+
+  const [hover, setHover] = useState<DuNode | null>(null);
+
+  // Esc closes the explorer (matches every other overlay).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [close]);
+
+  const current = resolveNode(tree, crumbs);
+  const scanning = state === "scanning";
+
+  return createPortal(
+    <div className="anim-modal fixed inset-0 z-modal flex flex-col bg-bg">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-bg-panel px-3 py-2">
+        <HardDrive size={15} className="shrink-0 text-accent" />
+        <span className="shrink-0 text-sm font-semibold">Disk Usage</span>
+
+        {/* Breadcrumb into the tree */}
+        <div className="flex min-w-0 flex-1 items-center overflow-x-auto whitespace-nowrap text-xs [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <button
+            onClick={() => navigateTo(-1)}
+            className={cn(
+              "max-w-[20rem] truncate rounded px-1 py-0.5 font-mono",
+              crumbs.length === 0
+                ? "font-medium text-text"
+                : "text-text-muted hover:bg-bg-hover hover:text-text"
+            )}
+            title={root}
+          >
+            {root || "/"}
+          </button>
+          {crumbs.map((seg, i) => (
+            <span key={i} className="flex items-center">
+              <ChevronRight size={12} className="shrink-0 text-text-dim" />
+              <button
+                onClick={() => navigateTo(i)}
+                className={cn(
+                  "max-w-[14rem] truncate rounded px-1 py-0.5 font-mono",
+                  i === crumbs.length - 1
+                    ? "font-medium text-text"
+                    : "text-text-muted hover:bg-bg-hover hover:text-text"
+                )}
+              >
+                {seg}
+              </button>
+            </span>
+          ))}
+        </div>
+
+        {/* Strategy badge */}
+        <span
+          className="shrink-0 rounded-sm bg-bg-subtle px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-text-dim"
+          title={`Scan strategy: ${STRATEGY_LABEL[strategy]}`}
+        >
+          {STRATEGY_LABEL[strategy]}
+        </span>
+
+        <button
+          onClick={() =>
+            setColorMode(colorMode === "type" ? "depth" : "type")
+          }
+          className="flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] text-text-muted hover:bg-bg-hover hover:text-text"
+          title="Toggle treemap colouring (by file type / by depth)"
+        >
+          <Palette size={12} />
+          {colorMode === "type" ? "By type" : "By depth"}
+        </button>
+
+        {scanning ? (
+          <button
+            onClick={() => cancel()}
+            className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] text-text-muted hover:bg-bg-hover hover:text-text"
+            title="Stop the scan"
+          >
+            <Ban size={12} /> Cancel
+          </button>
+        ) : (
+          <button
+            onClick={() => rescan()}
+            className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] text-text-muted hover:bg-bg-hover hover:text-text"
+            title="Re-scan this folder"
+          >
+            <RefreshCw size={12} /> Rescan
+          </button>
+        )}
+        <button
+          onClick={() => close()}
+          className="shrink-0 rounded-md p-1 text-text-muted hover:bg-bg-hover hover:text-danger"
+          title="Close (Esc)"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {/* Progress banner while scanning */}
+      {scanning && (
+        <div className="flex shrink-0 items-center gap-2 border-b border-border bg-bg-subtle px-3 py-1.5 text-xs text-text-muted">
+          <Loader2 size={13} className="animate-spin text-accent" />
+          <span>
+            Scanning… {dirsScanned.toLocaleString()} folders,{" "}
+            {filesFound.toLocaleString()} files ·{" "}
+            <span className="font-medium text-text">{fmtSize(totalBytes)}</span>
+          </span>
+        </div>
+      )}
+
+      {/* Body */}
+      {error ? (
+        <div className="flex flex-1 items-center justify-center">
+          <div className="flex max-w-md flex-col items-center gap-2 text-center">
+            <AlertCircle size={22} className="text-danger" />
+            <div className="text-sm font-medium">Scan failed</div>
+            <div className="text-xs text-text-dim">{error}</div>
+            <button
+              onClick={() => rescan()}
+              className="mt-1 rounded-md border border-border px-3 py-1 text-xs hover:bg-bg-hover"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          {/* Treemap */}
+          <div className="relative flex min-w-0 flex-1 flex-col border-r border-border">
+            <div className="min-h-0 flex-1 p-2">
+              {current && !scanning ? (
+                <DiskTreemap
+                  root={current}
+                  colorMode={colorMode}
+                  onDrill={(n) => drillTo(n)}
+                  onHover={setHover}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-xs text-text-dim">
+                  {scanning ? "Building the map…" : "No data"}
+                </div>
+              )}
+            </div>
+            {/* Hover readout */}
+            <div className="flex h-6 shrink-0 items-center gap-2 border-t border-border bg-bg-panel px-3 text-[11px] text-text-dim">
+              {hover ? (
+                <>
+                  <span className="min-w-0 flex-1 truncate font-mono" title={hover.path}>
+                    {hover.path}
+                  </span>
+                  <span className="shrink-0 font-medium text-text">
+                    {fmtSize(hover.size)}
+                  </span>
+                </>
+              ) : current ? (
+                <span className="truncate">
+                  {current.name} · {fmtSize(current.size)} ·{" "}
+                  {(current.children?.length ?? 0).toLocaleString()} items — click a box to drill in
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Size-ranked list */}
+          <RankedList
+            node={current}
+            onDrill={(n) => drillTo(n)}
+          />
+        </div>
+      )}
+    </div>,
+    document.body
+  );
+}
+
+const MAX_ROWS = 500;
+
+function RankedList({
+  node,
+  onDrill,
+}: {
+  node: DuNode | null;
+  onDrill: (n: DuNode) => void;
+}) {
+  const children = node?.children ?? [];
+  const parentSize = node?.size ?? 0;
+  const shown = children.slice(0, MAX_ROWS);
+
+  return (
+    <div className="flex w-80 shrink-0 flex-col bg-bg-panel">
+      <div className="flex shrink-0 items-center justify-between border-b border-border bg-bg-subtle px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+        <span>Biggest items</span>
+        <span>{children.length.toLocaleString()}</span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {children.length === 0 ? (
+          <div className="px-3 py-6 text-center text-xs text-text-dim">
+            Nothing here.
+          </div>
+        ) : (
+          shown.map((c) => {
+            const pct = parentSize > 0 ? (c.size / parentSize) * 100 : 0;
+            const isDir = c.kind === "directory";
+            const matUrl =
+              c.kind === "file" ? materialIconUrl(c.name) : undefined;
+            return (
+              <button
+                key={c.path}
+                onClick={() => isDir && onDrill(c)}
+                disabled={!isDir}
+                title={c.path}
+                className={cn(
+                  "flex w-full items-center gap-2 border-b border-border-subtle px-3 py-1.5 text-left text-xs",
+                  isDir
+                    ? "cursor-pointer hover:bg-bg-hover"
+                    : "cursor-default"
+                )}
+              >
+                {matUrl ? (
+                  <img
+                    src={matUrl}
+                    width={14}
+                    height={14}
+                    alt=""
+                    draggable={false}
+                    className="shrink-0"
+                  />
+                ) : (
+                  <Folder size={14} className="shrink-0 text-accent" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="min-w-0 truncate">{c.name}</span>
+                    <span className="shrink-0 tabular-nums text-text-dim">
+                      {fmtSize(c.size)}
+                    </span>
+                  </div>
+                  {/* Percentage-of-parent bar */}
+                  <div className="mt-1 h-1 w-full overflow-hidden rounded-full bg-bg-subtle">
+                    <div
+                      className="h-full rounded-full bg-accent"
+                      style={{ width: `${Math.max(1, pct)}%` }}
+                    />
+                  </div>
+                </div>
+                <span className="w-10 shrink-0 text-right tabular-nums text-[10px] text-text-dim">
+                  {pct >= 0.1 ? `${pct.toFixed(0)}%` : "<1%"}
+                </span>
+              </button>
+            );
+          })
+        )}
+        {children.length > MAX_ROWS && (
+          <div className="px-3 py-2 text-center text-[10px] text-text-dim">
+            +{(children.length - MAX_ROWS).toLocaleString()} more not shown
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DiskUsage.tsx
+++ b/src/components/DiskUsage.tsx
@@ -30,7 +30,13 @@ import { DiskTreemap } from "./DiskTreemap";
 
 /** Parent directory of a POSIX/Windows path (its own root when at top). */
 function parentDir(p: string): string {
+  // POSIX root is its own parent.
+  if (p === "/") return "/";
+  // A Windows drive root ("C:\" or "C:/") is its own parent — never slice it
+  // down to a bare "C:" that no backend can list.
+  const driveRoot = p.match(/^[a-zA-Z]:[\\/]/)?.[0];
   const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  if (driveRoot && i === 2) return driveRoot;
   if (i <= 0) return p.startsWith("/") ? "/" : p;
   return p.slice(0, i);
 }

--- a/src/components/DiskUsage.tsx
+++ b/src/components/DiskUsage.tsx
@@ -40,6 +40,7 @@ function DiskUsage() {
     filesFound,
     totalBytes,
     error,
+    note,
     tree,
     crumbs,
     colorMode,
@@ -104,13 +105,21 @@ function DiskUsage() {
           ))}
         </div>
 
-        {/* Strategy badge */}
+        {/* Strategy badge (+ fallback note) */}
         <span
           className="shrink-0 rounded-sm bg-bg-subtle px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-text-dim"
-          title={`Scan strategy: ${STRATEGY_LABEL[strategy]}`}
+          title={note ? note : `Scan strategy: ${STRATEGY_LABEL[strategy]}`}
         >
           {STRATEGY_LABEL[strategy]}
         </span>
+        {note && (
+          <span
+            className="hidden shrink-0 truncate text-[10px] text-text-dim lg:inline"
+            title={note}
+          >
+            {note}
+          </span>
+        )}
 
         <button
           onClick={() =>

--- a/src/components/DualPaneBrowser.tsx
+++ b/src/components/DualPaneBrowser.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FilePane } from "@faro/file-ui";
 import { SyncDialog } from "./SyncDialog";
 import { useConnections } from "@/stores/connectionsStore";
 import { useTransfers, toTransferItem } from "@/stores/transfersStore";
+import { useLayout } from "@/stores/layoutStore";
 import { LOCAL_SESSION } from "@/lib/types";
 import type { DirEntry } from "@/lib/types";
 import { ArrowRightLeft } from "lucide-react";
@@ -31,6 +32,21 @@ export function DualPaneBrowser() {
     if (!activeSessionId) return;
     setRemotePaths((m) => ({ ...m, [activeSessionId]: path }));
   };
+
+  // "Reveal in browser" from the Disk Usage explorer. Local targets go to the
+  // local pane; a matching server target updates that session's remote pane.
+  const revealTarget = useLayout((s) => s.revealTarget);
+  const clearReveal = useLayout((s) => s.clearReveal);
+  useEffect(() => {
+    if (!revealTarget) return;
+    if (revealTarget.sessionId === LOCAL_SESSION) {
+      setLocalPath(revealTarget.path);
+      clearReveal();
+    } else if (revealTarget.sessionId === activeSessionId) {
+      setRemotePaths((m) => ({ ...m, [activeSessionId]: revealTarget.path }));
+      clearReveal();
+    }
+  }, [revealTarget, activeSessionId, clearReveal]);
 
   const uploadAll = (entries: DirEntry[]) => {
     if (!activeSessionId) return;

--- a/src/components/FileBrowser.tsx
+++ b/src/components/FileBrowser.tsx
@@ -23,6 +23,9 @@ export function FileBrowser() {
   const profile = profiles.find((p) => p.id === activeProfileId) || null;
 
   const browseLocal = useLayout((s) => s.browseLocal);
+  const setBrowseLocal = useLayout((s) => s.setBrowseLocal);
+  const revealTarget = useLayout((s) => s.revealTarget);
+  const clearReveal = useLayout((s) => s.clearReveal);
   const defaultDownloadFolder = useSettings((s) => s.defaultDownloadFolder);
 
   const enqueueDownloads = useTransfers((s) => s.enqueueDownloads);
@@ -41,6 +44,22 @@ export function FileBrowser() {
   const serverSid = activeSessionId;
   const serverRemotePath =
     (serverSid && remotePaths[serverSid]) || profile?.defaultRemotePath || ".";
+
+  // Honour a "reveal in browser" request from the Disk Usage explorer: point the
+  // pane at the target directory on the matching session, then clear the signal.
+  useEffect(() => {
+    if (!revealTarget) return;
+    if (revealTarget.sessionId === LOCAL_SESSION) {
+      setBrowseLocal(true);
+      setLocalPath(revealTarget.path);
+      clearReveal();
+    } else if (revealTarget.sessionId === serverSid) {
+      setBrowseLocal(false);
+      setRemotePaths((m) => ({ ...m, [serverSid]: revealTarget.path }));
+      clearReveal();
+    }
+    // A reveal for a non-active session is left pending until it becomes active.
+  }, [revealTarget, serverSid, setBrowseLocal, clearReveal]);
 
   // Re-list the directory whenever a batch of transfers drains to zero, so an
   // upload's result shows up without a manual refresh.

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -7,6 +7,7 @@ import {
   ShieldOff,
   ShieldCheck,
   Cloud,
+  Globe,
   Loader2,
   CheckCircle2,
   AlertTriangle,
@@ -383,6 +384,7 @@ function ProtocolBadge({ protocol }: { protocol: Protocol }) {
   if (protocol === "ftp") Icon = ShieldOff;
   else if (protocol === "ftps") Icon = ShieldCheck;
   else if (protocol === "s3" || protocol === "azure" || protocol === "gcs") Icon = Cloud;
+  else if (protocol === "webdav") Icon = Globe;
   return (
     <span className="flex h-5 items-center gap-1 rounded bg-bg-subtle px-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
       <Icon size={9} />

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -385,7 +385,7 @@ function ProtocolBadge({ protocol }: { protocol: Protocol }) {
   else if (protocol === "ftps") Icon = ShieldCheck;
   else if (protocol === "s3" || protocol === "azure" || protocol === "gcs") Icon = Cloud;
   else if (protocol === "webdav" || protocol === "http") Icon = Globe;
-  else if (protocol === "dropbox" || protocol === "onedrive") Icon = Cloud;
+  else if (protocol === "dropbox" || protocol === "onedrive" || protocol === "gdrive") Icon = Cloud;
   return (
     <span className="flex h-5 items-center gap-1 rounded bg-bg-subtle px-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
       <Icon size={9} />

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -385,7 +385,7 @@ function ProtocolBadge({ protocol }: { protocol: Protocol }) {
   else if (protocol === "ftps") Icon = ShieldCheck;
   else if (protocol === "s3" || protocol === "azure" || protocol === "gcs") Icon = Cloud;
   else if (protocol === "webdav" || protocol === "http") Icon = Globe;
-  else if (protocol === "dropbox") Icon = Cloud;
+  else if (protocol === "dropbox" || protocol === "onedrive") Icon = Cloud;
   return (
     <span className="flex h-5 items-center gap-1 rounded bg-bg-subtle px-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
       <Icon size={9} />

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -385,6 +385,7 @@ function ProtocolBadge({ protocol }: { protocol: Protocol }) {
   else if (protocol === "ftps") Icon = ShieldCheck;
   else if (protocol === "s3" || protocol === "azure" || protocol === "gcs") Icon = Cloud;
   else if (protocol === "webdav" || protocol === "http") Icon = Globe;
+  else if (protocol === "dropbox") Icon = Cloud;
   return (
     <span className="flex h-5 items-center gap-1 rounded bg-bg-subtle px-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
       <Icon size={9} />

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -385,7 +385,7 @@ function ProtocolBadge({ protocol }: { protocol: Protocol }) {
   else if (protocol === "ftps") Icon = ShieldCheck;
   else if (protocol === "s3" || protocol === "azure" || protocol === "gcs") Icon = Cloud;
   else if (protocol === "webdav" || protocol === "http") Icon = Globe;
-  else if (protocol === "dropbox" || protocol === "onedrive" || protocol === "gdrive") Icon = Cloud;
+  else if (protocol === "dropbox" || protocol === "onedrive" || protocol === "gdrive" || protocol === "box") Icon = Cloud;
   return (
     <span className="flex h-5 items-center gap-1 rounded bg-bg-subtle px-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
       <Icon size={9} />

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -382,7 +382,7 @@ function ProtocolBadge({ protocol }: { protocol: Protocol }) {
   let label = protocol.toUpperCase();
   if (protocol === "ftp") Icon = ShieldOff;
   else if (protocol === "ftps") Icon = ShieldCheck;
-  else if (protocol === "s3" || protocol === "azure") Icon = Cloud;
+  else if (protocol === "s3" || protocol === "azure" || protocol === "gcs") Icon = Cloud;
   return (
     <span className="flex h-5 items-center gap-1 rounded bg-bg-subtle px-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
       <Icon size={9} />

--- a/src/components/ImportDialog.tsx
+++ b/src/components/ImportDialog.tsx
@@ -384,7 +384,7 @@ function ProtocolBadge({ protocol }: { protocol: Protocol }) {
   if (protocol === "ftp") Icon = ShieldOff;
   else if (protocol === "ftps") Icon = ShieldCheck;
   else if (protocol === "s3" || protocol === "azure" || protocol === "gcs") Icon = Cloud;
-  else if (protocol === "webdav") Icon = Globe;
+  else if (protocol === "webdav" || protocol === "http") Icon = Globe;
   return (
     <span className="flex h-5 items-center gap-1 rounded bg-bg-subtle px-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
       <Icon size={9} />

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -169,14 +169,18 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   const isHttp = protocol === "http";
   const isDropbox = protocol === "dropbox";
   const isOnedrive = protocol === "onedrive";
-  const isCloudOAuth = isDropbox || isOnedrive;
+  const isGdrive = protocol === "gdrive";
+  const isCloudOAuth = isDropbox || isOnedrive || isGdrive;
   const isObject = isObjectProtocol(protocol);
   const isAgent = isAgentProtocol(protocol);
 
   // OAuth clouds (Dropbox/OneDrive/…): authorization state. Editing an
   // already-authorized profile (its account label is persisted) starts authorized.
   const [cloudAuthed, setCloudAuthed] = useState<boolean>(
-    (seed?.protocol === "dropbox" || seed?.protocol === "onedrive") && !!seed?.account
+    (seed?.protocol === "dropbox" ||
+      seed?.protocol === "onedrive" ||
+      seed?.protocol === "gdrive") &&
+      !!seed?.account
   );
   const [cloudAccount, setCloudAccount] = useState<string>(seed?.account ?? "");
 
@@ -341,7 +345,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
 
         <Field label="Protocol">
           <div className="grid grid-cols-3 gap-1 rounded-md border border-border bg-bg-subtle p-1">
-            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "faro-agent"] as Protocol[]).map((p) => (
+            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "faro-agent"] as Protocol[]).map((p) => (
               <ProtocolButton
                 key={p}
                 active={protocol === p}
@@ -411,7 +415,13 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
         ) : isCloudOAuth ? (
           <OAuthConnectSection
             label={PROTOCOL_LABEL[protocol]}
-            authorize={isDropbox ? ipc.dropboxAuthorize : ipc.onedriveAuthorize}
+            authorize={
+              isDropbox
+                ? ipc.dropboxAuthorize
+                : isOnedrive
+                  ? ipc.onedriveAuthorize
+                  : ipc.gdriveAuthorize
+            }
             profileId={id}
             authed={cloudAuthed}
             account={cloudAccount}
@@ -1369,6 +1379,8 @@ function protocolHint(p: Protocol): string {
       return "OAuth · Cloud";
     case "onedrive":
       return "OAuth · Cloud";
+    case "gdrive":
+      return "OAuth · Cloud";
     case "faro-agent":
       return "Machine · :8722";
   }
@@ -1393,6 +1405,7 @@ function ProtocolButton({
   else if (label === "HTTP") Icon = Download;
   else if (label === "Dropbox") Icon = Box;
   else if (label === "OneDrive") Icon = Cloud;
+  else if (label === "Google Drive") Icon = Cloud;
   else if (label === "Faro Agent") Icon = MonitorSmartphone;
   return (
     <button

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -6,12 +6,14 @@ import {
   PROTOCOL_DEFAULT_PORT,
   PROTOCOL_LABEL,
   S3_PROVIDER_PRESETS,
+  WEBDAV_PROVIDER_PRESETS,
   isObjectProtocol,
   isAgentProtocol,
   type AuthMethod,
   type ConnectionProfile,
   type Protocol,
   type S3Provider,
+  type WebdavProvider,
   type DiscoveredAgent,
 } from "@/lib/types";
 import {
@@ -19,6 +21,7 @@ import {
   ShieldOff,
   Terminal as TerminalIcon,
   Cloud,
+  Globe,
   Eye,
   EyeOff,
   Wand2,
@@ -43,6 +46,15 @@ interface Props {
 
 function genId(): string {
   return crypto.randomUUID();
+}
+
+/// Best-effort hostname from a WebDAV server URL, for the rail label.
+function hostFromUrl(u: string): string {
+  try {
+    return new URL(u.includes("://") ? u : `https://${u}`).hostname;
+  } catch {
+    return u;
+  }
 }
 
 /// Guess which provider a saved S3 profile belongs to from its endpoint URL.
@@ -151,6 +163,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   const isS3 = protocol === "s3";
   const isAzure = protocol === "azure";
   const isGcs = protocol === "gcs";
+  const isWebdav = protocol === "webdav";
   const isObject = isObjectProtocol(protocol);
   const isAgent = isAgentProtocol(protocol);
 
@@ -175,9 +188,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             ? `${azureAccount}/${bucket}`
             : isGcs
               ? `${bucket}@gcs`
-              : isAgent
-                ? `Agent @ ${host}`
-                : `${username}@${host}`),
+              : isWebdav
+                ? `${username ? `${username}@` : ""}${hostFromUrl(endpoint)}`
+                : isAgent
+                  ? `Agent @ ${host}`
+                  : `${username}@${host}`),
       protocol,
       host: isObject
         ? endpoint ||
@@ -186,7 +201,9 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             : isGcs
               ? "storage.googleapis.com"
               : "s3.amazonaws.com")
-        : host,
+        : isWebdav
+          ? hostFromUrl(endpoint)
+          : host,
       port,
       username: isAzure ? azureAccount : isAgent || isGcs ? "" : username,
       auth: isAgent ? { kind: "password", password: "" } : auth,
@@ -195,7 +212,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
       autoConnect: autoConnect || undefined,
       bucket: isObject ? bucket : undefined,
       region: isS3 ? region : undefined,
-      endpoint: isObject ? endpoint || undefined : undefined,
+      endpoint: isObject || isWebdav ? endpoint || undefined : undefined,
       account: isAzure ? azureAccount : undefined,
       agentKey: isAgent ? agentKey : undefined,
       group: group.trim() || undefined,
@@ -236,9 +253,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
       ? !!azureAccount && !!bucket && !!password
       : isGcs
         ? !!bucket && gcsCredOk
-        : isAgent
-          ? !!host && !!agentKey
-          : !!host && !!username;
+        : isWebdav
+          ? !!endpoint && !!password
+          : isAgent
+            ? !!host && !!agentKey
+            : !!host && !!username;
   // Name what's still required so a disabled Save isn't a dead end.
   const missing = (
     isS3
@@ -250,9 +269,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
               !bucket && "bucket",
               !gcsCredOk && (authKind === "key" ? "key file path" : "JSON key"),
             ]
-          : isAgent
-            ? [!host && "host", !agentKey && "pairing"]
-            : [!host && "host", !username && "username"]
+          : isWebdav
+            ? [!endpoint && "server URL", !password && "password / token"]
+            : isAgent
+              ? [!host && "host", !agentKey && "pairing"]
+              : [!host && "host", !username && "username"]
   ).filter(Boolean);
 
   return (
@@ -295,7 +316,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
 
         <Field label="Protocol">
           <div className="grid grid-cols-3 gap-1 rounded-md border border-border bg-bg-subtle p-1">
-            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "faro-agent"] as Protocol[]).map((p) => (
+            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "faro-agent"] as Protocol[]).map((p) => (
               <ProtocolButton
                 key={p}
                 active={protocol === p}
@@ -343,6 +364,15 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             setKeyPath={setKeyPath}
             keyJson={password}
             setKeyJson={setPassword}
+          />
+        ) : isWebdav ? (
+          <WebdavSection
+            url={endpoint}
+            setUrl={setEndpoint}
+            username={username}
+            setUsername={setUsername}
+            password={password}
+            setPassword={setPassword}
           />
         ) : isAgent ? (
           <AgentSection
@@ -825,6 +855,116 @@ function AzureSection({
   );
 }
 
+function WebdavSection({
+  url,
+  setUrl,
+  username,
+  setUsername,
+  password,
+  setPassword,
+}: {
+  url: string;
+  setUrl: (v: string) => void;
+  username: string;
+  setUsername: (v: string) => void;
+  password: string;
+  setPassword: (v: string) => void;
+}) {
+  const [provider, setProvider] = useState<WebdavProvider>("nextcloud");
+  // Bearer mode = no username (the value in `password` is the token).
+  const [mode, setMode] = useState<"basic" | "bearer">(
+    !username && password ? "bearer" : "basic"
+  );
+  const preset = WEBDAV_PROVIDER_PRESETS[provider];
+
+  const applyPreset = (p: WebdavProvider) => {
+    setProvider(p);
+    const tpl = WEBDAV_PROVIDER_PRESETS[p].urlHint;
+    // Prefill the URL template, substituting a known username where it appears.
+    setUrl(username ? tpl.replace("<user>", username) : tpl);
+  };
+
+  return (
+    <>
+      <Field label="Provider">
+        <div className="grid grid-cols-4 gap-1 rounded-md border border-border bg-bg-subtle p-1">
+          {(Object.keys(WEBDAV_PROVIDER_PRESETS) as WebdavProvider[]).map((p) => {
+            const data = WEBDAV_PROVIDER_PRESETS[p];
+            return (
+              <button
+                key={p}
+                type="button"
+                onClick={() => applyPreset(p)}
+                className={
+                  "flex flex-col items-start rounded-sm px-2 py-1.5 text-left transition-colors " +
+                  (provider === p
+                    ? "bg-accent-soft text-text ring-1 ring-inset ring-accent/40"
+                    : "text-text-muted hover:bg-bg-hover hover:text-text")
+                }
+              >
+                <span className="flex items-center gap-1 text-[11px] font-semibold">
+                  <Globe size={11} className={provider === p ? "text-accent" : ""} />
+                  {data.label}
+                </span>
+                <span className="text-[10px] text-text-dim">{data.vendor}</span>
+              </button>
+            );
+          })}
+        </div>
+      </Field>
+
+      <Hint>{preset.description}</Hint>
+
+      <Field label="Server URL">
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder={preset.urlHint}
+          className={inputCls}
+        />
+      </Field>
+
+      <Field label="Auth">
+        <div className="grid grid-cols-2 gap-1 rounded-md border border-border bg-bg-subtle p-1">
+          {(["basic", "bearer"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => {
+                setMode(m);
+                if (m === "bearer") setUsername("");
+              }}
+              className={
+                "rounded-sm px-2 py-1.5 text-[11px] font-semibold transition-colors " +
+                (mode === m
+                  ? "bg-accent-soft text-text ring-1 ring-inset ring-accent/40"
+                  : "text-text-muted hover:bg-bg-hover hover:text-text")
+              }
+            >
+              {m === "basic" ? "Username + password" : "Bearer token"}
+            </button>
+          ))}
+        </div>
+      </Field>
+
+      {mode === "basic" && (
+        <Field label="Username">
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="alice"
+            className={inputCls}
+          />
+        </Field>
+      )}
+
+      <Field label={mode === "basic" ? "Password" : "Bearer token"}>
+        <PasswordInput value={password} onChange={setPassword} />
+      </Field>
+    </>
+  );
+}
+
 function GcsSection({
   bucket,
   setBucket,
@@ -1026,6 +1166,8 @@ function protocolHint(p: Protocol): string {
       return "Blob · :443";
     case "gcs":
       return "Object · :443";
+    case "webdav":
+      return "HTTP · :443";
     case "faro-agent":
       return "Machine · :8722";
   }
@@ -1046,6 +1188,7 @@ function ProtocolButton({
   if (label === "FTPS") Icon = ShieldCheck;
   else if (label === "FTP") Icon = ShieldOff;
   else if (label === "S3" || label === "Azure" || label === "GCS") Icon = Cloud;
+  else if (label === "WebDAV") Icon = Globe;
   else if (label === "Faro Agent") Icon = MonitorSmartphone;
   return (
     <button

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -168,15 +168,17 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   const isWebdav = protocol === "webdav";
   const isHttp = protocol === "http";
   const isDropbox = protocol === "dropbox";
+  const isOnedrive = protocol === "onedrive";
+  const isCloudOAuth = isDropbox || isOnedrive;
   const isObject = isObjectProtocol(protocol);
   const isAgent = isAgentProtocol(protocol);
 
-  // Dropbox: OAuth authorization state. Editing an already-authorized profile
-  // (its account label is persisted) starts authorized.
-  const [dropboxAuthed, setDropboxAuthed] = useState<boolean>(
-    seed?.protocol === "dropbox" && !!seed?.account
+  // OAuth clouds (Dropbox/OneDrive/…): authorization state. Editing an
+  // already-authorized profile (its account label is persisted) starts authorized.
+  const [cloudAuthed, setCloudAuthed] = useState<boolean>(
+    (seed?.protocol === "dropbox" || seed?.protocol === "onedrive") && !!seed?.account
   );
-  const [dropboxAccount, setDropboxAccount] = useState<string>(seed?.account ?? "");
+  const [cloudAccount, setCloudAccount] = useState<string>(seed?.account ?? "");
 
   /// Build the profile from the current form state. Shared by Save and by the
   /// pairing flow (which must persist the profile before it can pair by id).
@@ -201,8 +203,8 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
               ? `${bucket}@gcs`
               : isWebdav || isHttp
                 ? `${username ? `${username}@` : ""}${hostFromUrl(endpoint)}`
-                : isDropbox
-                  ? dropboxAccount || "Dropbox"
+                : isCloudOAuth
+                  ? cloudAccount || PROTOCOL_LABEL[protocol]
                   : isAgent
                     ? `Agent @ ${host}`
                     : `${username}@${host}`),
@@ -216,19 +218,19 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
               : "s3.amazonaws.com")
         : isWebdav || isHttp
           ? hostFromUrl(endpoint)
-          : isDropbox
-            ? "dropbox.com"
+          : isCloudOAuth
+            ? `${protocol}.com`
             : host,
       port,
-      username: isAzure ? azureAccount : isAgent || isGcs || isDropbox ? "" : username,
-      auth: isAgent || isDropbox ? { kind: "password", password: "" } : auth,
+      username: isAzure ? azureAccount : isAgent || isGcs || isCloudOAuth ? "" : username,
+      auth: isAgent || isCloudOAuth ? { kind: "password", password: "" } : auth,
       defaultRemotePath: defaultRemotePath || undefined,
       color: profile?.color,
       autoConnect: autoConnect || undefined,
       bucket: isObject ? bucket : undefined,
       region: isS3 ? region : undefined,
       endpoint: isObject || isWebdav || isHttp ? endpoint || undefined : undefined,
-      account: isAzure ? azureAccount : isDropbox ? dropboxAccount || undefined : undefined,
+      account: isAzure ? azureAccount : isCloudOAuth ? cloudAccount || undefined : undefined,
       agentKey: isAgent ? agentKey : undefined,
       group: group.trim() || undefined,
       sortOrder: profile?.sortOrder,
@@ -272,8 +274,8 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
           ? !!endpoint && !!password
           : isHttp
             ? !!endpoint
-            : isDropbox
-              ? dropboxAuthed
+            : isCloudOAuth
+              ? cloudAuthed
               : isAgent
                 ? !!host && !!agentKey
                 : !!host && !!username;
@@ -292,8 +294,8 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             ? [!endpoint && "server URL", !password && "password / token"]
             : isHttp
               ? [!endpoint && "URL"]
-              : isDropbox
-                ? [!dropboxAuthed && "Dropbox authorization"]
+              : isCloudOAuth
+                ? [!cloudAuthed && `${PROTOCOL_LABEL[protocol]} authorization`]
                 : isAgent
                   ? [!host && "host", !agentKey && "pairing"]
                   : [!host && "host", !username && "username"]
@@ -339,7 +341,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
 
         <Field label="Protocol">
           <div className="grid grid-cols-3 gap-1 rounded-md border border-border bg-bg-subtle p-1">
-            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "faro-agent"] as Protocol[]).map((p) => (
+            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "faro-agent"] as Protocol[]).map((p) => (
               <ProtocolButton
                 key={p}
                 active={protocol === p}
@@ -406,19 +408,21 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             password={password}
             setPassword={setPassword}
           />
-        ) : isDropbox ? (
-          <DropboxSection
+        ) : isCloudOAuth ? (
+          <OAuthConnectSection
+            label={PROTOCOL_LABEL[protocol]}
+            authorize={isDropbox ? ipc.dropboxAuthorize : ipc.onedriveAuthorize}
             profileId={id}
-            authed={dropboxAuthed}
-            account={dropboxAccount}
+            authed={cloudAuthed}
+            account={cloudAccount}
             onAuthorized={(label) => {
-              setDropboxAuthed(true);
-              setDropboxAccount(label);
-              if (!name) setName(label || "Dropbox");
+              setCloudAuthed(true);
+              setCloudAccount(label);
+              if (!name) setName(label || PROTOCOL_LABEL[protocol]);
             }}
             onReset={() => {
-              setDropboxAuthed(false);
-              setDropboxAccount("");
+              setCloudAuthed(false);
+              setCloudAccount("");
             }}
           />
         ) : isAgent ? (
@@ -902,16 +906,20 @@ function AzureSection({
   );
 }
 
-/// Dropbox OAuth connect. Like agent pairing: authorizing runs a browser flow
-/// and stores tokens in the OS keychain keyed by the profile id, then the editor
-/// persists the profile. No password lives in Faro.
-function DropboxSection({
+/// OAuth cloud connect (Dropbox / OneDrive / …). Like agent pairing: authorizing
+/// runs a browser flow and stores tokens in the OS keychain keyed by the profile
+/// id, then the editor persists the profile. No password lives in Faro.
+function OAuthConnectSection({
+  label,
+  authorize: runAuthorize,
   profileId,
   authed,
   account,
   onAuthorized,
   onReset,
 }: {
+  label: string;
+  authorize: (profileId: string) => Promise<{ accountLabel: string }>;
   profileId: string;
   authed: boolean;
   account: string;
@@ -923,14 +931,14 @@ function DropboxSection({
   const authorize = async () => {
     setBusy(true);
     try {
-      const res = await ipc.dropboxAuthorize(profileId);
+      const res = await runAuthorize(profileId);
       onAuthorized(res.accountLabel);
       toast.success(
-        "Connected to Dropbox",
+        `Connected to ${label}`,
         res.accountLabel ? `Authorized as ${res.accountLabel}` : undefined
       );
     } catch (e) {
-      toast.error("Dropbox authorization failed", String(e));
+      toast.error(`${label} authorization failed`, String(e));
     } finally {
       setBusy(false);
     }
@@ -939,8 +947,8 @@ function DropboxSection({
   return (
     <>
       <Hint>
-        Connect a Dropbox account. Authorizing opens your browser once; Faro
-        stores the refresh token in your OS keychain and never sees your Dropbox
+        Connect a {label} account. Authorizing opens your browser once; Faro
+        stores the refresh token in your OS keychain and never sees your {label}{" "}
         password.
       </Hint>
 
@@ -966,7 +974,7 @@ function DropboxSection({
           className="btn-accent mb-3 flex w-full items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? <Loader2 size={14} className="animate-spin" /> : <Box size={14} />}
-          {busy ? "Waiting for authorization…" : "Connect with Dropbox"}
+          {busy ? "Waiting for authorization…" : `Connect with ${label}`}
         </button>
       )}
     </>
@@ -1359,6 +1367,8 @@ function protocolHint(p: Protocol): string {
       return "Read-only · :443";
     case "dropbox":
       return "OAuth · Cloud";
+    case "onedrive":
+      return "OAuth · Cloud";
     case "faro-agent":
       return "Machine · :8722";
   }
@@ -1382,6 +1392,7 @@ function ProtocolButton({
   else if (label === "WebDAV") Icon = Globe;
   else if (label === "HTTP") Icon = Download;
   else if (label === "Dropbox") Icon = Box;
+  else if (label === "OneDrive") Icon = Cloud;
   else if (label === "Faro Agent") Icon = MonitorSmartphone;
   return (
     <button

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -170,7 +170,8 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   const isDropbox = protocol === "dropbox";
   const isOnedrive = protocol === "onedrive";
   const isGdrive = protocol === "gdrive";
-  const isCloudOAuth = isDropbox || isOnedrive || isGdrive;
+  const isBox = protocol === "box";
+  const isCloudOAuth = isDropbox || isOnedrive || isGdrive || isBox;
   const isObject = isObjectProtocol(protocol);
   const isAgent = isAgentProtocol(protocol);
 
@@ -179,7 +180,8 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   const [cloudAuthed, setCloudAuthed] = useState<boolean>(
     (seed?.protocol === "dropbox" ||
       seed?.protocol === "onedrive" ||
-      seed?.protocol === "gdrive") &&
+      seed?.protocol === "gdrive" ||
+      seed?.protocol === "box") &&
       !!seed?.account
   );
   const [cloudAccount, setCloudAccount] = useState<string>(seed?.account ?? "");
@@ -345,7 +347,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
 
         <Field label="Protocol">
           <div className="grid grid-cols-3 gap-1 rounded-md border border-border bg-bg-subtle p-1">
-            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "faro-agent"] as Protocol[]).map((p) => (
+            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "box", "faro-agent"] as Protocol[]).map((p) => (
               <ProtocolButton
                 key={p}
                 active={protocol === p}
@@ -420,7 +422,9 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
                 ? ipc.dropboxAuthorize
                 : isOnedrive
                   ? ipc.onedriveAuthorize
-                  : ipc.gdriveAuthorize
+                  : isGdrive
+                    ? ipc.gdriveAuthorize
+                    : ipc.boxAuthorize
             }
             profileId={id}
             authed={cloudAuthed}
@@ -1381,6 +1385,8 @@ function protocolHint(p: Protocol): string {
       return "OAuth · Cloud";
     case "gdrive":
       return "OAuth · Cloud";
+    case "box":
+      return "OAuth · Cloud";
     case "faro-agent":
       return "Machine · :8722";
   }
@@ -1406,6 +1412,7 @@ function ProtocolButton({
   else if (label === "Dropbox") Icon = Box;
   else if (label === "OneDrive") Icon = Cloud;
   else if (label === "Google Drive") Icon = Cloud;
+  else if (label === "Box") Icon = Box;
   else if (label === "Faro Agent") Icon = MonitorSmartphone;
   return (
     <button

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -128,8 +128,10 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
       setPort(PROTOCOL_DEFAULT_PORT[p]);
     }
     if (isObjectProtocol(p)) {
-      // Object stores only do key auth — coerce to password.
-      setAuthKind("password");
+      // Object stores authenticate by key material, not interactive login. S3 /
+      // Azure carry it in the password field; GCS uses a service-account JSON,
+      // which defaults to a key *file* path (Password mode pastes the JSON).
+      setAuthKind(p === "gcs" ? "key" : "password");
     }
     if ((p === "ftp" || p === "ftps") && authKind !== "password") {
       setAuthKind("password");
@@ -148,6 +150,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   const isFtp = protocol === "ftp" || protocol === "ftps";
   const isS3 = protocol === "s3";
   const isAzure = protocol === "azure";
+  const isGcs = protocol === "gcs";
   const isObject = isObjectProtocol(protocol);
   const isAgent = isAgentProtocol(protocol);
 
@@ -170,13 +173,22 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
           ? `${bucket}@${s3Provider}`
           : isAzure
             ? `${azureAccount}/${bucket}`
-            : isAgent
-              ? `Agent @ ${host}`
-              : `${username}@${host}`),
+            : isGcs
+              ? `${bucket}@gcs`
+              : isAgent
+                ? `Agent @ ${host}`
+                : `${username}@${host}`),
       protocol,
-      host: isObject ? endpoint || (isAzure ? "blob.core.windows.net" : "s3.amazonaws.com") : host,
+      host: isObject
+        ? endpoint ||
+          (isAzure
+            ? "blob.core.windows.net"
+            : isGcs
+              ? "storage.googleapis.com"
+              : "s3.amazonaws.com")
+        : host,
       port,
-      username: isAzure ? azureAccount : isAgent ? "" : username,
+      username: isAzure ? azureAccount : isAgent || isGcs ? "" : username,
       auth: isAgent ? { kind: "password", password: "" } : auth,
       defaultRemotePath: defaultRemotePath || undefined,
       color: profile?.color,
@@ -217,22 +229,30 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
     void connectProfile(id);
   };
 
+  const gcsCredOk = authKind === "key" ? !!keyPath : !!password;
   const canSave = isS3
     ? !!bucket && !!username && !!password
     : isAzure
       ? !!azureAccount && !!bucket && !!password
-      : isAgent
-        ? !!host && !!agentKey
-        : !!host && !!username;
+      : isGcs
+        ? !!bucket && gcsCredOk
+        : isAgent
+          ? !!host && !!agentKey
+          : !!host && !!username;
   // Name what's still required so a disabled Save isn't a dead end.
   const missing = (
     isS3
       ? [!bucket && "bucket", !username && "access key ID", !password && "secret key"]
       : isAzure
         ? [!azureAccount && "account", !bucket && "container", !password && "access key"]
-        : isAgent
-          ? [!host && "host", !agentKey && "pairing"]
-          : [!host && "host", !username && "username"]
+        : isGcs
+          ? [
+              !bucket && "bucket",
+              !gcsCredOk && (authKind === "key" ? "key file path" : "JSON key"),
+            ]
+          : isAgent
+            ? [!host && "host", !agentKey && "pairing"]
+            : [!host && "host", !username && "username"]
   ).filter(Boolean);
 
   return (
@@ -275,7 +295,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
 
         <Field label="Protocol">
           <div className="grid grid-cols-3 gap-1 rounded-md border border-border bg-bg-subtle p-1">
-            {(["sftp", "ftp", "ftps", "s3", "azure", "faro-agent"] as Protocol[]).map((p) => (
+            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "faro-agent"] as Protocol[]).map((p) => (
               <ProtocolButton
                 key={p}
                 active={protocol === p}
@@ -312,6 +332,17 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             setAccessKey={setPassword}
             endpoint={endpoint}
             setEndpoint={setEndpoint}
+          />
+        ) : isGcs ? (
+          <GcsSection
+            bucket={bucket}
+            setBucket={setBucket}
+            keyMode={authKind === "key" ? "file" : "paste"}
+            setKeyMode={(m) => setAuthKind(m === "file" ? "key" : "password")}
+            keyPath={keyPath}
+            setKeyPath={setKeyPath}
+            keyJson={password}
+            setKeyJson={setPassword}
           />
         ) : isAgent ? (
           <AgentSection
@@ -794,6 +825,87 @@ function AzureSection({
   );
 }
 
+function GcsSection({
+  bucket,
+  setBucket,
+  keyMode,
+  setKeyMode,
+  keyPath,
+  setKeyPath,
+  keyJson,
+  setKeyJson,
+}: {
+  bucket: string;
+  setBucket: (v: string) => void;
+  keyMode: "file" | "paste";
+  setKeyMode: (v: "file" | "paste") => void;
+  keyPath: string;
+  setKeyPath: (v: string) => void;
+  keyJson: string;
+  setKeyJson: (v: string) => void;
+}) {
+  return (
+    <>
+      <Hint>
+        Google Cloud Storage. Create a service account with Storage access, then
+        use its JSON key (Cloud console → IAM &amp; Admin → Service accounts →
+        Keys). Point at the downloaded file, or paste the key directly.
+      </Hint>
+
+      <Field label="Bucket">
+        <input
+          value={bucket}
+          onChange={(e) => setBucket(e.target.value)}
+          placeholder="my-gcs-bucket"
+          className={inputCls}
+        />
+      </Field>
+
+      <Field label="Service account key">
+        <div className="grid grid-cols-2 gap-1 rounded-md border border-border bg-bg-subtle p-1">
+          {(["file", "paste"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setKeyMode(m)}
+              className={
+                "rounded-sm px-2 py-1.5 text-[11px] font-semibold transition-colors " +
+                (keyMode === m
+                  ? "bg-accent-soft text-text ring-1 ring-inset ring-accent/40"
+                  : "text-text-muted hover:bg-bg-hover hover:text-text")
+              }
+            >
+              {m === "file" ? "Key file path" : "Paste JSON"}
+            </button>
+          ))}
+        </div>
+      </Field>
+
+      {keyMode === "file" ? (
+        <Field label="Key file path">
+          <input
+            value={keyPath}
+            onChange={(e) => setKeyPath(e.target.value)}
+            placeholder="~/keys/service-account.json"
+            className={inputCls}
+          />
+        </Field>
+      ) : (
+        <Field label="Service account JSON">
+          <textarea
+            value={keyJson}
+            onChange={(e) => setKeyJson(e.target.value)}
+            placeholder='{ "type": "service_account", ... }'
+            spellCheck={false}
+            rows={5}
+            className={cn(inputCls, "resize-y font-mono text-[11px] leading-snug")}
+          />
+        </Field>
+      )}
+    </>
+  );
+}
+
 function S3Section({
   provider,
   onProviderChange,
@@ -912,6 +1024,8 @@ function protocolHint(p: Protocol): string {
       return "Object · :443";
     case "azure":
       return "Blob · :443";
+    case "gcs":
+      return "Object · :443";
     case "faro-agent":
       return "Machine · :8722";
   }
@@ -931,7 +1045,7 @@ function ProtocolButton({
   let Icon = TerminalIcon;
   if (label === "FTPS") Icon = ShieldCheck;
   else if (label === "FTP") Icon = ShieldOff;
-  else if (label === "S3" || label === "Azure") Icon = Cloud;
+  else if (label === "S3" || label === "Azure" || label === "GCS") Icon = Cloud;
   else if (label === "Faro Agent") Icon = MonitorSmartphone;
   return (
     <button

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -52,7 +52,16 @@ function guessProvider(endpoint?: string): S3Provider {
   const e = endpoint.toLowerCase();
   if (e.includes("r2.cloudflarestorage.com")) return "r2";
   if (e.includes("backblazeb2.com")) return "b2";
-  return "aws";
+  if (e.includes("wasabisys.com")) return "wasabi";
+  if (e.includes("digitaloceanspaces.com")) return "spaces";
+  if (e.includes("storjshare.io")) return "storj";
+  if (e.includes("your-objectstorage.com")) return "hetzner";
+  if (e.includes("scw.cloud")) return "scaleway";
+  if (e.includes("oraclecloud.com")) return "oci";
+  if (e.includes("cloud-object-storage.appdomain.cloud")) return "ibm";
+  if (e.includes("supabase.co")) return "supabase";
+  // A bare endpoint we don't recognize is some self-hosted / niche S3 server.
+  return "generic";
 }
 
 export function ProfileEditor({ profile, prefill, onClose }: Props) {
@@ -817,7 +826,7 @@ function S3Section({
     <>
       <Field label="Provider">
         <div className="grid grid-cols-3 gap-1 rounded-md border border-border bg-bg-subtle p-1">
-          {(["aws", "r2", "b2"] as S3Provider[]).map((p) => {
+          {(Object.keys(S3_PROVIDER_PRESETS) as S3Provider[]).map((p) => {
             const data = S3_PROVIDER_PRESETS[p];
             return (
               <button
@@ -835,7 +844,7 @@ function S3Section({
                   <Cloud size={11} className={provider === p ? "text-accent" : ""} />
                   {data.label}
                 </span>
-                <span className="text-[10px] text-text-dim">{p === "aws" ? "Amazon" : p === "r2" ? "Cloudflare" : "Backblaze"}</span>
+                <span className="text-[10px] text-text-dim">{data.vendor}</span>
               </button>
             );
           })}

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -23,6 +23,7 @@ import {
   Cloud,
   Globe,
   Download,
+  Box,
   Eye,
   EyeOff,
   Wand2,
@@ -166,8 +167,16 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   const isGcs = protocol === "gcs";
   const isWebdav = protocol === "webdav";
   const isHttp = protocol === "http";
+  const isDropbox = protocol === "dropbox";
   const isObject = isObjectProtocol(protocol);
   const isAgent = isAgentProtocol(protocol);
+
+  // Dropbox: OAuth authorization state. Editing an already-authorized profile
+  // (its account label is persisted) starts authorized.
+  const [dropboxAuthed, setDropboxAuthed] = useState<boolean>(
+    seed?.protocol === "dropbox" && !!seed?.account
+  );
+  const [dropboxAccount, setDropboxAccount] = useState<string>(seed?.account ?? "");
 
   /// Build the profile from the current form state. Shared by Save and by the
   /// pairing flow (which must persist the profile before it can pair by id).
@@ -192,9 +201,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
               ? `${bucket}@gcs`
               : isWebdav || isHttp
                 ? `${username ? `${username}@` : ""}${hostFromUrl(endpoint)}`
-                : isAgent
-                  ? `Agent @ ${host}`
-                  : `${username}@${host}`),
+                : isDropbox
+                  ? dropboxAccount || "Dropbox"
+                  : isAgent
+                    ? `Agent @ ${host}`
+                    : `${username}@${host}`),
       protocol,
       host: isObject
         ? endpoint ||
@@ -205,17 +216,19 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
               : "s3.amazonaws.com")
         : isWebdav || isHttp
           ? hostFromUrl(endpoint)
-          : host,
+          : isDropbox
+            ? "dropbox.com"
+            : host,
       port,
-      username: isAzure ? azureAccount : isAgent || isGcs ? "" : username,
-      auth: isAgent ? { kind: "password", password: "" } : auth,
+      username: isAzure ? azureAccount : isAgent || isGcs || isDropbox ? "" : username,
+      auth: isAgent || isDropbox ? { kind: "password", password: "" } : auth,
       defaultRemotePath: defaultRemotePath || undefined,
       color: profile?.color,
       autoConnect: autoConnect || undefined,
       bucket: isObject ? bucket : undefined,
       region: isS3 ? region : undefined,
       endpoint: isObject || isWebdav || isHttp ? endpoint || undefined : undefined,
-      account: isAzure ? azureAccount : undefined,
+      account: isAzure ? azureAccount : isDropbox ? dropboxAccount || undefined : undefined,
       agentKey: isAgent ? agentKey : undefined,
       group: group.trim() || undefined,
       sortOrder: profile?.sortOrder,
@@ -259,9 +272,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
           ? !!endpoint && !!password
           : isHttp
             ? !!endpoint
-            : isAgent
-              ? !!host && !!agentKey
-              : !!host && !!username;
+            : isDropbox
+              ? dropboxAuthed
+              : isAgent
+                ? !!host && !!agentKey
+                : !!host && !!username;
   // Name what's still required so a disabled Save isn't a dead end.
   const missing = (
     isS3
@@ -277,9 +292,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             ? [!endpoint && "server URL", !password && "password / token"]
             : isHttp
               ? [!endpoint && "URL"]
-              : isAgent
-                ? [!host && "host", !agentKey && "pairing"]
-                : [!host && "host", !username && "username"]
+              : isDropbox
+                ? [!dropboxAuthed && "Dropbox authorization"]
+                : isAgent
+                  ? [!host && "host", !agentKey && "pairing"]
+                  : [!host && "host", !username && "username"]
   ).filter(Boolean);
 
   return (
@@ -322,7 +339,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
 
         <Field label="Protocol">
           <div className="grid grid-cols-3 gap-1 rounded-md border border-border bg-bg-subtle p-1">
-            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "faro-agent"] as Protocol[]).map((p) => (
+            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "dropbox", "faro-agent"] as Protocol[]).map((p) => (
               <ProtocolButton
                 key={p}
                 active={protocol === p}
@@ -388,6 +405,21 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             setUsername={setUsername}
             password={password}
             setPassword={setPassword}
+          />
+        ) : isDropbox ? (
+          <DropboxSection
+            profileId={id}
+            authed={dropboxAuthed}
+            account={dropboxAccount}
+            onAuthorized={(label) => {
+              setDropboxAuthed(true);
+              setDropboxAccount(label);
+              if (!name) setName(label || "Dropbox");
+            }}
+            onReset={() => {
+              setDropboxAuthed(false);
+              setDropboxAccount("");
+            }}
           />
         ) : isAgent ? (
           <AgentSection
@@ -870,6 +902,77 @@ function AzureSection({
   );
 }
 
+/// Dropbox OAuth connect. Like agent pairing: authorizing runs a browser flow
+/// and stores tokens in the OS keychain keyed by the profile id, then the editor
+/// persists the profile. No password lives in Faro.
+function DropboxSection({
+  profileId,
+  authed,
+  account,
+  onAuthorized,
+  onReset,
+}: {
+  profileId: string;
+  authed: boolean;
+  account: string;
+  onAuthorized: (label: string) => void;
+  onReset: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  const authorize = async () => {
+    setBusy(true);
+    try {
+      const res = await ipc.dropboxAuthorize(profileId);
+      onAuthorized(res.accountLabel);
+      toast.success(
+        "Connected to Dropbox",
+        res.accountLabel ? `Authorized as ${res.accountLabel}` : undefined
+      );
+    } catch (e) {
+      toast.error("Dropbox authorization failed", String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <Hint>
+        Connect a Dropbox account. Authorizing opens your browser once; Faro
+        stores the refresh token in your OS keychain and never sees your Dropbox
+        password.
+      </Hint>
+
+      {authed ? (
+        <div className="mb-3 flex items-center justify-between rounded-md border border-success/30 bg-success/10 px-2.5 py-2">
+          <span className="flex items-center gap-1.5 text-xs text-text">
+            <Check size={13} className="text-success" />
+            Connected{account ? ` as ${account}` : ""}.
+          </span>
+          <button
+            type="button"
+            onClick={onReset}
+            className="text-[11px] text-text-dim underline hover:text-text"
+          >
+            Reconnect
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={authorize}
+          disabled={busy}
+          className="btn-accent mb-3 flex w-full items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {busy ? <Loader2 size={14} className="animate-spin" /> : <Box size={14} />}
+          {busy ? "Waiting for authorization…" : "Connect with Dropbox"}
+        </button>
+      )}
+    </>
+  );
+}
+
 function HttpSection({
   url,
   setUrl,
@@ -1254,6 +1357,8 @@ function protocolHint(p: Protocol): string {
       return "HTTP · :443";
     case "http":
       return "Read-only · :443";
+    case "dropbox":
+      return "OAuth · Cloud";
     case "faro-agent":
       return "Machine · :8722";
   }
@@ -1276,6 +1381,7 @@ function ProtocolButton({
   else if (label === "S3" || label === "Azure" || label === "GCS") Icon = Cloud;
   else if (label === "WebDAV") Icon = Globe;
   else if (label === "HTTP") Icon = Download;
+  else if (label === "Dropbox") Icon = Box;
   else if (label === "Faro Agent") Icon = MonitorSmartphone;
   return (
     <button

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -22,6 +22,7 @@ import {
   Terminal as TerminalIcon,
   Cloud,
   Globe,
+  Download,
   Eye,
   EyeOff,
   Wand2,
@@ -164,6 +165,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   const isAzure = protocol === "azure";
   const isGcs = protocol === "gcs";
   const isWebdav = protocol === "webdav";
+  const isHttp = protocol === "http";
   const isObject = isObjectProtocol(protocol);
   const isAgent = isAgentProtocol(protocol);
 
@@ -188,7 +190,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             ? `${azureAccount}/${bucket}`
             : isGcs
               ? `${bucket}@gcs`
-              : isWebdav
+              : isWebdav || isHttp
                 ? `${username ? `${username}@` : ""}${hostFromUrl(endpoint)}`
                 : isAgent
                   ? `Agent @ ${host}`
@@ -201,7 +203,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             : isGcs
               ? "storage.googleapis.com"
               : "s3.amazonaws.com")
-        : isWebdav
+        : isWebdav || isHttp
           ? hostFromUrl(endpoint)
           : host,
       port,
@@ -212,7 +214,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
       autoConnect: autoConnect || undefined,
       bucket: isObject ? bucket : undefined,
       region: isS3 ? region : undefined,
-      endpoint: isObject || isWebdav ? endpoint || undefined : undefined,
+      endpoint: isObject || isWebdav || isHttp ? endpoint || undefined : undefined,
       account: isAzure ? azureAccount : undefined,
       agentKey: isAgent ? agentKey : undefined,
       group: group.trim() || undefined,
@@ -255,9 +257,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
         ? !!bucket && gcsCredOk
         : isWebdav
           ? !!endpoint && !!password
-          : isAgent
-            ? !!host && !!agentKey
-            : !!host && !!username;
+          : isHttp
+            ? !!endpoint
+            : isAgent
+              ? !!host && !!agentKey
+              : !!host && !!username;
   // Name what's still required so a disabled Save isn't a dead end.
   const missing = (
     isS3
@@ -271,9 +275,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             ]
           : isWebdav
             ? [!endpoint && "server URL", !password && "password / token"]
-            : isAgent
-              ? [!host && "host", !agentKey && "pairing"]
-              : [!host && "host", !username && "username"]
+            : isHttp
+              ? [!endpoint && "URL"]
+              : isAgent
+                ? [!host && "host", !agentKey && "pairing"]
+                : [!host && "host", !username && "username"]
   ).filter(Boolean);
 
   return (
@@ -316,7 +322,7 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
 
         <Field label="Protocol">
           <div className="grid grid-cols-3 gap-1 rounded-md border border-border bg-bg-subtle p-1">
-            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "faro-agent"] as Protocol[]).map((p) => (
+            {(["sftp", "ftp", "ftps", "s3", "azure", "gcs", "webdav", "http", "faro-agent"] as Protocol[]).map((p) => (
               <ProtocolButton
                 key={p}
                 active={protocol === p}
@@ -367,6 +373,15 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
           />
         ) : isWebdav ? (
           <WebdavSection
+            url={endpoint}
+            setUrl={setEndpoint}
+            username={username}
+            setUsername={setUsername}
+            password={password}
+            setPassword={setPassword}
+          />
+        ) : isHttp ? (
+          <HttpSection
             url={endpoint}
             setUrl={setEndpoint}
             username={username}
@@ -855,6 +870,75 @@ function AzureSection({
   );
 }
 
+function HttpSection({
+  url,
+  setUrl,
+  username,
+  setUsername,
+  password,
+  setPassword,
+}: {
+  url: string;
+  setUrl: (v: string) => void;
+  username: string;
+  setUsername: (v: string) => void;
+  password: string;
+  setPassword: (v: string) => void;
+}) {
+  const [auth, setAuth] = useState<boolean>(!!username);
+  return (
+    <>
+      <Hint>
+        Read-only browse of any static file server. Point at a directory with an
+        autoindex (nginx / Apache) to browse it, or paste a direct file URL to
+        pull a single artifact. No uploads, renames, or deletes.
+      </Hint>
+
+      <Field label="URL">
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://files.example.com/pub/"
+          className={inputCls}
+        />
+      </Field>
+
+      <label className="mb-3 flex cursor-pointer items-center gap-2.5 rounded-md border border-border bg-bg-subtle px-2.5 py-2">
+        <input
+          type="checkbox"
+          checked={auth}
+          onChange={(e) => {
+            setAuth(e.target.checked);
+            if (!e.target.checked) {
+              setUsername("");
+              setPassword("");
+            }
+          }}
+          className="h-3.5 w-3.5 shrink-0 accent-[rgb(var(--accent))]"
+        />
+        <span className="text-xs font-medium text-text">
+          Server needs HTTP Basic auth
+        </span>
+      </label>
+
+      {auth && (
+        <>
+          <Field label="Username">
+            <input
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className={inputCls}
+            />
+          </Field>
+          <Field label="Password">
+            <PasswordInput value={password} onChange={setPassword} />
+          </Field>
+        </>
+      )}
+    </>
+  );
+}
+
 function WebdavSection({
   url,
   setUrl,
@@ -1168,6 +1252,8 @@ function protocolHint(p: Protocol): string {
       return "Object · :443";
     case "webdav":
       return "HTTP · :443";
+    case "http":
+      return "Read-only · :443";
     case "faro-agent":
       return "Machine · :8722";
   }
@@ -1189,6 +1275,7 @@ function ProtocolButton({
   else if (label === "FTP") Icon = ShieldOff;
   else if (label === "S3" || label === "Azure" || label === "GCS") Icon = Cloud;
   else if (label === "WebDAV") Icon = Globe;
+  else if (label === "HTTP") Icon = Download;
   else if (label === "Faro Agent") Icon = MonitorSmartphone;
   return (
     <button

--- a/src/components/ServerRail.tsx
+++ b/src/components/ServerRail.tsx
@@ -47,7 +47,7 @@ type RowState = "focused" | "connected" | "connecting" | "error" | "idle";
 
 // Servers sort by protocol (SFTP first — the primary use), then by name, so the
 // rail order stays learnable as connections come and go.
-const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "faro-agent"];
+const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "faro-agent"];
 
 const fallbackColor = "rgb(var(--accent))";
 
@@ -58,6 +58,7 @@ function profileAddress(p: ConnectionProfile): string {
   if (p.protocol === "webdav" || p.protocol === "http") return p.endpoint ?? p.host;
   if (p.protocol === "dropbox") return p.account ? `Dropbox · ${p.account}` : "Dropbox";
   if (p.protocol === "onedrive") return p.account ? `OneDrive · ${p.account}` : "OneDrive";
+  if (p.protocol === "gdrive") return p.account ? `Drive · ${p.account}` : "Google Drive";
   const port =
     p.port !== PROTOCOL_DEFAULT_PORT[p.protocol] ? `:${p.port}` : "";
   // A Faro Agent connection controls a machine, not a login — no username.

--- a/src/components/ServerRail.tsx
+++ b/src/components/ServerRail.tsx
@@ -37,6 +37,7 @@ import { monogram } from "@/lib/format";
 import {
   PROTOCOL_DEFAULT_PORT,
   PROTOCOL_LABEL,
+  isObjectProtocol,
   type ConnectionProfile,
   type Protocol,
 } from "@/lib/types";
@@ -46,13 +47,14 @@ type RowState = "focused" | "connected" | "connecting" | "error" | "idle";
 
 // Servers sort by protocol (SFTP first — the primary use), then by name, so the
 // rail order stays learnable as connections come and go.
-const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "faro-agent"];
+const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "faro-agent"];
 
 const fallbackColor = "rgb(var(--accent))";
 
 function profileAddress(p: ConnectionProfile): string {
   if (p.protocol === "s3") return `s3://${p.bucket ?? "?"}`;
   if (p.protocol === "azure") return `az://${p.account ?? "?"}/${p.bucket ?? "?"}`;
+  if (p.protocol === "gcs") return `gs://${p.bucket ?? "?"}`;
   const port =
     p.port !== PROTOCOL_DEFAULT_PORT[p.protocol] ? `:${p.port}` : "";
   // A Faro Agent connection controls a machine, not a login — no username.
@@ -1374,7 +1376,7 @@ function RailSearch({
           </div>
         ) : (
           results.map((p) => {
-            const isObject = p.protocol === "s3" || p.protocol === "azure";
+            const isObject = isObjectProtocol(p.protocol);
             const ProtoIcon = isObject ? Cloud : Server;
             const online = connectedIds.has(p.id);
             return (

--- a/src/components/ServerRail.tsx
+++ b/src/components/ServerRail.tsx
@@ -47,7 +47,7 @@ type RowState = "focused" | "connected" | "connecting" | "error" | "idle";
 
 // Servers sort by protocol (SFTP first — the primary use), then by name, so the
 // rail order stays learnable as connections come and go.
-const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "faro-agent"];
+const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "dropbox", "faro-agent"];
 
 const fallbackColor = "rgb(var(--accent))";
 
@@ -56,6 +56,7 @@ function profileAddress(p: ConnectionProfile): string {
   if (p.protocol === "azure") return `az://${p.account ?? "?"}/${p.bucket ?? "?"}`;
   if (p.protocol === "gcs") return `gs://${p.bucket ?? "?"}`;
   if (p.protocol === "webdav" || p.protocol === "http") return p.endpoint ?? p.host;
+  if (p.protocol === "dropbox") return p.account ? `Dropbox · ${p.account}` : "Dropbox";
   const port =
     p.port !== PROTOCOL_DEFAULT_PORT[p.protocol] ? `:${p.port}` : "";
   // A Faro Agent connection controls a machine, not a login — no username.

--- a/src/components/ServerRail.tsx
+++ b/src/components/ServerRail.tsx
@@ -47,7 +47,7 @@ type RowState = "focused" | "connected" | "connecting" | "error" | "idle";
 
 // Servers sort by protocol (SFTP first — the primary use), then by name, so the
 // rail order stays learnable as connections come and go.
-const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "faro-agent"];
+const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "gdrive", "box", "faro-agent"];
 
 const fallbackColor = "rgb(var(--accent))";
 
@@ -59,6 +59,7 @@ function profileAddress(p: ConnectionProfile): string {
   if (p.protocol === "dropbox") return p.account ? `Dropbox · ${p.account}` : "Dropbox";
   if (p.protocol === "onedrive") return p.account ? `OneDrive · ${p.account}` : "OneDrive";
   if (p.protocol === "gdrive") return p.account ? `Drive · ${p.account}` : "Google Drive";
+  if (p.protocol === "box") return p.account ? `Box · ${p.account}` : "Box";
   const port =
     p.port !== PROTOCOL_DEFAULT_PORT[p.protocol] ? `:${p.port}` : "";
   // A Faro Agent connection controls a machine, not a login — no username.

--- a/src/components/ServerRail.tsx
+++ b/src/components/ServerRail.tsx
@@ -47,7 +47,7 @@ type RowState = "focused" | "connected" | "connecting" | "error" | "idle";
 
 // Servers sort by protocol (SFTP first — the primary use), then by name, so the
 // rail order stays learnable as connections come and go.
-const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "faro-agent"];
+const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "faro-agent"];
 
 const fallbackColor = "rgb(var(--accent))";
 
@@ -55,7 +55,7 @@ function profileAddress(p: ConnectionProfile): string {
   if (p.protocol === "s3") return `s3://${p.bucket ?? "?"}`;
   if (p.protocol === "azure") return `az://${p.account ?? "?"}/${p.bucket ?? "?"}`;
   if (p.protocol === "gcs") return `gs://${p.bucket ?? "?"}`;
-  if (p.protocol === "webdav") return p.endpoint ?? p.host;
+  if (p.protocol === "webdav" || p.protocol === "http") return p.endpoint ?? p.host;
   const port =
     p.port !== PROTOCOL_DEFAULT_PORT[p.protocol] ? `:${p.port}` : "";
   // A Faro Agent connection controls a machine, not a login — no username.

--- a/src/components/ServerRail.tsx
+++ b/src/components/ServerRail.tsx
@@ -47,7 +47,7 @@ type RowState = "focused" | "connected" | "connecting" | "error" | "idle";
 
 // Servers sort by protocol (SFTP first — the primary use), then by name, so the
 // rail order stays learnable as connections come and go.
-const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "faro-agent"];
+const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "faro-agent"];
 
 const fallbackColor = "rgb(var(--accent))";
 
@@ -55,6 +55,7 @@ function profileAddress(p: ConnectionProfile): string {
   if (p.protocol === "s3") return `s3://${p.bucket ?? "?"}`;
   if (p.protocol === "azure") return `az://${p.account ?? "?"}/${p.bucket ?? "?"}`;
   if (p.protocol === "gcs") return `gs://${p.bucket ?? "?"}`;
+  if (p.protocol === "webdav") return p.endpoint ?? p.host;
   const port =
     p.port !== PROTOCOL_DEFAULT_PORT[p.protocol] ? `:${p.port}` : "";
   // A Faro Agent connection controls a machine, not a login — no username.

--- a/src/components/ServerRail.tsx
+++ b/src/components/ServerRail.tsx
@@ -47,7 +47,7 @@ type RowState = "focused" | "connected" | "connecting" | "error" | "idle";
 
 // Servers sort by protocol (SFTP first — the primary use), then by name, so the
 // rail order stays learnable as connections come and go.
-const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "dropbox", "faro-agent"];
+const GROUP_ORDER: Protocol[] = ["sftp", "ftps", "ftp", "s3", "azure", "gcs", "webdav", "http", "dropbox", "onedrive", "faro-agent"];
 
 const fallbackColor = "rgb(var(--accent))";
 
@@ -57,6 +57,7 @@ function profileAddress(p: ConnectionProfile): string {
   if (p.protocol === "gcs") return `gs://${p.bucket ?? "?"}`;
   if (p.protocol === "webdav" || p.protocol === "http") return p.endpoint ?? p.host;
   if (p.protocol === "dropbox") return p.account ? `Dropbox · ${p.account}` : "Dropbox";
+  if (p.protocol === "onedrive") return p.account ? `OneDrive · ${p.account}` : "OneDrive";
   const port =
     p.port !== PROTOCOL_DEFAULT_PORT[p.protocol] ? `:${p.port}` : "";
   // A Faro Agent connection controls a machine, not a login — no username.

--- a/src/components/SyncDialog.tsx
+++ b/src/components/SyncDialog.tsx
@@ -421,7 +421,9 @@ function ReasonBadge({ reason }: { reason: SyncReason }) {
       ? "new"
       : reason === "newer"
         ? "newer"
-        : "size";
+        : reason === "edited"
+          ? "edited"
+          : "size";
   const tone =
     reason === "missing" ? "bg-success/15 text-success" : "bg-accent-soft text-accent";
   return (

--- a/src/components/SyncSettings.tsx
+++ b/src/components/SyncSettings.tsx
@@ -107,6 +107,12 @@ function PairRow({ pair }: { pair: PairView }) {
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-x-2.5 gap-y-0.5 text-[11px] text-text-dim">
             <span className="uppercase tracking-wider">{pair.strategy}</span>
+            {pair.exclude?.length > 0 && (
+              <span title={pair.exclude.join("\n")}>
+                {pair.exclude.length} exclude
+                {pair.exclude.length === 1 ? "" : "s"}
+              </span>
+            )}
             {syncing ? (
               <span className="flex items-center gap-1 text-warning">
                 <Loader2 size={10} className="animate-spin" />
@@ -192,6 +198,8 @@ function PairForm({ onDone }: { onDone: () => void }) {
   const [direction, setDirection] = useState<SyncDirection>("localToRemote");
   const [strategy, setStrategy] = useState<SyncStrategy>("additive");
   const [pollIntervalSecs, setPollIntervalSecs] = useState(60);
+  const [excludeText, setExcludeText] = useState("");
+  const [mirrorDeleteCap, setMirrorDeleteCap] = useState(100);
   const [busy, setBusy] = useState(false);
 
   const pickProfile = (id: string) => {
@@ -231,6 +239,8 @@ function PairForm({ onDone }: { onDone: () => void }) {
       strategy,
       enabled: true,
       pollIntervalSecs,
+      exclude: parseExclude(excludeText),
+      mirrorDeleteCap,
     };
     try {
       await upsert(pair);
@@ -328,11 +338,48 @@ function PairForm({ onDone }: { onDone: () => void }) {
       </div>
 
       {strategy === "mirror" && (
-        <div className="flex items-start gap-2 rounded-md border border-danger/30 bg-danger-soft/60 px-2.5 py-2 text-[11.5px] text-text-muted">
-          <AlertTriangle size={12} className="mt-0.5 shrink-0 text-danger" />
-          Mirror deletes files on the destination that don't exist on the source.
+        <div className="space-y-2 rounded-md border border-danger/30 bg-danger-soft/60 px-2.5 py-2">
+          <div className="flex items-start gap-2 text-[11.5px] text-text-muted">
+            <AlertTriangle size={12} className="mt-0.5 shrink-0 text-danger" />
+            Mirror deletes files on the destination that don't exist on the
+            source. As a safeguard, Faro refuses to delete when the source folder
+            is empty or unreadable, and caps deletions per sync.
+          </div>
+          <div className="flex items-center gap-1.5 pl-5">
+            <span className="text-[11px] text-text-muted">
+              Max deletes per sync
+            </span>
+            <input
+              type="number"
+              min={0}
+              max={100000}
+              value={mirrorDeleteCap}
+              onChange={(e) =>
+                setMirrorDeleteCap(
+                  Math.max(0, Math.min(100000, parseInt(e.target.value) || 0))
+                )
+              }
+              className="w-20 rounded-md border border-border bg-bg-panel px-2 py-1 text-sm outline-none focus:border-accent"
+            />
+            <span className="text-[11px] text-text-dim">0 = no cap</span>
+          </div>
         </div>
       )}
+
+      <Field label="Exclude patterns">
+        <textarea
+          value={excludeText}
+          onChange={(e) => setExcludeText(e.target.value)}
+          placeholder={"node_modules\n.git\n*.tmp\n/dist"}
+          rows={3}
+          spellCheck={false}
+          className="w-full resize-y rounded-md border border-border bg-bg-panel px-2.5 py-1.5 font-mono text-[12px] outline-none focus:border-accent"
+        />
+        <div className="mt-1 text-[10.5px] text-text-dim">
+          One gitignore-style pattern per line (also comma-separated). Matches are
+          never uploaded or mirror-deleted.
+        </div>
+      </Field>
 
       <Field label="Poll interval">
         <div className="flex items-center gap-1.5">
@@ -372,6 +419,15 @@ function PairForm({ onDone }: { onDone: () => void }) {
       </div>
     </div>
   );
+}
+
+/** Split the exclude textarea into clean patterns (newline- or comma-separated,
+ *  blanks and `#` comments dropped). Mirrors the backend's tolerant parsing. */
+function parseExclude(text: string): string[] {
+  return text
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s !== "" && !s.startsWith("#"));
 }
 
 function Field({

--- a/src/lib/fileUiAdapter.ts
+++ b/src/lib/fileUiAdapter.ts
@@ -8,6 +8,7 @@ import { ipc } from "./ipc";
 import { useEditor } from "@/stores/editorStore";
 import { useTerminals } from "@/stores/terminalsStore";
 import { useLayout } from "@/stores/layoutStore";
+import { useDiskScan } from "@/stores/diskScanStore";
 
 // POSIX single-quote a path so a `cd` survives spaces / shell metacharacters.
 function shQuote(p: string): string {
@@ -46,6 +47,12 @@ export const tauriFileSystem: FileSystemAdapter = {
   openTerminal: async (sessionId, path) => {
     useLayout.getState().setTerminalOpen(true);
     useTerminals.getState().openTab(sessionId, `cd ${shQuote(path)}\n`);
+  },
+
+  // Open the Disk Usage explorer and kick off a scan of `path`. The store owns
+  // the scan lifecycle (progress events, cancel, drill-down); this just triggers it.
+  analyzeDiskUsage: async (sessionId, path) => {
+    await useDiskScan.getState().openFor(sessionId, path);
   },
 
   // Image previews for the grid view. Local files only for now — the backend

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -80,6 +80,10 @@ export const ipc = {
   dropboxAuthorize: (profileId: string) =>
     invoke<{ accountLabel: string }>("dropbox_authorize", { profileId }),
 
+  /** Run the interactive OneDrive OAuth flow for a profile (Microsoft Graph). */
+  onedriveAuthorize: (profileId: string) =>
+    invoke<{ accountLabel: string }>("onedrive_authorize", { profileId }),
+
   // ---- Remote control: host THIS machine as a Faro Agent (Settings) ----
 
   /** Current state of the in-app agent host (enabled, running, policy, peers,

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -35,6 +35,8 @@ import type {
   DeepLink,
   SyncPair,
   PairView,
+  ScanSnapshot,
+  DiskScanProgress,
 } from "./types";
 
 // Typed wrappers around the Tauri command surface. The string names must match
@@ -294,6 +296,22 @@ export const ipc = {
     invoke<PairView[]>("foldersync_set_enabled", { id, enabled }),
   folderSyncSyncNow: (id: string) =>
     invoke<PairView[]>("foldersync_sync_now", { id }),
+
+  // ---- Disk Usage Explorer ----
+  /** Kick off a recursive size scan of `path` on a session; returns a scan id. */
+  diskScanStart: (sessionId: SessionId, path: string) =>
+    invoke<string>("diskscan_start", { sessionId, path }),
+  /** Lightweight status (live counts while scanning). */
+  diskScanStatus: (scanId: string) =>
+    invoke<ScanSnapshot>("diskscan_status", { scanId }),
+  /** Full snapshot including the aggregated tree (present once done). */
+  diskScanTree: (scanId: string) =>
+    invoke<ScanSnapshot>("diskscan_tree", { scanId }),
+  diskScanCancel: (scanId: string) =>
+    invoke<void>("diskscan_cancel", { scanId }),
+  /** Drop a finished scan from the backend (tab closed). */
+  diskScanForget: (scanId: string) =>
+    invoke<void>("diskscan_forget", { scanId }),
 };
 
 export async function onEditSaved(
@@ -384,6 +402,29 @@ export async function onDeepLink(
   cb: (link: DeepLink) => void
 ): Promise<UnlistenFn> {
   return listen<DeepLink>("deep-link://open", (e) => cb(e.payload));
+}
+
+/** Disk-usage scan lifecycle. `progress` carries live counts; the terminal
+ *  events (`done`/`error`/`canceled`) carry a full ScanSnapshot with the tree. */
+export async function onDiskScanEvent(
+  cb: (
+    kind: "progress" | "done" | "error" | "canceled",
+    payload: DiskScanProgress | ScanSnapshot
+  ) => void
+): Promise<UnlistenFn> {
+  const unsubs = await Promise.all([
+    listen<DiskScanProgress>("diskscan://progress", (e) =>
+      cb("progress", e.payload)
+    ),
+    listen<ScanSnapshot>("diskscan://done", (e) => cb("done", e.payload)),
+    listen<ScanSnapshot>("diskscan://error", (e) => cb("error", e.payload)),
+    listen<ScanSnapshot>("diskscan://canceled", (e) =>
+      cb("canceled", e.payload)
+    ),
+  ]);
+  return () => {
+    unsubs.forEach((u) => u());
+  };
 }
 
 export async function onTransferEvent(

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -74,6 +74,12 @@ export const ipc = {
   pairAgent: (host: string, port: number, code: string) =>
     invoke<AgentPairResult>("pair_agent", { host, port, code }),
 
+  /** Run the interactive Dropbox OAuth flow for a profile (opens the browser,
+   *  catches the loopback redirect, stores tokens in the OS keychain). Resolves
+   *  with the authorized account label. The editor saves the profile on success. */
+  dropboxAuthorize: (profileId: string) =>
+    invoke<{ accountLabel: string }>("dropbox_authorize", { profileId }),
+
   // ---- Remote control: host THIS machine as a Faro Agent (Settings) ----
 
   /** Current state of the in-app agent host (enabled, running, policy, peers,

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -88,6 +88,10 @@ export const ipc = {
   gdriveAuthorize: (profileId: string) =>
     invoke<{ accountLabel: string }>("gdrive_authorize", { profileId }),
 
+  /** Run the interactive Box OAuth flow for a profile. */
+  boxAuthorize: (profileId: string) =>
+    invoke<{ accountLabel: string }>("box_authorize", { profileId }),
+
   // ---- Remote control: host THIS machine as a Faro Agent (Settings) ----
 
   /** Current state of the in-app agent host (enabled, running, policy, peers,

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -84,6 +84,10 @@ export const ipc = {
   onedriveAuthorize: (profileId: string) =>
     invoke<{ accountLabel: string }>("onedrive_authorize", { profileId }),
 
+  /** Run the interactive Google Drive OAuth flow for a profile. */
+  gdriveAuthorize: (profileId: string) =>
+    invoke<{ accountLabel: string }>("gdrive_authorize", { profileId }),
+
   // ---- Remote control: host THIS machine as a Faro Agent (Settings) ----
 
   /** Current state of the in-app agent host (enabled, running, policy, peers,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export type Protocol =
   | "azure"
   | "gcs"
   | "webdav"
+  | "http"
   | "faro-agent";
 
 export interface ConnectionProfile {
@@ -51,6 +52,7 @@ export const PROTOCOL_DEFAULT_PORT: Record<Protocol, number> = {
   azure: 443,
   gcs: 443,
   webdav: 443,
+  http: 443,
   "faro-agent": 8722,
 };
 
@@ -62,6 +64,7 @@ export const PROTOCOL_LABEL: Record<Protocol, string> = {
   azure: "Azure",
   gcs: "GCS",
   webdav: "WebDAV",
+  http: "HTTP",
   "faro-agent": "Faro Agent",
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,7 @@ export type Protocol =
   | "webdav"
   | "http"
   | "dropbox"
+  | "onedrive"
   | "faro-agent";
 
 export interface ConnectionProfile {
@@ -55,6 +56,7 @@ export const PROTOCOL_DEFAULT_PORT: Record<Protocol, number> = {
   webdav: 443,
   http: 443,
   dropbox: 443,
+  onedrive: 443,
   "faro-agent": 8722,
 };
 
@@ -68,6 +70,7 @@ export const PROTOCOL_LABEL: Record<Protocol, string> = {
   webdav: "WebDAV",
   http: "HTTP",
   dropbox: "Dropbox",
+  onedrive: "OneDrive",
   "faro-agent": "Faro Agent",
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,6 +17,7 @@ export type Protocol =
   | "http"
   | "dropbox"
   | "onedrive"
+  | "gdrive"
   | "faro-agent";
 
 export interface ConnectionProfile {
@@ -57,6 +58,7 @@ export const PROTOCOL_DEFAULT_PORT: Record<Protocol, number> = {
   http: 443,
   dropbox: 443,
   onedrive: 443,
+  gdrive: 443,
   "faro-agent": 8722,
 };
 
@@ -71,6 +73,7 @@ export const PROTOCOL_LABEL: Record<Protocol, string> = {
   http: "HTTP",
   dropbox: "Dropbox",
   onedrive: "OneDrive",
+  gdrive: "Google Drive",
   "faro-agent": "Faro Agent",
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -278,33 +278,126 @@ export interface EditErrorEvent {
   message: string;
 }
 
-export type S3Provider = "aws" | "r2" | "b2";
+export type S3Provider =
+  | "aws"
+  | "r2"
+  | "b2"
+  | "wasabi"
+  | "spaces"
+  | "minio"
+  | "storj"
+  | "hetzner"
+  | "scaleway"
+  | "oci"
+  | "ibm"
+  | "supabase"
+  | "generic";
 
 export interface S3ProviderPreset {
   label: string;
+  /** Short vendor sub-label under the button (e.g. "Amazon", "Cloudflare"). */
+  vendor: string;
   description: string;
   endpointHint: string; // displayed as placeholder
   defaultRegion: string;
 }
 
+// Curated S3-compatible presets. Each is purely a New-Connection convenience:
+// the backend (`session/object.rs`) treats every non-AWS endpoint the same —
+// path-style addressing, credentials from access-key/secret. Providers with a
+// per-account endpoint (R2, MinIO, Spaces, Hetzner, OCI, IBM, Supabase) show the
+// template as a placeholder; the user fills in their account/region/namespace.
 export const S3_PROVIDER_PRESETS: Record<S3Provider, S3ProviderPreset> = {
   aws: {
     label: "AWS S3",
+    vendor: "Amazon",
     description: "Native Amazon S3; endpoint derived from region.",
     endpointHint: "(leave blank — derived from region)",
     defaultRegion: "us-east-1",
   },
   r2: {
     label: "Cloudflare R2",
+    vendor: "Cloudflare",
     description: "S3-compatible. Region is always 'auto'.",
     endpointHint: "https://<account>.r2.cloudflarestorage.com",
     defaultRegion: "auto",
   },
   b2: {
     label: "Backblaze B2",
+    vendor: "Backblaze",
     description: "S3-compatible. Endpoint is per-bucket region.",
     endpointHint: "https://s3.us-west-002.backblazeb2.com",
     defaultRegion: "us-west-002",
+  },
+  wasabi: {
+    label: "Wasabi",
+    vendor: "Wasabi",
+    description: "S3-compatible hot storage. Endpoint is region-specific.",
+    endpointHint: "https://s3.us-east-1.wasabisys.com",
+    defaultRegion: "us-east-1",
+  },
+  spaces: {
+    label: "DO Spaces",
+    vendor: "DigitalOcean",
+    description: "DigitalOcean Spaces. Endpoint is the datacenter region.",
+    endpointHint: "https://nyc3.digitaloceanspaces.com",
+    defaultRegion: "nyc3",
+  },
+  minio: {
+    label: "MinIO",
+    vendor: "Self-hosted",
+    description: "Self-hosted MinIO. Point the endpoint at your server.",
+    endpointHint: "https://minio.example.com:9000",
+    defaultRegion: "us-east-1",
+  },
+  storj: {
+    label: "Storj",
+    vendor: "Storj DCS",
+    description: "Storj S3-compatible gateway. Region is ignored.",
+    endpointHint: "https://gateway.storjshare.io",
+    defaultRegion: "us-east-1",
+  },
+  hetzner: {
+    label: "Hetzner",
+    vendor: "Hetzner",
+    description: "Hetzner Object Storage. Endpoint is the location.",
+    endpointHint: "https://fsn1.your-objectstorage.com",
+    defaultRegion: "fsn1",
+  },
+  scaleway: {
+    label: "Scaleway",
+    vendor: "Scaleway",
+    description: "Scaleway Object Storage. Endpoint is region-specific.",
+    endpointHint: "https://s3.fr-par.scw.cloud",
+    defaultRegion: "fr-par",
+  },
+  oci: {
+    label: "Oracle OCI",
+    vendor: "Oracle",
+    description: "OCI Object Storage (S3 compat). Endpoint carries the namespace.",
+    endpointHint: "https://<namespace>.compat.objectstorage.us-ashburn-1.oraclecloud.com",
+    defaultRegion: "us-ashburn-1",
+  },
+  ibm: {
+    label: "IBM COS",
+    vendor: "IBM Cloud",
+    description: "IBM Cloud Object Storage (S3 compat). Endpoint is region-specific.",
+    endpointHint: "https://s3.us-south.cloud-object-storage.appdomain.cloud",
+    defaultRegion: "us-south",
+  },
+  supabase: {
+    label: "Supabase",
+    vendor: "Supabase",
+    description: "Supabase Storage S3 endpoint. Region matches the project.",
+    endpointHint: "https://<project>.supabase.co/storage/v1/s3",
+    defaultRegion: "us-east-1",
+  },
+  generic: {
+    label: "S3-compatible",
+    vendor: "Self-hosted",
+    description: "Any S3 API server (Ceph RGW, Garage, SeaweedFS, …).",
+    endpointHint: "https://s3.example.com",
+    defaultRegion: "us-east-1",
   },
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -159,7 +159,7 @@ export interface ImporterPaths {
 
 export type SyncDirection = "localToRemote" | "remoteToLocal";
 export type SyncStrategy = "additive" | "mirror";
-export type SyncReason = "missing" | "newer" | "sizeChanged";
+export type SyncReason = "missing" | "newer" | "sizeChanged" | "edited";
 
 export interface SyncFile {
   relative: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,7 @@ export type Protocol =
   | "s3"
   | "azure"
   | "gcs"
+  | "webdav"
   | "faro-agent";
 
 export interface ConnectionProfile {
@@ -49,6 +50,7 @@ export const PROTOCOL_DEFAULT_PORT: Record<Protocol, number> = {
   s3: 443,
   azure: 443,
   gcs: 443,
+  webdav: 443,
   "faro-agent": 8722,
 };
 
@@ -59,6 +61,7 @@ export const PROTOCOL_LABEL: Record<Protocol, string> = {
   s3: "S3",
   azure: "Azure",
   gcs: "GCS",
+  webdav: "WebDAV",
   "faro-agent": "Faro Agent",
 };
 
@@ -407,6 +410,52 @@ export const S3_PROVIDER_PRESETS: Record<S3Provider, S3ProviderPreset> = {
     description: "Any S3 API server (Ceph RGW, Garage, SeaweedFS, …).",
     endpointHint: "https://s3.example.com",
     defaultRegion: "us-east-1",
+  },
+};
+
+export type WebdavProvider = "nextcloud" | "owncloud" | "storagebox" | "generic";
+
+export interface WebdavProviderPreset {
+  label: string;
+  vendor: string;
+  description: string;
+  /** URL template shown as a placeholder; `<user>` is substituted from the
+   *  username when a preset is applied. */
+  urlHint: string;
+  /** Whether this preset expects a username (Basic auth). */
+  wantsUser: boolean;
+}
+
+// WebDAV presets (the Phase-0 preset idea generalized beyond S3). Selecting one
+// prefills the server-URL template; the user swaps in their host/username.
+export const WEBDAV_PROVIDER_PRESETS: Record<WebdavProvider, WebdavProviderPreset> = {
+  nextcloud: {
+    label: "Nextcloud",
+    vendor: "Nextcloud",
+    description: "Use an app password (Settings → Security → Devices & sessions).",
+    urlHint: "https://cloud.example.com/remote.php/dav/files/<user>/",
+    wantsUser: true,
+  },
+  owncloud: {
+    label: "ownCloud",
+    vendor: "ownCloud",
+    description: "Same DAV path as Nextcloud; an app password is recommended.",
+    urlHint: "https://cloud.example.com/remote.php/dav/files/<user>/",
+    wantsUser: true,
+  },
+  storagebox: {
+    label: "Storage Box",
+    vendor: "Hetzner",
+    description: "Hetzner Storage Box over WebDAV. Enable WebDAV in the panel.",
+    urlHint: "https://<user>.your-storagebox.de",
+    wantsUser: true,
+  },
+  generic: {
+    label: "Generic",
+    vendor: "WebDAV",
+    description: "Any WebDAV server. Basic auth, or leave the user blank for a bearer token.",
+    urlHint: "https://dav.example.com/",
+    wantsUser: true,
   },
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export type Protocol =
   | "gcs"
   | "webdav"
   | "http"
+  | "dropbox"
   | "faro-agent";
 
 export interface ConnectionProfile {
@@ -53,6 +54,7 @@ export const PROTOCOL_DEFAULT_PORT: Record<Protocol, number> = {
   gcs: 443,
   webdav: 443,
   http: 443,
+  dropbox: 443,
   "faro-agent": 8722,
 };
 
@@ -65,6 +67,7 @@ export const PROTOCOL_LABEL: Record<Protocol, string> = {
   gcs: "GCS",
   webdav: "WebDAV",
   http: "HTTP",
+  dropbox: "Dropbox",
   "faro-agent": "Faro Agent",
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,14 @@ export type AuthMethod =
   | { kind: "key"; path: string; passphrase?: string }
   | { kind: "agent" };
 
-export type Protocol = "sftp" | "ftp" | "ftps" | "s3" | "azure" | "faro-agent";
+export type Protocol =
+  | "sftp"
+  | "ftp"
+  | "ftps"
+  | "s3"
+  | "azure"
+  | "gcs"
+  | "faro-agent";
 
 export interface ConnectionProfile {
   id: string;
@@ -41,6 +48,7 @@ export const PROTOCOL_DEFAULT_PORT: Record<Protocol, number> = {
   ftps: 21,
   s3: 443,
   azure: 443,
+  gcs: 443,
   "faro-agent": 8722,
 };
 
@@ -50,11 +58,12 @@ export const PROTOCOL_LABEL: Record<Protocol, string> = {
   ftps: "FTPS",
   s3: "S3",
   azure: "Azure",
+  gcs: "GCS",
   "faro-agent": "Faro Agent",
 };
 
 export function isObjectProtocol(p: Protocol): boolean {
-  return p === "s3" || p === "azure";
+  return p === "s3" || p === "azure" || p === "gcs";
 }
 
 /** A Faro Agent connection controls a whole remote machine, not a login on a

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -242,6 +242,8 @@ export interface ScanSnapshot {
   filesFound: number;
   totalBytes: number;
   error?: string;
+  /** Why the fast path fell back to the walk, when it did. */
+  note?: string;
   tree?: DuNode;
   startedAt: number;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -214,6 +214,47 @@ export interface PairView extends SyncPair {
   lastError: string | null;
 }
 
+// ---- Disk Usage Explorer (mirrors src-tauri/src/diskscan.rs) ----
+
+export type ScanState = "scanning" | "done" | "error" | "canceled";
+/** Which strategy produced the scan. Phase 1 is always "generic"; the exec and
+ *  object-store fast paths report "shell" / "objectFlat". */
+export type ScanStrategy = "generic" | "shell" | "objectFlat";
+
+/** One node in the aggregated size tree. `size` is total bytes under the node
+ *  (own size for a file, sum of descendants for a directory). */
+export interface DuNode {
+  name: string;
+  path: string;
+  kind: FileKind;
+  size: number;
+  children?: DuNode[];
+}
+
+/** A scan snapshot: live progress while scanning, the `tree` once done. */
+export interface ScanSnapshot {
+  id: string;
+  sessionId: string;
+  root: string;
+  state: ScanState;
+  strategy: ScanStrategy;
+  dirsScanned: number;
+  filesFound: number;
+  totalBytes: number;
+  error?: string;
+  tree?: DuNode;
+  startedAt: number;
+}
+
+/** The lightweight `diskscan://progress` event body. */
+export interface DiskScanProgress {
+  id: string;
+  dirsScanned: number;
+  filesFound: number;
+  totalBytes: number;
+  strategy: ScanStrategy;
+}
+
 // ---- Edit-in-place ----
 
 export interface EditStartedEvent {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -201,6 +201,8 @@ export interface SyncPair {
   strategy: SyncStrategy;
   enabled: boolean;
   pollIntervalSecs: number; // default 60
+  exclude: string[]; // gitignore-style patterns; never pushed nor mirror-deleted
+  mirrorDeleteCap: number; // max deletes per Mirror reconcile; 0 = unlimited
 }
 
 /** A sync pair plus its live runtime status (what the backend returns). */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,7 @@ export type Protocol =
   | "dropbox"
   | "onedrive"
   | "gdrive"
+  | "box"
   | "faro-agent";
 
 export interface ConnectionProfile {
@@ -59,6 +60,7 @@ export const PROTOCOL_DEFAULT_PORT: Record<Protocol, number> = {
   dropbox: 443,
   onedrive: 443,
   gdrive: 443,
+  box: 443,
   "faro-agent": 8722,
 };
 
@@ -74,6 +76,7 @@ export const PROTOCOL_LABEL: Record<Protocol, string> = {
   dropbox: "Dropbox",
   onedrive: "OneDrive",
   gdrive: "Google Drive",
+  box: "Box",
   "faro-agent": "Faro Agent",
 };
 

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -178,7 +178,7 @@ export function listDir(sessionId: string, path: string): DirEntry[] {
   let base: Array<Omit<DirEntry, "path">>;
   if (sessionId === "local") {
     base = path === "C:\\" || path === "/" ? LOCAL_C : LOCAL_GENERIC;
-  } else if (proto === "s3" || proto === "azure") {
+  } else if (proto === "s3" || proto === "azure" || proto === "gcs") {
     base = S3_ROOT;
   } else {
     base = REMOTE[path] ?? REMOTE_GENERIC;
@@ -191,7 +191,7 @@ export function capabilities(sessionId: string): Capabilities {
   if (sessionId === "local") {
     return { canChmod: false, canSymlink: true, canRename: true, hasDirectories: true, hasShell: false };
   }
-  if (proto === "s3" || proto === "azure") {
+  if (proto === "s3" || proto === "azure" || proto === "gcs") {
     return { canChmod: false, canSymlink: false, canRename: true, hasDirectories: false, hasShell: false };
   }
   if (proto === "ftp" || proto === "ftps") {

--- a/src/stores/diskScanStore.ts
+++ b/src/stores/diskScanStore.ts
@@ -27,6 +27,8 @@ interface DiskScanStoreState {
   filesFound: number;
   totalBytes: number;
   error: string | null;
+  /** Why the fast path fell back to the walk, when it did. */
+  note: string | null;
   /** Aggregated size tree (present once the scan is done). */
   tree: DuNode | null;
 
@@ -63,6 +65,7 @@ function fromSnapshot(s: ScanSnapshot) {
     filesFound: s.filesFound,
     totalBytes: s.totalBytes,
     error: s.error ?? null,
+    note: s.note ?? null,
     tree: s.tree ?? null,
   };
 }
@@ -90,6 +93,7 @@ export const useDiskScan = create<DiskScanStoreState>((set, get) => ({
   filesFound: 0,
   totalBytes: 0,
   error: null,
+  note: null,
   tree: null,
   crumbs: [],
   colorMode: "type",
@@ -128,6 +132,7 @@ export const useDiskScan = create<DiskScanStoreState>((set, get) => ({
       filesFound: 0,
       totalBytes: 0,
       error: null,
+      note: null,
       tree: null,
       crumbs: [],
       unlisten,
@@ -175,6 +180,7 @@ export const useDiskScan = create<DiskScanStoreState>((set, get) => ({
       state: null,
       tree: null,
       error: null,
+      note: null,
       crumbs: [],
       unlisten: null,
     });

--- a/src/stores/diskScanStore.ts
+++ b/src/stores/diskScanStore.ts
@@ -86,7 +86,10 @@ function pruneNode(node: DuNode, targetPath: string): DuNode {
       removed += c.size;
       continue;
     }
-    if (targetPath.startsWith(c.path + "/")) {
+    if (
+      targetPath.startsWith(c.path + "/") ||
+      targetPath.startsWith(c.path + "\\")
+    ) {
       const before = c.size;
       const pruned = pruneNode(c, targetPath);
       removed += before - pruned.size;
@@ -236,7 +239,7 @@ export const useDiskScan = create<DiskScanStoreState>((set, get) => ({
     const rel = node.path.startsWith(rootPath)
       ? node.path.slice(rootPath.length)
       : node.path;
-    const crumbs = rel.split("/").filter(Boolean);
+    const crumbs = rel.split(/[/\\]/).filter(Boolean);
     set({ crumbs });
   },
 

--- a/src/stores/diskScanStore.ts
+++ b/src/stores/diskScanStore.ts
@@ -48,6 +48,11 @@ interface DiskScanStoreState {
   /** Close the overlay and forget the backend scan. */
   close: () => void;
 
+  /** Delete a node on the backend, then prune it from the tree in place
+   *  (subtracting its size from every ancestor) so the map updates without a
+   *  full rescan. */
+  removeNode: (node: DuNode) => Promise<void>;
+
   /** Drill into a directory node (by walking to it from the tree root). */
   drillTo: (node: DuNode) => void;
   /** Jump the breadcrumb to depth `k` (−1 = the root). */
@@ -68,6 +73,29 @@ function fromSnapshot(s: ScanSnapshot) {
     note: s.note ?? null,
     tree: s.tree ?? null,
   };
+}
+
+/** Rebuild `node` without the descendant at `targetPath`, subtracting its size
+ *  from every ancestor along the way. */
+function pruneNode(node: DuNode, targetPath: string): DuNode {
+  if (!node.children) return node;
+  let removed = 0;
+  const children: DuNode[] = [];
+  for (const c of node.children) {
+    if (c.path === targetPath) {
+      removed += c.size;
+      continue;
+    }
+    if (targetPath.startsWith(c.path + "/")) {
+      const before = c.size;
+      const pruned = pruneNode(c, targetPath);
+      removed += before - pruned.size;
+      children.push(pruned);
+    } else {
+      children.push(c);
+    }
+  }
+  return { ...node, size: node.size - removed, children };
 }
 
 /** Resolve the currently-shown node by walking `crumbs` from the tree root. */
@@ -184,6 +212,21 @@ export const useDiskScan = create<DiskScanStoreState>((set, get) => ({
       crumbs: [],
       unlisten: null,
     });
+  },
+
+  removeNode: async (node) => {
+    const { sessionId, tree, root } = get();
+    if (!sessionId || !tree) return;
+    // Never let the scan root itself be deleted from here.
+    if (node.path === tree.path || node.path === root) return;
+    try {
+      await ipc.deletePath(sessionId, node.path, node.kind === "directory");
+    } catch (e) {
+      toast.error("Delete failed", String(e));
+      return;
+    }
+    set({ tree: pruneNode(tree, node.path) });
+    toast.success("Deleted", node.name);
   },
 
   drillTo: (node) => {

--- a/src/stores/diskScanStore.ts
+++ b/src/stores/diskScanStore.ts
@@ -1,0 +1,199 @@
+import { create } from "zustand";
+import { ipc, onDiskScanEvent } from "@/lib/ipc";
+import { toast } from "./toastStore";
+import type {
+  DuNode,
+  ScanSnapshot,
+  ScanState,
+  ScanStrategy,
+  DiskScanProgress,
+  SessionId,
+} from "@/lib/types";
+
+// How the treemap colours its cells.
+export type ColorMode = "type" | "depth";
+
+interface DiskScanStoreState {
+  /** Whether the Disk Usage explorer overlay is open. */
+  open: boolean;
+  scanId: string | null;
+  sessionId: SessionId | null;
+  /** The directory the scan was rooted at. */
+  root: string;
+
+  state: ScanState | null;
+  strategy: ScanStrategy;
+  dirsScanned: number;
+  filesFound: number;
+  totalBytes: number;
+  error: string | null;
+  /** Aggregated size tree (present once the scan is done). */
+  tree: DuNode | null;
+
+  /** Drill-down path: segment names from the tree root to the shown node. */
+  crumbs: string[];
+  colorMode: ColorMode;
+
+  /** Detach the event listener for the current scan. */
+  unlisten: (() => void) | null;
+
+  /** Open the explorer and start a scan of `path` on `sessionId`. */
+  openFor: (sessionId: SessionId, path: string) => Promise<void>;
+  /** Re-run the scan on the same root. */
+  rescan: () => Promise<void>;
+  /** Ask the backend to stop the running scan. */
+  cancel: () => Promise<void>;
+  /** Close the overlay and forget the backend scan. */
+  close: () => void;
+
+  /** Drill into a directory node (by walking to it from the tree root). */
+  drillTo: (node: DuNode) => void;
+  /** Jump the breadcrumb to depth `k` (−1 = the root). */
+  navigateTo: (k: number) => void;
+
+  setColorMode: (m: ColorMode) => void;
+}
+
+/** Copy a terminal snapshot's fields into the store. */
+function fromSnapshot(s: ScanSnapshot) {
+  return {
+    state: s.state,
+    strategy: s.strategy,
+    dirsScanned: s.dirsScanned,
+    filesFound: s.filesFound,
+    totalBytes: s.totalBytes,
+    error: s.error ?? null,
+    tree: s.tree ?? null,
+  };
+}
+
+/** Resolve the currently-shown node by walking `crumbs` from the tree root. */
+export function resolveNode(tree: DuNode | null, crumbs: string[]): DuNode | null {
+  if (!tree) return null;
+  let n = tree;
+  for (const seg of crumbs) {
+    const next = n.children?.find((c) => c.name === seg);
+    if (!next) break;
+    n = next;
+  }
+  return n;
+}
+
+export const useDiskScan = create<DiskScanStoreState>((set, get) => ({
+  open: false,
+  scanId: null,
+  sessionId: null,
+  root: "",
+  state: null,
+  strategy: "generic",
+  dirsScanned: 0,
+  filesFound: 0,
+  totalBytes: 0,
+  error: null,
+  tree: null,
+  crumbs: [],
+  colorMode: "type",
+  unlisten: null,
+
+  openFor: async (sessionId, path) => {
+    const prev = get();
+    // Tear down any previous scan first.
+    if (prev.scanId) ipc.diskScanForget(prev.scanId).catch(() => {});
+    prev.unlisten?.();
+
+    const unlisten = await onDiskScanEvent((kind, payload) => {
+      // Only react to events for the scan we're currently showing.
+      if (!payload || payload.id !== get().scanId) return;
+      if (kind === "progress") {
+        const p = payload as DiskScanProgress;
+        set({
+          dirsScanned: p.dirsScanned,
+          filesFound: p.filesFound,
+          totalBytes: p.totalBytes,
+          strategy: p.strategy,
+        });
+      } else {
+        set(fromSnapshot(payload as ScanSnapshot));
+      }
+    });
+
+    set({
+      open: true,
+      scanId: null,
+      sessionId,
+      root: path,
+      state: "scanning",
+      strategy: "generic",
+      dirsScanned: 0,
+      filesFound: 0,
+      totalBytes: 0,
+      error: null,
+      tree: null,
+      crumbs: [],
+      unlisten,
+    });
+
+    try {
+      const scanId = await ipc.diskScanStart(sessionId, path);
+      set({ scanId });
+      // Reconcile: the scan may have finished before `scanId` was set, so a
+      // terminal event could have been ignored above.
+      const snap = await ipc.diskScanTree(scanId);
+      if (snap.state !== "scanning") set(fromSnapshot(snap));
+      else
+        set({
+          dirsScanned: snap.dirsScanned,
+          filesFound: snap.filesFound,
+          totalBytes: snap.totalBytes,
+          strategy: snap.strategy,
+        });
+    } catch (e) {
+      set({ state: "error", error: String(e) });
+      toast.error("Couldn't start disk usage scan", String(e));
+    }
+  },
+
+  rescan: async () => {
+    const { sessionId, root } = get();
+    if (sessionId != null) await get().openFor(sessionId, root);
+  },
+
+  cancel: async () => {
+    const { scanId } = get();
+    if (scanId) await ipc.diskScanCancel(scanId).catch(() => {});
+  },
+
+  close: () => {
+    const { scanId, unlisten } = get();
+    if (scanId) ipc.diskScanForget(scanId).catch(() => {});
+    unlisten?.();
+    set({
+      open: false,
+      scanId: null,
+      sessionId: null,
+      root: "",
+      state: null,
+      tree: null,
+      error: null,
+      crumbs: [],
+      unlisten: null,
+    });
+  },
+
+  drillTo: (node) => {
+    const { tree } = get();
+    if (!tree || node.kind !== "directory") return;
+    const rootPath = tree.path;
+    const rel = node.path.startsWith(rootPath)
+      ? node.path.slice(rootPath.length)
+      : node.path;
+    const crumbs = rel.split("/").filter(Boolean);
+    set({ crumbs });
+  },
+
+  navigateTo: (k) => {
+    set((s) => ({ crumbs: k < 0 ? [] : s.crumbs.slice(0, k + 1) }));
+  },
+
+  setColorMode: (m) => set({ colorMode: m }),
+}));

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -42,6 +42,13 @@ interface LayoutState {
   browseLocal: boolean;
   setBrowseLocal: (v: boolean) => void;
 
+  // A one-shot "show this path in the file browser" request (from the Disk
+  // Usage explorer's "Reveal" action). The active browser consumes it and
+  // clears it. `path` is the directory to open (a file's parent).
+  revealTarget: { sessionId: string; path: string } | null;
+  requestReveal: (sessionId: string, path: string) => void;
+  clearReveal: () => void;
+
   paletteOpen: boolean;
   setPaletteOpen: (v: boolean) => void;
   togglePalette: () => void;
@@ -73,6 +80,10 @@ export const useLayout = create<LayoutState>((set) => ({
 
   browseLocal: false,
   setBrowseLocal: (v) => set({ browseLocal: v }),
+
+  revealTarget: null,
+  requestReveal: (sessionId, path) => set({ revealTarget: { sessionId, path } }),
+  clearReveal: () => set({ revealTarget: null }),
 
   paletteOpen: false,
   setPaletteOpen: (v) => set({ paletteOpen: v }),

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -181,7 +181,7 @@ const DEFAULTS: Persisted = {
   showHiddenFiles: false,
   sortField: "name",
   sortDirection: "asc",
-  paneViewMode: "details",
+  paneViewMode: "grid",
   paneDensity: "comfortable",
   browserLayout: "single",
   railExpanded: false,
@@ -197,12 +197,23 @@ const DEFAULTS: Persisted = {
   anthropicApiKey: "",
 };
 
+const VIEW_MIGRATION_KEY = "faro.viewModeDefaultV2";
+
 function load(): Persisted {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULTS;
     const parsed = JSON.parse(raw) as Partial<Persisted>;
-    return { ...DEFAULTS, ...parsed };
+    const merged = { ...DEFAULTS, ...parsed };
+    // One-time migration: the default file view moved from "details" to "grid".
+    // Flip existing installs that were still on the old default once, then
+    // respect whatever the user picks afterward.
+    if (localStorage.getItem(VIEW_MIGRATION_KEY) !== "done") {
+      if (merged.paneViewMode === "details") merged.paneViewMode = "grid";
+      localStorage.setItem(VIEW_MIGRATION_KEY, "done");
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
+    }
+    return merged;
   } catch {
     return DEFAULTS;
   }


### PR DESCRIPTION
Faro learned where your bytes are hiding — and picked up seven new places to put them. The centerpiece is a WinDirStat-style Disk Usage Explorer that works over *any* backend, built on a new shared scan engine and a `faro.db` SQLite index that were deliberately landed first (Plan 3) so disk usage, diff, and search all walk trees through one engine instead of three. The connection list grew native Google Cloud Storage, WebDAV, a read-only HTTP(S) source, and four consumer clouds — Dropbox, OneDrive, Google Drive, and Box — all four riding on one set of shared loopback+PKCE OAuth infrastructure with keychain token storage, so the fourth backend cost almost nothing beyond its API quirks. Folder sync got the safety hardware it arguably should have had from day one: gitignore-style excludes, a mirror-delete cap, and a hard refusal to wipe the destination when the source folder comes up empty or unmounted. The sync reconciler also remembers per-file state in `faro.db` now, so same-size edits are caught and interrupted runs resume instead of re-uploading. Rounding it out, the file browser defaults to grid view with real per-type icons from Material Icon Theme.

### Highlights

- **Disk Usage Explorer** — right-click any folder on any backend and see a live canvas treemap plus a size-ranked list of what's eating the space, with reveal-in-browser, copy-path, and delete actions straight from the map.
- Disk usage scans take **fast paths** where the protocol allows: a single shell `find` over SSH/agent connections and a flat object listing for S3/Azure/GCS — with the generic concurrent walk as the universal fallback.
- **Seven new backends:** native Google Cloud Storage, WebDAV (Nextcloud, ownCloud, Hetzner Storage Box, and friends), a read-only HTTP(S) source for autoindex pages and direct URLs, and four consumer clouds — Dropbox, OneDrive, Google Drive, and Box.
- **The consumer clouds connect via your browser** — one OAuth authorization each, and the refresh token lives in your OS keychain, never in a config file. Faro never sees your password.
- The New Connection dialog now offers **ten S3-compatible presets** (Wasabi, DO Spaces, MinIO, Storj, Hetzner, Scaleway, Oracle OCI, IBM COS, Supabase, generic) with per-provider endpoint hints, plus WebDAV provider presets.
- **Folder sync is much harder to hurt yourself with:** exclude patterns keep noise like `node_modules` out of both uploads and deletes, Mirror deletes are capped (default 100 files), and an empty or unreadable source folder never triggers a destination wipe.
- Files default to a **grid view with real file-type icons** — per-language, per-format SVGs instead of three generic glyphs.

<details>
<summary>Technical changes</summary>

**Scan + index foundation (Plan 3)**

- New `db.rs`: one shared `faro.db` SQLite database in `AppState` (rusqlite `bundled`, WAL), with forward-only migrations versioned via the `user_version` pragma; v1 lands the `sync_state` table keyed `(pair_id, rel_path)`.
- New `scan.rs`: the sync walk extracted into a shared scan engine — bounded-concurrency BFS (`FuturesUnordered`, default 16 in-flight `list_dir`s), a `CancelToken`, and per-directory `ScanProgress` callbacks. Folder sync, disk usage, and future diff/search all call this one walk.
- `RemoteFs` gains a `change_signal` capability (`MtimeSize` / `Etag` / `Hash`) and `DirEntry` gains an optional `etag` — object stores now surface the per-object ETag as an opaque change token.
- The folder-sync reconciler plans against the persisted index (`sync::plan_indexed`): a stored `remote_signal`/mtime/size row catches in-place same-size edits and lets interrupted syncs resume without re-uploading. `snapshot_index` upserts the current source tree and prunes vanished rows after every reconcile, best-effort — a DB hiccup costs only the optimization, never correctness.

**Disk Usage Explorer (Plan 4)**

- New `diskscan.rs`: a `ScanManager` shaped like `TransferManager`/`agent_host` (Arc in `AppState`, scans in a mutexed map), streaming progress over `diskscan://…` events and serving the aggregated `DuNode` tree once on completion; commands `diskscan_start/status/tree/cancel/forget`.
- Three `ScanStrategy` variants: the generic walk, a shell fast path (`find -type f -printf` piped through a parser) for SSH/agent sessions, and a flat-listing fast path for object stores.
- New `DiskTreemap.tsx`: a squarified-ish treemap on Canvas (recursive binary split along the longer axis), type/depth color modes, hover inspection, click-to-drill; `DiskUsage.tsx` hosts the treemap plus a size-ranked list with breadcrumb navigation; `diskScanStore.ts` follows the `bridgeStore` shape.
- Map actions: reveal-in-file-browser (a one-shot `revealTarget` request in `layoutStore` the active pane consumes), copy path, and delete with re-aggregation.

**Folder sync safety**

- `SyncPair` gains `exclude: Vec<String>` and `mirror_delete_cap: u32` (default 100; 0 disables). `apply_safety` prunes excluded paths from *both* copies and deletes, so an excluded file is neither pushed nor mirror-deleted.
- Data-loss guard: before trusting a Mirror plan's delete set, the reconciler lists the source root — an empty or unreadable source (unmounted drive, deleted folder, typo) clears all deletes and surfaces a warning instead of wiping the destination. Deletes over the cap are likewise withheld; uploads still run, and the guard note lands in `last_error` without failing the run.
- `is_excluded` is a gitignore-lite matcher: `#` comments, basename patterns matching any segment at any depth, `/`-containing patterns anchored at the root and covering descendants, with `*` / `**` / `?` glob semantics.
- `SyncSettings.tsx` exposes the exclude list and delete cap per pair.

**New backends (Plan 5)**

- GCS (`session/object.rs`): `object_store`'s `GoogleCloudStorageBuilder`, authenticated by a service-account key — JSON file path (Key auth) or pasted JSON (Password auth) — reusing the existing `ObjectFs` unchanged.
- WebDAV (`remotefs/webdav.rs`, `session/webdav.rs`): `PROPFIND` listings parsed with quick-xml, rename via `MOVE`, ETag-based change detection with mtime+size fallback; transfers stream `GET` downloads chunk-by-chunk and `PUT` uploads straight off disk with explicit Content-Length.
- Read-only HTTP(S) source (`remotefs/http.rs`, `session/http.rs`): lists via server autoindex (nginx/Apache HTML or nginx JSON), single-file mode for pasted direct URLs, metadata via best-effort `HEAD`; every mutation errors and uploads are refused at conflict resolution.
- Shared OAuth infra (`oauth.rs`): the loopback + PKCE authorization-code flow (RFC 8252/7636) with no external OAuth crate — fixed redirect port 53682, S256 challenge, provider-agnostic `OAuthConfig` with injectable endpoints. Tokens persist in the OS keychain via `keyring`, never in profile JSON. A shared `RefreshingToken` holder (mutex-guarded `TokenSet` per session) centralizes proactive-refresh, forced-401-retry, and keychain re-persist so all four clouds share one refresh path.
- Dropbox (`remotefs/dropbox.rs`, `session/dropbox.rs`): API v2 over the trait — `list_folder` paging, `move_v2` rename, per-file `rev` as the change token; downloads stream `/2/files/download`, uploads use single-shot `/2/files/upload` with a clear refusal above Dropbox's 150 MB cap (chunked sessions are a follow-up).
- OneDrive (`remotefs/onedrive.rs`, `session/onedrive.rs`): Microsoft Graph, path-addressed via the `:/path:` addressing scheme with a percent-encoding set that leaves unreserved filename chars intact; ETag change token.
- Google Drive (`remotefs/gdrive.rs`, `session/gdrive.rs`): Drive v3, which is **ID-addressed** — a path→id resolver (cached listing walk) fronts every op, rename/move via PATCH, `md5Checksum` as the change token for binary files (folders and Google-native docs fall back to mtime+size).
- Box (`remotefs/boxdrive.rs`, `session/boxdrive.rs`): Box API v2, ID-addressed like Drive and reusing the same resolver pattern; rename/move via PUT, `sha1` as the change token.
- `Session` enum grows `Webdav`/`Http`/`Dropbox`/`OneDrive`/`GDrive`/`Box` variants wired through connect, disconnect, transfers, and the remote editor's download path; `ProfileEditor.tsx`'s Dropbox section is generalized into a reusable `OAuthConnectSection` driven by a per-protocol `authorize` IPC (`ipc.dropboxAuthorize` / `onedriveAuthorize` / `gdriveAuthorize` / `boxAuthorize`), and the protocol picker lists all four clouds.
- `types.ts`: `S3_PROVIDER_PRESETS` expanded to ten entries with endpoint hints; new `WEBDAV_PROVIDER_PRESETS`.

**Files UI**

- Per-type file icons from Material Icon Theme (`packages/file-ui/src/lib/materialIcons.ts`), rendered as SVG `<img>`s with the lucide glyph fallback for folders/symlinks/unknowns; license recorded in `THIRD_PARTY_LICENSES.md`.
- Grid view is the new default pane mode, with a one-shot migration key so existing users are switched exactly once and their subsequent choice sticks.

**Docs**

- Plans renumbered into build order; new specs for scan/index foundation (3), Disk Usage Explorer (4), additional backends (5), directory diff (6), fleet search (7), fleet skills (8), Iconify brand icons (10), and scoped sharing (11, deferred pending auth); ROADMAP updated and shipped phases marked, including the SMB-on-Windows blocker note.
- `CLAUDE.md` working agreement added; `.pr/` drafts gitignored.

</details>
