### PR TITLE
Preset icon picker replaces free-text icon field

### DIFF
--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -1,0 +1,226 @@
+// Preset icon picker for a connection's rail bubble (profile.icon). Click the
+// preview to open a searchable grid of curated emojis + every bundled Iconify
+// glyph — nobody should have to memorise `mdi:rocket-launch`. The stored value
+// stays a plain string (emoji char or "prefix:name"), so the rail, the mock
+// layer, and the backend need no changes.
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, Search, X } from "lucide-react";
+import { BrandIcon } from "@/lib/brandIcons";
+import { BRAND_ICONS } from "@/lib/brandIconData";
+import { cn } from "@/lib/cn";
+
+const EMOJI_CHOICES: { char: string; label: string }[] = [
+  { char: "🚀", label: "rocket" },
+  { char: "🛰️", label: "satellite" },
+  { char: "🌐", label: "globe" },
+  { char: "🔥", label: "fire" },
+  { char: "⚡", label: "lightning" },
+  { char: "⭐", label: "star" },
+  { char: "❤️", label: "heart" },
+  { char: "🛡️", label: "shield" },
+  { char: "🏠", label: "home" },
+  { char: "🏢", label: "office" },
+  { char: "☁️", label: "cloud" },
+  { char: "🗄️", label: "database" },
+  { char: "💾", label: "floppy disk" },
+  { char: "📦", label: "package" },
+  { char: "🔧", label: "wrench" },
+  { char: "🐱", label: "cat" },
+  { char: "🐶", label: "dog" },
+  { char: "🤖", label: "robot" },
+  { char: "👽", label: "alien" },
+  { char: "👻", label: "ghost" },
+  { char: "🥷", label: "ninja" },
+  { char: "🍕", label: "pizza" },
+  { char: "☕", label: "coffee" },
+  { char: "🌵", label: "cactus" },
+  { char: "🐧", label: "penguin" },
+  { char: "🏰", label: "castle" },
+  { char: "⛵", label: "sailboat" },
+  { char: "✈️", label: "airplane" },
+];
+
+const POPOVER_W = 320; // w-80
+const POPOVER_MAX_H = 320; // max-h-80
+
+export function IconPicker({
+  value,
+  onChange,
+  fallback,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  /** What the preview shows when nothing is picked (the name monogram). */
+  fallback: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  const trimmed = value.trim();
+  const valueIsKnownKey = trimmed.includes(":") && !!BRAND_ICONS[trimmed];
+
+  const openPicker = () => {
+    const r = btnRef.current?.getBoundingClientRect();
+    if (r) {
+      setPos({
+        top: Math.max(8, Math.min(r.bottom + 6, window.innerHeight - POPOVER_MAX_H - 8)),
+        left: Math.max(8, Math.min(r.left, window.innerWidth - POPOVER_W - 8)),
+      });
+    }
+    setQuery("");
+    setOpen(true);
+  };
+
+  // Escape closes; overlay-click covers the mouse case.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const q = query.trim().toLowerCase();
+  const emoji = EMOJI_CHOICES.filter((e) => !q || e.label.includes(q));
+  const keys = Object.keys(BRAND_ICONS).filter((k) => !q || k.includes(q));
+
+  const pick = (v: string) => {
+    onChange(v);
+    setOpen(false);
+  };
+
+  const cellCls = (active: boolean) =>
+    cn(
+      "flex h-8 w-8 items-center justify-center rounded-md text-base transition-colors",
+      active ? "bg-accent-soft ring-1 ring-accent/50" : "hover:bg-bg-hover"
+    );
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={openPicker}
+        title="Pick a bubble icon"
+        className="flex h-[34px] w-full items-center gap-1.5 rounded-md border border-border bg-bg-subtle px-2 text-sm hover:border-accent/60"
+      >
+        <span className="flex h-6 w-6 items-center justify-center rounded-md bg-bg text-[13px] font-bold leading-none">
+          {trimmed && valueIsKnownKey ? (
+            <BrandIcon icon={trimmed} size={15} />
+          ) : trimmed && !trimmed.includes(":") ? (
+            trimmed
+          ) : (
+            <span className="text-text-dim">{fallback}</span>
+          )}
+        </span>
+        <span className="flex-1 truncate text-left text-[11px] text-text-muted">
+          {trimmed || "Default (monogram)"}
+        </span>
+        <ChevronDown size={13} className="shrink-0 text-text-dim" />
+      </button>
+
+      {open && pos && (
+        <div className="fixed inset-0 z-palette" onClick={() => setOpen(false)}>
+          <div
+            role="dialog"
+            aria-label="Pick a bubble icon"
+            onClick={(e) => e.stopPropagation()}
+            style={{ top: pos.top, left: pos.left }}
+            className="anim-modal fixed flex max-h-80 w-80 flex-col rounded-xl border border-border bg-bg-panel shadow-elev-3"
+          >
+            <div className="flex items-center gap-1.5 border-b border-border px-2.5 py-2">
+              <Search size={13} className="shrink-0 text-text-dim" />
+              <input
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && q) pick(q);
+                }}
+                placeholder="Search icons…"
+                className="w-full bg-transparent text-xs outline-none placeholder:text-text-dim"
+              />
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="rounded p-0.5 text-text-muted hover:bg-bg-hover hover:text-text"
+              >
+                <X size={13} />
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-2">
+              <button
+                type="button"
+                onClick={() => pick("")}
+                className={cn(
+                  "mb-1 flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors",
+                  !trimmed ? "bg-accent-soft" : "hover:bg-bg-hover"
+                )}
+              >
+                <X size={12} className="text-text-dim" />
+                Default (name monogram)
+              </button>
+
+              {emoji.length > 0 && (
+                <>
+                  <div className="px-1 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-dim">
+                    Emoji
+                  </div>
+                  <div className="grid grid-cols-8 gap-0.5">
+                    {emoji.map((e) => (
+                      <button
+                        key={e.char}
+                        type="button"
+                        title={e.label}
+                        onClick={() => pick(e.char)}
+                        className={cellCls(trimmed === e.char)}
+                      >
+                        {e.char}
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
+
+              {keys.length > 0 && (
+                <>
+                  <div className="px-1 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-text-dim">
+                    Icons
+                  </div>
+                  <div className="grid grid-cols-8 gap-0.5">
+                    {keys.map((k) => (
+                      <button
+                        key={k}
+                        type="button"
+                        title={k}
+                        onClick={() => pick(k)}
+                        className={cellCls(trimmed === k)}
+                      >
+                        <BrandIcon icon={k} size={16} />
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
+
+              {q && (
+                <button
+                  type="button"
+                  onClick={() => pick(q)}
+                  className="mt-1.5 flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-text-muted transition-colors hover:bg-bg-hover"
+                >
+                  Use “{query.trim()}” as a custom icon
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -42,6 +42,7 @@ import { cn } from "@/lib/cn";
 import { BrandIcon, protocolIcon } from "@/lib/brandIcons";
 import { BRAND_ICONS } from "@/lib/brandIconData";
 import { monogram } from "@/lib/format";
+import { IconPicker } from "./IconPicker";
 import { generatePassword } from "@/lib/password";
 import { ipc } from "@/lib/ipc";
 import { toast } from "@/stores/toastStore";
@@ -188,12 +189,12 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
   );
   const [autoConnect, setAutoConnect] = useState(profile?.autoConnect ?? false);
   const [group, setGroup] = useState(seed?.group ?? "");
-  // Custom rail bubble glyph: emoji/short string, or a bundled Iconify key.
+  // Custom rail bubble glyph: emoji/short string, or a bundled Iconify key
+  // (picked via the IconPicker grid; custom keys still possible via search).
   const [icon, setIcon] = useState(seed?.icon ?? "");
   // A value with a colon is treated as an Iconify key; unknown keys warn and
   // the rail falls back to the name monogram.
-  const iconKeyKnown = icon.trim().includes(":") && !!BRAND_ICONS[icon.trim()];
-  const iconUnknown = icon.trim().includes(":") && !iconKeyKnown;
+  const iconUnknown = icon.trim().includes(":") && !BRAND_ICONS[icon.trim()];
 
   // S3-only state.
   const [bucket, setBucket] = useState(seed?.bucket ?? "");
@@ -624,25 +625,11 @@ export function ProfileEditor({ profile, prefill, onClose }: Props) {
             />
           </Field>
           <Field label="Icon (optional)" className="w-40">
-            <div className="relative">
-              <input
-                value={icon}
-                onChange={(e) => setIcon(e.target.value)}
-                placeholder="🚀 or mdi:rocket-launch"
-                className={cn(inputCls, "pr-9")}
-              />
-              {/* Live bubble preview: the emoji / bundled icon, or the name
-                  monogram the rail falls back to. */}
-              <span className="absolute right-1.5 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md bg-bg-subtle text-[13px] font-bold leading-none">
-                {icon.trim() && iconKeyKnown ? (
-                  <BrandIcon icon={icon.trim()} size={15} />
-                ) : icon.trim() && !icon.trim().includes(":") ? (
-                  icon.trim()
-                ) : (
-                  <span className="text-text-dim">{monogram(name || "?")}</span>
-                )}
-              </span>
-            </div>
+            <IconPicker
+              value={icon}
+              onChange={setIcon}
+              fallback={monogram(name || "?")}
+            />
           </Field>
           <Field label="Group (optional)" className="w-40">
             <input


### PR DESCRIPTION
Typing an mdi: key by hand was the weak point of the custom-icon feature. The Icon field is now a visual picker: click the preview bubble to open a searchable popover with a curated emoji grid (28, labelled for search) plus every bundled Iconify glyph (84), a "Default (name monogram)" clear row, and a "use custom" row so power users can still enter any emoji or key. Stored value is unchanged (plain string), so rail/backend/mock are untouched; the unknown-key warning stays for custom entries.