### PR TITLE
feat(hubspot): scope-gated surfaces — connect with whatever the app has

### DIFF
--- a/docs/hubspot-private-app.md
+++ b/docs/hubspot-private-app.md
@@ -1,0 +1,36 @@
+# HubSpot private app: required scopes
+
+Faro connects to a HubSpot portal with a **private-app access token**
+(`pat-…`). The token alone is not enough — the private app must also be
+granted the scopes for the surfaces you want to browse. Each scope unlocks
+one root in Faro; any single one is enough to connect, and roots without
+their scope simply stay hidden.
+
+## Setup
+
+1. In the HubSpot portal: **Settings → Integrations → Private Apps**.
+2. Open the app (or create one) → **Scopes** tab.
+3. Enable the scopes below, then **Save**. Scope changes take effect
+   immediately — no reinstall, and the token does not change.
+
+## Scopes
+
+| Scope | Unlocks in Faro | Notes |
+| --- | --- | --- |
+| `content` | `design (draft)` + `design (published)` — Design Manager source files (templates, modules, CSS/JS, HubL) | Read/write. Writes to `design (published)` deploy instantly, like pressing Publish in the Design Manager. |
+| `files` | `files` — the File Manager asset library | Read/write (upload, rename, delete). |
+| `hubdb` | `hubdb` — HubDB tables as read-only `.csv` files | Read-only in Faro for now. |
+
+`content`, `files`, and `hubdb` appear in the scope picker under their CMS /
+files / HubDB groupings; searching the scope name in the picker's filter box
+is the fastest way to find them.
+
+## Troubleshooting
+
+- **"HubSpot rejected the token (401)"** — the pasted value isn't a valid
+  private-app token. Private-app tokens start with `pat-`; old HubSpot API
+  keys (`hapikey`) were retired in November 2022 and no longer work.
+- **A root is missing after connect, or entering it says it "needs the
+  `…` scope"** — the app lacks that scope; enable it and reconnect.
+- **"The token is valid, but the private app has none of the scopes Faro
+  uses"** — none of the three scopes above are enabled.

--- a/docs/plans/20_hubspot-backend.md
+++ b/docs/plans/20_hubspot-backend.md
@@ -91,9 +91,11 @@ directory. No special-casing.
 
 `/files/v3/files`, `/files/v3/folders`:
 
-- List: `GET /files/v3/files?parentFolderId=…` (paged) + folder listing.
-  Entries carry `id`, `name`, `path`, `size`, `createdAt`/`updatedAt`,
-  `defaultHostingUrl`.
+- List: `GET /files/v3/files/search?parentFolderId=…` (paged) + folder
+  listing at `/files/v3/folders/search`. (The plain `/files/v3/files?…`
+  list URLs 405 at HubSpot's edge — listing is GET on the search routes,
+  same params and response shape.) Entries carry `id`, `name`, `path`,
+  `size`, `createdAt`/`updatedAt`, `defaultHostingUrl`.
 - Upload: multipart `POST /files/v3/files` with `folderPath` **or**
   `folderId`, `fileName`, and a required `options.access`
   (`PUBLIC_INDEXABLE` / `PUBLIC_NOT_INDEXABLE` / `PRIVATE`). Replace:
@@ -189,12 +191,15 @@ planned.
    (lift the Shopify helper — if it's copy-paste, extract it to a shared
    `session/http_throttle.rs` used by both, don't fork it). Static bearer
    token, no exchange dance. `hubspot_connect(profile)`: resolves the token
-   from the keychain, probes `GET /cms/v3/source-code/draft/metadata/%252F`
-   (root — the path parameter is a double-encoded `/`; the plain `metadata/`
-   form is rejected at HubSpot's edge with a bare Jetty 404)
-   — connect-time validation with a user-actionable error on 401/403 naming
-   the missing scope. `account_label()` → portal id/domain if cheaply
-   fetchable, else "HubSpot".
+   from the keychain, validates it against `GET /account-info/v3/details`
+   (401 → bad token — that endpoint is scopeless), then probes one route per
+   surface to detect the app's scopes: `content` → the design roots (root
+   metadata at `GET /cms/v3/source-code/draft/metadata/%252F` — the path
+   parameter is a double-encoded `/`; the plain `metadata/` form is rejected
+   at HubSpot's edge with a bare Jetty 404), `files` → `/files/`, `hubdb` →
+   `/hubdb/`. A missing scope hides that root instead of failing connect;
+   connect fails only when no surface is usable. `account_label()` → portal
+   id/domain if cheaply fetchable, else "HubSpot".
    - **Credentials**: no `host` field (api.hubapi.com is fixed; the client
      follows HubSpot's region redirect); the `pat-…` token stored in the **OS
      keychain** via `credentials.rs` (`set_secret("hubspot:{profile_id}", …)`)

--- a/src-tauri/src/remotefs/hubspot.rs
+++ b/src-tauri/src/remotefs/hubspot.rs
@@ -6,18 +6,19 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 /// RemoteFs over three HubSpot surfaces sharing one session. The portal root
-/// lists four virtual directories: `design (draft)` and `design (published)`
-/// — labeled so the live one is unmistakable — mapping to the CMS Source Code
-/// API v3's two environments, plus `files` for the File Manager (Files API
-/// v3) and `hubdb` for HubDB tables as read-only virtual CSV files. Inside
-/// the design roots, folders come from the metadata tree (`children`
-/// arrays); inside `files`, from the paged folder/file listings (real
-/// folders). `/hubdb/` is a flat list of `{table}.csv` files (no subfolders,
-/// no writes — HubDB write-back ships in a later phase). No chmod/symlinks;
-/// design rename is GET + PUT + DELETE (the API has no atomic rename), File
-/// Manager rename is a PATCH (folders go through the async update task).
-/// Everything carries size + updated timestamps, so the change signal is
-/// `MtimeSize` (no etag exists).
+/// lists the virtual directories the private app's scopes unlock (probed at
+/// connect): `design (draft)` and `design (published)` — labeled so the live
+/// one is unmistakable — mapping to the CMS Source Code API v3's two
+/// environments (`content` scope), plus `files` for the File Manager (Files
+/// API v3, `files` scope) and `hubdb` for HubDB tables as read-only virtual
+/// CSV files (`hubdb` scope). Inside the design roots, folders come from the
+/// metadata tree (`children` arrays); inside `files`, from the paged
+/// folder/file listings (real folders). `/hubdb/` is a flat list of
+/// `{table}.csv` files (no subfolders, no writes — HubDB write-back ships in
+/// a later phase). No chmod/symlinks; design rename is GET + PUT + DELETE
+/// (the API has no atomic rename), File Manager rename is a PATCH (folders go
+/// through the async update task). Everything carries size + updated
+/// timestamps, so the change signal is `MtimeSize` (no etag exists).
 pub struct HubSpotFs {
     session: Arc<HubSpotSession>,
 }
@@ -119,6 +120,15 @@ pub const HUBDB_DIR: &str = "hubdb";
 /// the HTTP backend's (`HTTP source is read-only (…)`).
 fn hubdb_read_only(op: &str) -> anyhow::Error {
     anyhow!("/hubdb/ is read-only ({op} not supported) — HubDB write-back lands in a later phase")
+}
+
+/// Entering a root the private app's scopes don't cover. Connect hides these
+/// roots, but a stale tree node or a deep link can still land here.
+fn missing_scope(root: &str, scope: &str) -> anyhow::Error {
+    anyhow!(
+        "{root} needs the `{scope}` scope — enable it in HubSpot → Settings → Integrations → \
+         Private Apps → your app → Scopes, then reconnect"
+    )
 }
 
 /// The inner path under `/hubdb/` ("" for the hubdb root itself), or `None`
@@ -279,9 +289,21 @@ impl RemoteFs for HubSpotFs {
     async fn list_dir(&self, path: &str) -> Result<Vec<DirEntry>> {
         let norm = normalize(path);
         if norm == "/" {
-            // The portal root: one virtual directory per design environment,
-            // plus the File Manager and HubDB.
-            return Ok([DRAFT_DIR, PUBLISHED_DIR, FILES_DIR, HUBDB_DIR]
+            // The portal root: one virtual directory per surface the app's
+            // scopes unlock (detected at connect).
+            let s = self.session.surfaces;
+            let mut dirs = Vec::new();
+            if s.design {
+                dirs.push(DRAFT_DIR);
+                dirs.push(PUBLISHED_DIR);
+            }
+            if s.files {
+                dirs.push(FILES_DIR);
+            }
+            if s.hubdb {
+                dirs.push(HUBDB_DIR);
+            }
+            return Ok(dirs
                 .into_iter()
                 .map(|d| DirEntry {
                     name: d.to_string(),
@@ -295,6 +317,9 @@ impl RemoteFs for HubSpotFs {
                 .collect());
         }
         if let Some(inner) = hubdb_inner(&norm) {
+            if !self.session.surfaces.hubdb {
+                return Err(missing_scope("/hubdb/", "hubdb"));
+            }
             if !inner.is_empty() {
                 // Flat root: anything deeper is a .csv file, not a directory.
                 return Err(anyhow!("{path} is a file, not a directory"));
@@ -303,10 +328,16 @@ impl RemoteFs for HubSpotFs {
             return Ok(hubdb_entries(norm.trim_end_matches('/'), &tables));
         }
         if let Some(inner) = files_inner(&norm) {
+            if !self.session.surfaces.files {
+                return Err(missing_scope("/files/", "files"));
+            }
             let entries = self.session.files_list(&inner).await?;
             return Ok(file_entries(norm.trim_end_matches('/'), &entries));
         }
         let (env, inner) = split_path(&norm)?;
+        if !self.session.surfaces.design {
+            return Err(missing_scope("the design roots", "content"));
+        }
         let node = self.session.metadata(env, &inner).await?;
         if !node.folder {
             return Err(anyhow!("{path} is a file, not a directory"));
@@ -1017,5 +1048,76 @@ mod tests {
 
         crate::credentials::delete_secret(&credential_key(&pid));
         eprintln!("live_hubspot_roundtrip: OK");
+    }
+
+    /// A token whose app lacks the `content` scope still connects: the
+    /// design roots drop out of the portal root, entering one names the
+    /// missing scope, and the remaining surfaces work. Same mock run as
+    /// `live_hubspot_roundtrip` (`FARO_HUBSPOT_MOCK_URL`).
+    #[tokio::test]
+    #[ignore = "requires the HubSpot mock (FARO_HUBSPOT_MOCK_URL)"]
+    async fn hubspot_missing_scope_degrades() {
+        use crate::profiles::{AuthMethod, ConnectionProfile};
+        use crate::session::hubspot::{credential_key, hubspot_connect};
+
+        let Ok(mock) = std::env::var("FARO_HUBSPOT_MOCK_URL") else {
+            eprintln!("skip: FARO_HUBSPOT_MOCK_URL unset");
+            return;
+        };
+        std::env::set_var("FARO_HUBSPOT_API_BASE", &mock);
+
+        let profile = ConnectionProfile {
+            id: "hubspot-no-content-test".into(),
+            name: "portal".into(),
+            protocol: "hubspot".into(),
+            host: String::new(),
+            port: 443,
+            username: String::new(),
+            auth: AuthMethod::Password {
+                password: String::new(),
+            },
+            default_remote_path: None,
+            color: None,
+            auto_connect: None,
+            bucket: None,
+            region: None,
+            endpoint: None,
+            account: None,
+            agent_key: None,
+            group: None,
+            sort_order: None,
+            jump_host: None,
+            jump_port: None,
+            jump_username: None,
+        };
+
+        let pid = profile.id.clone();
+        crate::credentials::set_secret(&credential_key(&pid), "pat-no-content")
+            .expect("seed secret");
+        let session = Arc::new(hubspot_connect(&profile).await.expect("connect"));
+        assert!(!session.surfaces.design);
+        assert!(session.surfaces.files);
+        assert!(session.surfaces.hubdb);
+
+        let fs = HubSpotFs::new(session);
+        let roots = fs.list_dir("/").await.expect("roots");
+        assert_eq!(roots.len(), 3);
+        assert!(!roots.iter().any(|e| e.name == DRAFT_DIR));
+        assert!(!roots.iter().any(|e| e.name == PUBLISHED_DIR));
+        assert!(roots.iter().any(|e| e.name == FILES_DIR));
+
+        let err = fs
+            .list_dir("/design (draft)")
+            .await
+            .expect_err("design root without content scope");
+        assert!(err.to_string().contains("`content`"), "{err}");
+
+        // The remaining surfaces are unaffected.
+        let files_root = fs.list_dir("/files").await.expect("files root");
+        assert!(files_root.iter().any(|e| e.name == "library"));
+        assert!(fs.list_dir("/hubdb").await.expect("hubdb root").len() == 3);
+
+        crate::credentials::delete_secret(&credential_key(&pid));
+        eprintln!("hubspot_missing_scope_degrades: OK");
     }
 }

--- a/src-tauri/src/session/hubspot.rs
+++ b/src-tauri/src/session/hubspot.rs
@@ -92,9 +92,9 @@ pub struct NodeMeta {
 pub const FILES_UPLOAD_ACCESS: &str = "PUBLIC_NOT_INDEXABLE";
 
 /// One file or folder in the HubSpot File Manager (Files API v3), from the
-/// `GET /files/v3/files` / `GET /files/v3/folders` paged listings. Note the
-/// API's `name` field excludes the file extension — the display name is
-/// derived from `path`, which always carries it.
+/// `GET /files/v3/files/search` / `GET /files/v3/folders/search` paged
+/// listings. Note the API's `name` field excludes the file extension — the
+/// display name is derived from `path`, which always carries it.
 #[derive(Debug, Clone)]
 pub struct FileEntry {
     pub id: String,
@@ -141,6 +141,16 @@ type FilesListingCache = StdMutex<HashMap<String, (Instant, Arc<Vec<FileEntry>>)
 /// HubDB table listing cache — the whole `/hubdb/` dir in one entry.
 type HubDbCache = StdMutex<Option<(Instant, Arc<Vec<HubDbTable>>)>>;
 
+/// Which HubSpot surfaces the private app's scopes unlock, detected at
+/// connect: `content` → the two design roots, `files` → `/files/`, `hubdb` →
+/// `/hubdb/`. A missing scope hides that root instead of failing connect.
+#[derive(Clone, Copy, Default)]
+pub struct Surfaces {
+    pub design: bool,
+    pub files: bool,
+    pub hubdb: bool,
+}
+
 /// A live HubSpot connection. Stateless HTTP like the other cloud backends —
 /// every op is an independent request carrying the private-app token, paced by
 /// a tiny throttle because HubSpot rate-limits hard (429 + `Retry-After`).
@@ -155,6 +165,8 @@ pub struct HubSpotSession {
     throttle: HttpThrottle,
     /// The connection label, resolved at connect (portal id when fetchable).
     label: String,
+    /// Roots the app's scopes unlock, probed at connect.
+    pub surfaces: Surfaces,
     /// Metadata per (environment, path), cached briefly.
     metadata: MetadataCache,
     /// File Manager folder listings, cached briefly (path ↔ id resolution
@@ -428,7 +440,7 @@ impl HubSpotSession {
         Ok(entries)
     }
 
-    /// Page through one Files API list endpoint (`files` or `folders`),
+    /// Page through one Files API search endpoint (`files` or `folders`),
     /// following the `paging.next.after` cursor.
     async fn files_list_kind(
         &self,
@@ -439,7 +451,9 @@ impl HubSpotSession {
         let mut out = Vec::new();
         let mut after: Option<String> = None;
         loop {
-            let mut api_path = format!("/files/v3/{kind}?limit=100");
+            // The plain list URLs 405 at HubSpot's edge — listing goes
+            // through the GET search endpoints (same params + response).
+            let mut api_path = format!("/files/v3/{kind}/search?limit=100");
             if let Some(id) = parent_id {
                 api_path += &format!("&parentFolderId={id}");
             }
@@ -848,10 +862,11 @@ impl HubSpotSession {
 }
 
 /// Open a HubSpot session from a profile whose private-app token is in the OS
-/// keychain (`hubspot:{profile_id}`). Probes the draft environment's root
-/// metadata so a bad token or missing scope fails at connect, not on first
-/// browse. The root is addressed as `%252F` — the double-encoded "/" path
-/// parameter; the plain `metadata/` form 404s at HubSpot's edge.
+/// keychain (`hubspot:{profile_id}`). Validates the token against account
+/// details (the one endpoint every private-app token can read, so 401 means a
+/// bad token — not a missing scope), then detects which roots the app's
+/// scopes unlock: a scope the app lacks hides that root instead of failing
+/// connect. Connect only fails when *no* surface is usable.
 pub async fn hubspot_connect(profile: &ConnectionProfile) -> Result<HubSpotSession> {
     let token = crate::credentials::get_secret(&credential_key(&profile.id))?
         .filter(|s| !s.trim().is_empty())
@@ -877,53 +892,61 @@ pub async fn hubspot_connect(profile: &ConnectionProfile) -> Result<HubSpotSessi
         token,
         throttle: HttpThrottle::new(MIN_INTERVAL),
         label: "HubSpot".to_string(),
+        surfaces: Surfaces::default(),
         metadata: StdMutex::new(HashMap::new()),
         files_listings: StdMutex::new(HashMap::new()),
         hubdb_tables: StdMutex::new(None),
     };
 
-    // Connect-time validation with user-actionable errors.
+    // Token validity + label in one call.
     let resp = session
-        .send(Method::GET, "/cms/v3/source-code/draft/metadata/%252F", None)
+        .send(Method::GET, "/account-info/v3/details", None)
         .await?;
     let status = resp.status();
-    let text = resp.text().await.unwrap_or_default();
-    match status {
-        StatusCode::UNAUTHORIZED => {
-            return Err(anyhow!(
-                "HubSpot rejected the token (401). Check the private-app access token (pat-…) \
-                 and that the app has the `content` scope (Design Manager source files)."
-            ))
-        }
-        StatusCode::FORBIDDEN => {
-            return Err(anyhow!(
-                "HubSpot denied access (403). The private app is missing the `content` scope — \
-                 enable it in the app's settings, then reconnect."
-            ))
-        }
-        s if !s.is_success() => {
-            return Err(anyhow!(
-                "hubspot draft metadata probe failed ({}): {text}",
-                s.as_u16()
-            ))
-        }
-        _ => {}
+    if status == StatusCode::UNAUTHORIZED {
+        return Err(anyhow!(
+            "HubSpot rejected the token (401). Check the private-app access token (pat-…) — \
+             Settings → Integrations → Private Apps → your app → Show token."
+        ));
     }
-    // Best-effort label: the portal id from account details, when the token
-    // can read it; otherwise the plain default.
-    if let Ok(resp) = session
-        .send(Method::GET, "/account-info/v3/details", None)
-        .await
-    {
-        if resp.status().is_success() {
-            if let Ok(v) = resp.json::<Value>().await {
-                if let Some(pid) = v.get("portalId").and_then(|p| p.as_i64()) {
-                    session.label = format!("HubSpot portal {pid}");
-                }
+    if status.is_success() {
+        if let Ok(v) = resp.json::<Value>().await {
+            if let Some(pid) = v.get("portalId").and_then(|p| p.as_i64()) {
+                session.label = format!("HubSpot portal {pid}");
             }
         }
     }
+
+    // Surface detection: one scope per root. The design root's path parameter
+    // is "%252F" — the double-encoded "/" (the plain `metadata/` form and
+    // single-encoded %2F are rejected at HubSpot's edge with a bare 404).
+    session.surfaces = Surfaces {
+        design: probe_surface(&session, "/cms/v3/source-code/draft/metadata/%252F").await?,
+        files: probe_surface(&session, "/files/v3/files/search?limit=1").await?,
+        hubdb: probe_surface(&session, "/cms/v3/hubdb/tables?limit=1").await?,
+    };
+    if !session.surfaces.design && !session.surfaces.files && !session.surfaces.hubdb {
+        return Err(anyhow!(
+            "The token is valid, but the private app has none of the scopes Faro uses. Enable \
+             at least one in the app's settings — `content` (Design Manager files), `files` \
+             (File Manager), or `hubdb` (HubDB tables) — then reconnect."
+        ));
+    }
     Ok(session)
+}
+
+/// One surface probe at connect: available on 2xx, hidden on 403 (missing
+/// scope) or any other non-success, fatal on 401 (bad token — the surface
+/// probes run after account details, so this shouldn't happen).
+async fn probe_surface(session: &HubSpotSession, path: &str) -> Result<bool> {
+    let resp = session.send(Method::GET, path, None).await?;
+    let status = resp.status();
+    if status == StatusCode::UNAUTHORIZED {
+        return Err(anyhow!(
+            "HubSpot rejected the token (401). Check the private-app access token (pat-…)."
+        ));
+    }
+    Ok(status.is_success())
 }
 
 /// Parse one metadata object from the Source Code API's JSON. A folder's

--- a/src-tauri/tests/hubspot_mock.py
+++ b/src-tauri/tests/hubspot_mock.py
@@ -25,13 +25,13 @@ Endpoints (Source Code API):
   PUT    /cms/v3/source-code/{env}/content/{path}       multipart `file` field
   DELETE /cms/v3/source-code/{env}/content/{path}
 Endpoints (Files API v3):
-  GET    /files/v3/files?parentFolderId=&limit=&after=  paged file listing
+  GET    /files/v3/files/search?parentFolderId=&limit=&after=  paged listing
   POST   /files/v3/files                                multipart upload
   PUT    /files/v3/files/{id}                           multipart replace
   PATCH  /files/v3/files/{id}                           JSON {"name": stem}
   DELETE /files/v3/files/{id}
   GET    /files/v3/files/{id}/signed-url                {"url": ...} (PRIVATE)
-  GET    /files/v3/folders?parentFolderId=&limit=&after=
+  GET    /files/v3/folders/search?parentFolderId=&limit=&after=
   POST   /files/v3/folders                              JSON {name, parentFolderPath}
   PATCH  /files/v3/folders/{id}                         async: task token
   GET    /files/v3/folders/async/tasks/{taskId}/status
@@ -56,6 +56,9 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, unquote, urlparse
 
 VALID_TOKEN = "pat-test"
+# A valid token whose private app lacks the `content` scope: every Source
+# Code API call 403s the way HubSpot's MISSING_SCOPES does.
+NO_CONTENT_TOKEN = "pat-no-content"
 
 ALLOWED_EXTS = ("css", "js", "json", "html", "txt", "md", "jpg", "jpeg", "png",
                 "gif", "map", "svg", "ttf", "woff", "woff2", "zip")
@@ -278,11 +281,23 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _token(self):
+        auth = self.headers.get("Authorization", "")
+        return auth[len("Bearer "):] if auth.startswith("Bearer ") else ""
+
     def _authed(self):
-        if self.headers.get("Authorization", "") != f"Bearer {VALID_TOKEN}":
+        if self._token() not in (VALID_TOKEN, NO_CONTENT_TOKEN):
             self._send(401, {"status": "error", "message": "Unauthorized"})
             return False
         return True
+
+    def _scope_blocked(self):
+        """Source Code API gate: the NO_CONTENT_TOKEN app lacks `content`."""
+        if self._token() == NO_CONTENT_TOKEN:
+            self._send(403, {"status": "error", "category": "MISSING_SCOPES",
+                             "message": "missing scope: content"})
+            return True
+        return False
 
     def _route(self):
         """`/cms/v3/source-code/{env}/{metadata|content}/{path}` ->
@@ -589,7 +604,7 @@ class Handler(BaseHTTPRequestHandler):
             if not self._authed():
                 return
             kind, rest = froute
-            if not rest:
+            if not rest or rest == "search":
                 return self._fm_list(kind)
             if kind == "files" and rest.endswith("/signed-url"):
                 return self._fm_signed_url(rest.split("/")[0])
@@ -604,6 +619,8 @@ class Handler(BaseHTTPRequestHandler):
             return self._send(404, {"status": "error", "message": "Not Found"})
         env, kind, path = route
         if not self._authed():
+            return
+        if self._scope_blocked():
             return
         if kind == "metadata":
             node = metadata(env, path)

--- a/src/components/ProfileEditor.tsx
+++ b/src/components/ProfileEditor.tsx
@@ -2007,8 +2007,10 @@ function HubSpotSection({
       <Hint>
         No URL needed — the token identifies your portal; the API base
         (api.hubapi.com) is fixed. Create a private app in your HubSpot portal
-        (Settings → Integrations → Private Apps) with <code>content</code>,{" "}
-        <code>files</code>, and <code>hubdb</code> scopes.
+        (Settings → Integrations → Private Apps). Each scope unlocks a root:{" "}
+        <code>content</code> for the design roots, <code>files</code> for the
+        File Manager, <code>hubdb</code> for HubDB tables — any one is enough
+        to connect; roots without their scope stay hidden.
       </Hint>
 
       <Hint tone="warn">


### PR DESCRIPTION
A private app no longer needs every scope: connect validates the token against account-info (scopeless, so 401 means bad token), then probes one route per surface — content → design roots, files → /files/, hubdb → /hubdb/. A missing scope hides that root; entering one anyway names the scope to enable. Connect fails only when nothing is usable.

Also fixes two live-API mismatches found while testing against a real portal: File Manager listings move to the GET search routes (/files/v3/{files,folders}/search — the plain list URLs 405 at the edge), and the connect probe/root metadata use the double-encoded %252F root path.

docs/hubspot-private-app.md documents the scopes for whoever owns the HubSpot app. Mock gains a pat-no-content token (403s Source Code API) plus a degradation test.