### PR TITLE
Always re-download release assets for checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,7 +398,7 @@ jobs:
           tag="${{ needs.prepare.outputs.tag }}"
           mkdir -p assets
           gh release download "$tag" --repo "${{ github.repository }}" \
-            --dir assets --clobber --skip-existing
+            --dir assets --clobber
           (cd assets && sha256sum -- * > ../SHA256SUMS.txt)
           gh release upload "$tag" SHA256SUMS.txt \
             --repo "${{ github.repository }}" --clobber


### PR DESCRIPTION
Remove `--skip-existing` from the release workflow download step so assets are always refreshed before generating `SHA256SUMS.txt`. This avoids using stale local files when recomputing and uploading checksums.