### PR TITLE
fix(hubspot): address design root as %252F in metadata calls

### DIFF
--- a/docs/plans/20_hubspot-backend.md
+++ b/docs/plans/20_hubspot-backend.md
@@ -189,7 +189,9 @@ planned.
    (lift the Shopify helper — if it's copy-paste, extract it to a shared
    `session/http_throttle.rs` used by both, don't fork it). Static bearer
    token, no exchange dance. `hubspot_connect(profile)`: resolves the token
-   from the keychain, probes `GET /cms/v3/source-code/draft/metadata/` (root)
+   from the keychain, probes `GET /cms/v3/source-code/draft/metadata/%252F`
+   (root — the path parameter is a double-encoded `/`; the plain `metadata/`
+   form is rejected at HubSpot's edge with a bare Jetty 404)
    — connect-time validation with a user-actionable error on 401/403 naming
    the missing scope. `account_label()` → portal id/domain if cheaply
    fetchable, else "HubSpot".

--- a/src-tauri/src/session/hubspot.rs
+++ b/src-tauri/src/session/hubspot.rs
@@ -262,7 +262,15 @@ impl HubSpotSession {
                 }
             }
         }
-        let api_path = format!("/cms/v3/source-code/{env}/metadata/{}", urlenc_path(path));
+        // The root's path parameter is "/" — but a single-encoded %2F is
+        // rejected at HubSpot's edge (bare Jetty 404, before auth), and an
+        // empty segment 404s the same way. Double-encoded %252F survives the
+        // edge and resolves to the design root after the API's own decode.
+        let api_path = if path.is_empty() {
+            format!("/cms/v3/source-code/{env}/metadata/%252F")
+        } else {
+            format!("/cms/v3/source-code/{env}/metadata/{}", urlenc_path(path))
+        };
         let resp = self.send(Method::GET, &api_path, None).await?;
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
@@ -842,7 +850,8 @@ impl HubSpotSession {
 /// Open a HubSpot session from a profile whose private-app token is in the OS
 /// keychain (`hubspot:{profile_id}`). Probes the draft environment's root
 /// metadata so a bad token or missing scope fails at connect, not on first
-/// browse.
+/// browse. The root is addressed as `%252F` — the double-encoded "/" path
+/// parameter; the plain `metadata/` form 404s at HubSpot's edge.
 pub async fn hubspot_connect(profile: &ConnectionProfile) -> Result<HubSpotSession> {
     let token = crate::credentials::get_secret(&credential_key(&profile.id))?
         .filter(|s| !s.trim().is_empty())
@@ -875,7 +884,7 @@ pub async fn hubspot_connect(profile: &ConnectionProfile) -> Result<HubSpotSessi
 
     // Connect-time validation with user-actionable errors.
     let resp = session
-        .send(Method::GET, "/cms/v3/source-code/draft/metadata/", None)
+        .send(Method::GET, "/cms/v3/source-code/draft/metadata/%252F", None)
         .await?;
     let status = resp.status();
     let text = resp.text().await.unwrap_or_default();

--- a/src-tauri/tests/hubspot_mock.py
+++ b/src-tauri/tests/hubspot_mock.py
@@ -294,6 +294,11 @@ class Handler(BaseHTTPRequestHandler):
         if not m:
             return None
         env, kind, path = m.group(1), m.group(2), unquote(m.group(3) or "")
+        # The design root arrives double-encoded as %252F (the live edge
+        # rejects single-encoded %2F and empty segments with a bare 404);
+        # one unquote above leaves "%2F", which is the root.
+        if path == "%2F":
+            path = ""
         return env, kind, path.rstrip("/")
 
     def _parse_multipart_all(self):


### PR DESCRIPTION
HubSpot's edge now rejects /cms/v3/source-code/{env}/metadata/ (empty path) and single-encoded %2F with a bare Jetty 404 before auth, so connect always failed with 'hubspot draft metadata probe failed (404)' regardless of token validity. The root's path parameter must arrive double-encoded as %252F.

- probe the root via metadata/%252F at connect (401/403 messages kept)
- metadata() special-cases the empty root path the same way
- mock decodes %252F back to the root for the roundtrip test